### PR TITLE
README: update Ubuntu information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ servers on a [libvirt](https://libvirt.org/) host via [Terraform](https://terraf
 
 * libvirt 1.2.14 or newer on the hypervisor
 
-The provider uses `virDomainInterfaceAddresses` which was added in 1.2.14. Distributions like Ubuntu 14.04 LTS ship 1.2.2. If you need a stable server distribution with a recent libvirt version, try [openSUSE Leap](https://www.opensuse.org/).
+The provider uses `virDomainInterfaceAddresses` which was added in 1.2.14. If you need a stable server distribution with a recent libvirt version, try [openSUSE Leap](https://www.opensuse.org/) or [Ubuntu](http://www.ubuntu.com/server) (from version 15.10 Wily Werewolf on).
 
 In the future, I may try to support older libvirt versions if I find a way to elegantely conditional compile the code and get the IP addresses with alternative methods.
 


### PR DESCRIPTION
Both the latest version (16.04 LTS Xenial Xerus) and the previous one (15.10 Wily Werewolf) ship with adequate libvirt versions, there's little reason to mention 14.04 now.

https://launchpad.net/ubuntu/+source/libvirt