### PR TITLE
Allow to specify the base volume by using a name

### DIFF
--- a/docs/providers/libvirt/r/volume.html.markdown
+++ b/docs/providers/libvirt/r/volume.html.markdown
@@ -34,4 +34,5 @@ The following arguments are supported:
 * `size` - (Optional) The size of the volume in bytes (if you don't like this, help fix [this issue](https://github.com/hashicorp/terraform/issues/3287).
    If `source` is specified, `size` will be set to the source image file size.
 * `base_volume_id` - (Optional) The backing volume (CoW) to use for this volume.
-
+* `base_volume_name` - (Optional) The name of the backing volume (CoW) to use for this volume. Note well: when `base_volume_pool` is not specified the volume is going to be searched inside of `pool`.
+* `base_volume_pool` - (Optional) The name of the pool containing the volume defined by `base_volume_name`.


### PR DESCRIPTION
It's now possible to specify a base volume by using the
`base_volume_name`. This is an approach done also by other Terraform
providers: either use an "internal" ID or a human-friendly name.

This makes easier to share the same base volume between different
terraform projects.