### PR TITLE
Append number to target device

### DIFF
--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -2,6 +2,7 @@ package libvirt
 
 import (
 	"encoding/xml"
+        "strconv"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -32,13 +33,13 @@ func diskCommonSchema() map[string]*schema.Schema {
 	}
 }
 
-func newDefDisk() defDisk {
+func newDefDisk(targetdev int) defDisk {
 	disk := defDisk{}
 	disk.Type = "volume"
 	disk.Device = "disk"
 	disk.Format.Type = "qcow2"
 
-	disk.Target.Dev = "sda"
+	disk.Target.Dev = "sda" + strconv.Itoa(targetdev)
 	disk.Target.Bus = "virtio"
 
 	return disk

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -64,7 +64,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	disks := make([]defDisk, 0, disksCount)
 	for i := 0; i < disksCount; i++ {
 		prefix := fmt.Sprintf("disk.%d", i)
-		disk := newDefDisk()
+		disk := newDefDisk(i)
 
 		volumeKey := d.Get(prefix + ".volume_id").(string)
 		diskVolume, err := virConn.LookupStorageVolByKey(volumeKey)


### PR DESCRIPTION
This successfully mounts /dev/sda0 when a single disk is defined but fails when multiple disks are defined.

> libvirt_domain.domain: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.

> Mismatch reason: attribute mismatch: disk.1.volume_id

I'm stuck on this issue and would appreciate any help in resolving this.