### PR TITLE
Domain: allow to set title and description

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -5,13 +5,15 @@ import (
 )
 
 type defDomain struct {
-	XMLName  xml.Name  `xml:"domain"`
-	Name     string    `xml:"name"`
-	Type     string    `xml:"type,attr"`
-	Os       defOs     `xml:"os"`
-	Memory   defMemory `xml:"memory"`
-	VCpu     defVCpu   `xml:"vcpu"`
-	Features struct {
+	XMLName     xml.Name  `xml:"domain"`
+	Name        string    `xml:"name"`
+	Title       string    `xml:"title"`
+	Description string    `xml:"description"`
+	Type        string    `xml:"type,attr"`
+	Os          defOs     `xml:"os"`
+	Memory      defMemory `xml:"memory"`
+	VCpu        defVCpu   `xml:"vcpu"`
+	Features    struct {
 		Acpi string `xml:"acpi"`
 		Apic string `xml:"apic"`
 		Pae  string `xml:"pae"`

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -20,6 +20,18 @@ func resourceLibvirtDomain() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"title": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
 			"vcpu": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -123,6 +135,14 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		domainDef.Name = name.(string)
 	}
 
+	if title, ok := d.GetOk("title"); ok {
+		domainDef.Title = title.(string)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		domainDef.Description = description.(string)
+	}
+
 	domainDef.Memory.Amount = d.Get("memory").(int)
 	domainDef.VCpu.Amount = d.Get("vcpu").(int)
 	domainDef.Devices.Disks = disks
@@ -195,6 +215,8 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", domainDef.Name)
+	d.Set("title", domainDef.Title)
+	d.Set("description", domainDef.Description)
 	d.Set("vpu", domainDef.VCpu)
 	d.Set("memory", domainDef.Memory)
 


### PR DESCRIPTION
Allow to set title and description of a domain. This feature might seem
superfluous at first sight, but can be used to quickly integrate
terraform with other tools.

For example, this can be used to ship custom grains to salt-ssh via a
custom salt roster module.

If you are fine with this PR I'll extend the docs to reflect these changes.