### PR TITLE
Domain: allow to set custom metadata

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -31,6 +31,10 @@ The following arguments are supported:
 * `vcpu` - (Optional) The amount of virtual CPUs. If not specified, a single CPU will be created.
 * `disk` - (Optional) An array of one or more disks to attach to the domain. The `disk` object structure is documented below.
 * `network_interface` - (Optional) An array of one or more network interfaces to attach to the domain. The `network_interface` object structure is documented below.
+* `metadata` - (Optional) A string containing valid XML data. This is going to be
+  added to the final domain inside of the [metadata tag](https://libvirt.org/formatdomain.html#elementsMetadata).
+  This can be used to integrate terraform into other tools by inspecting the
+  the contents of the `terraform.tf` file.
 
 The `disk` block supports:
 

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -11,6 +11,7 @@ type defDomain struct {
 	Os       defOs     `xml:"os"`
 	Memory   defMemory `xml:"memory"`
 	VCpu     defVCpu   `xml:"vcpu"`
+	Metadata defMetadata
 	Features struct {
 		Acpi string `xml:"acpi"`
 		Apic string `xml:"apic"`
@@ -24,6 +25,13 @@ type defDomain struct {
 			Autoport string `xml:"autoport,attr"`
 		} `xml:"graphics"`
 	} `xml:"devices"`
+}
+
+type defMetadata struct {
+	XMLName          xml.Name `xml:"metadata"`
+	TerraformLibvirt struct {
+		Xml string `xml:",cdata"`
+	} `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
 }
 
 type defOs struct {


### PR DESCRIPTION
Allow to set custom metadata of a domain. This feature can be used to quickly
integrate terraform with other tools.

For example, this can be used to ship custom grains to salt-ssh via a
custom salt roster module.


This supersedes PR https://github.com/dmacvicar/terraform-provider-libvirt/pull/31