### PR TITLE
[wip] Improved network resource

### DIFF
--- a/docs/providers/libvirt/r/network.markdown
+++ b/docs/providers/libvirt/r/network.markdown
@@ -1,0 +1,67 @@
+---
+layout: "libvirt"
+page_title: "Libvirt: libvirt_network"
+sidebar_current: "docs-libvirt-network"
+description: |-
+  Manages a virtual machine (network) in libvirt
+---
+
+# libvirt\_network
+
+Manages a VM network resource within libvirt. For more information see
+[the official documentation](https://libvirt.org/formatnetwork.html).
+
+## Example Usage
+
+```
+resource "libvirt_network" "network1" {
+  # the name used by libvirt
+  name = "k8snet"
+
+  # mode can be: "nat" (default), "none", "route", "bridge"
+  mode = "nat"
+
+  #  the domain used by the DNS server in this network
+  domain = "k8s.local"
+
+  # the addresses allowed for domains connected and served by the DHCP server
+  addresses = ["10.17.3.0/24", "2001:db8:ca2:2::1/64"]
+
+  # (optional) the bridge device defines the name of a bridge device
+  # which will be used to construct the virtual network.
+  # (only necessary in "bridge" mode)
+  # bridge = "br7"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by libvirt.
+   Changing this forces a new resource to be created.
+* `domain` - The domain used by the DNS server.
+* `addresses` - A list of (0 or 1) ipv4 and (0 or 1) ipv6 ranges for being
+   served by the DHCP server.
+* `mode` -  One of:
+    - `none`: the guests can talk to each other and the host OS, but cannot reach
+    any other machines on the LAN.
+    - `nat`: it is the default network mode. This is a configuration that
+    allows guest OS to get outbound connectivity regardless of whether the host
+    uses ethernet, wireless, dialup, or VPN networking without requiring any
+    specific admin configuration. In the absence of host networking, it at
+    least allows guests to talk directly to each other.
+    - `route`: this is a variant on the default network which routes traffic from
+    the virtual network to the LAN _without applying any NAT_. It requires that the
+    IP address range be pre-configured in the routing tables of the router on
+    the host network.
+    - `bridge`: use a pre-existing host bridge. The guests will effectively be
+    directly connected to the physical network (i.e. their IP addresses will
+    all be on the subnet of the physical network, and there will be no
+    restrictions on inbound or outbound connections). The `bridge` network
+    attribute is mandatory in this case.
+* `bridge` - (Optional) The bridge device defines the name of a bridge
+   device which will be used to construct the virtual network (when not provided,
+   it will be automatically obtained by libvirt in `none`, `nat` and `route` modes).
+
+

--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -1,0 +1,145 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	libvirt "github.com/dmacvicar/libvirt-go"
+)
+
+type defNetworkIpDhcpRange struct {
+	XMLName xml.Name `xml:"range,omitempty"`
+
+	Start string `xml:"start,attr,omitempty"`
+	End   string `xml:"end,attr,omitempty"`
+}
+
+type defNetworkIpDhcpHost struct {
+	XMLName xml.Name `xml:"host,omitempty"`
+
+	Ip   string `xml:"ip,attr,omitempty"`
+	Mac  string `xml:"mac,attr,omitempty"`
+	Name string `xml:"name,attr,omitempty"`
+}
+
+type defNetworkIpDhcp struct {
+	XMLName xml.Name `xml:"dhcp,omitempty"`
+
+	Ranges []*defNetworkIpDhcpRange `xml:"range,omitempty"`
+	Hosts  []*defNetworkIpDhcpHost  `xml:"host,omitempty"`
+}
+
+type defNetworkIp struct {
+	XMLName xml.Name `xml:"ip,omitempty"`
+
+	Address string            `xml:"address,attr"`
+	Netmask string            `xml:"netmask,attr,omitempty"`
+	Prefix  int               `xml:"prefix,attr,omitempty"`
+	Family  string            `xml:"family,attr,omitempty"`
+	Dhcp    *defNetworkIpDhcp `xml:"dhcp,omitempty"`
+}
+
+type defNetworkBridge struct {
+	XMLName xml.Name `xml:"bridge,omitempty"`
+
+	Name string `xml:"name,attr,omitempty"`
+	Stp  string `xml:"stp,attr,omitempty"`
+}
+
+type defNetworkDomain struct {
+	XMLName xml.Name `xml:"domain,omitempty"`
+
+	Name      string `xml:"name,attr,omitempty"`
+	LocalOnly string `xml:"localOnly,attr,omitempty"`
+}
+
+type defNetworkForward struct {
+	Mode   string `xml:"mode,attr"`
+	Device string `xml:"dev,attr,omitempty"`
+	Nat    *struct {
+		Addresses []*struct {
+			Start string `xml:"start,attr"`
+			End   string `xml:"end,attr"`
+		} `xml:"address,omitempty"`
+		Ports []*struct {
+			Start string `xml:"start,attr"`
+			End   string `xml:"end,attr"`
+		} `xml:"port,omitempty"`
+	} `xml:"nat,omitempty"`
+}
+
+type defNetworkDns struct {
+	Host []*struct {
+		Ip       string   `xml:"ip,attr"`
+		HostName []string `xml:"hostname"`
+	} `xml:"host,omitempty"`
+	Forwarder []*struct {
+		Address string `xml:"addr,attr"`
+	} `xml:"forwarder,omitempty"`
+}
+
+// network definition in XML, compatible with what libvirt expects
+// note: we have to use pointers or otherwise golang's XML will not properly detect
+//       empty values and generate things like "<bridge></bridge>" that
+//       make libvirt crazy...
+type defNetwork struct {
+	XMLName xml.Name `xml:"network"`
+
+	Name    string             `xml:"name,omitempty"`
+	Domain  *defNetworkDomain  `xml:"domain,omitempty"`
+	Bridge  *defNetworkBridge  `xml:"bridge,omitempty"`
+	Forward *defNetworkForward `xml:"forward,omitempty"`
+	Ips     []*defNetworkIp    `xml:"ip,omitempty"`
+	Dns     *defNetworkDns     `xml:"dns,omitempty"`
+}
+
+// Check if the network has a DHCP server managed by libvirt
+func (net defNetwork) HasDHCP() bool {
+	if net.Forward != nil {
+		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Creates a network definition from a XML
+func newDefNetworkFromXML(s string) (defNetwork, error) {
+	var networkDef defNetwork
+	err := xml.Unmarshal([]byte(s), &networkDef)
+	if err != nil {
+		return defNetwork{}, err
+	}
+	return networkDef, nil
+}
+
+func newDefNetworkfromLibvirt(network *libvirt.VirNetwork) (defNetwork, error) {
+	networkXmlDesc, err := network.GetXMLDesc(0)
+	if err != nil {
+		return defNetwork{}, fmt.Errorf("Error retrieving libvirt domain XML description: %s", err)
+	}
+	networkDef := defNetwork{}
+	err = xml.Unmarshal([]byte(networkXmlDesc), &networkDef)
+	if err != nil {
+		return defNetwork{}, fmt.Errorf("Error reading libvirt network XML description: %s", err)
+	}
+	return  networkDef, nil
+}
+
+// Creates a network definition with the defaults the provider uses
+func newNetworkDef() defNetwork {
+	const defNetworkXML = `
+		<network>
+		  <name>default</name>
+		  <forward mode='nat'>
+		    <nat>
+		      <port start='1024' end='65535'/>
+		    </nat>
+		  </forward>
+		</network>`
+	if d, err := newDefNetworkFromXML(defNetworkXML); err != nil {
+		panic(fmt.Sprint("Unexpected error while parsing default network definition: %s", err))
+	} else {
+		return d
+	}
+}

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -1,0 +1,93 @@
+package libvirt
+
+import (
+	"bytes"
+	"encoding/xml"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func init() {
+	spew.Config.Indent = "\t"
+}
+
+func TestDefaultNetworkMarshall(t *testing.T) {
+	b := newNetworkDef()
+	prettyB := spew.Sdump(b)
+	t.Logf("Parsed default network:\n%s", prettyB)
+
+	buf := new(bytes.Buffer)
+	enc := xml.NewEncoder(buf)
+	enc.Indent("  ", "    ")
+	if err := enc.Encode(b); err != nil {
+		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
+	}
+	t.Logf("Marshalled default network:\n%s", buf.String())
+}
+
+func TestNetworkDefUnmarshall(t *testing.T) {
+	// some testing XML from the official docs (some unsupported attrs will be just ignored)
+	text := `
+		<network>
+			<name>my-network</name>
+			<bridge name="virbr0" stp="on" delay="5" macTableManager="libvirt"/>
+			<mac address='00:16:3E:5D:C7:9E'/>
+			<domain name="example.com" localOnly="no"/>
+			<forward mode='nat'>
+				<nat>
+					<address start='1.2.3.4' end='1.2.3.10'/>
+				</nat>
+			</forward>
+			<dns>
+				<txt name="example" value="example value" />
+				<forwarder addr="8.8.8.8"/>
+				<forwarder addr="8.8.4.4"/>
+				<srv service='name' protocol='tcp' domain='test-domain-name' target='.' port='1024' priority='10' weight='10'/>
+				<host ip='192.168.122.2'>
+					<hostname>myhost</hostname>
+					<hostname>myhostalias</hostname>
+				</host>
+			</dns>
+			<ip address="192.168.122.1" netmask="255.255.255.0">
+				<dhcp>
+					<range start="192.168.122.100" end="192.168.122.254" />
+					<host mac="00:16:3e:77:e2:ed" name="foo.example.com" ip="192.168.122.10" />
+					<host mac="00:16:3e:3e:a9:1a" name="bar.example.com" ip="192.168.122.11" />
+				</dhcp>
+			</ip>
+			<ip family="ipv6" address="2001:db8:ca2:2::1" prefix="64" />
+			<route family="ipv6" address="2001:db9:ca1:1::" prefix="64" gateway="2001:db8:ca2:2::2" />
+  		</network>
+	`
+
+	b, err := newDefNetworkFromXML(text)
+	prettyB := spew.Sdump(b)
+	t.Logf("Parsed:\n%s", prettyB)
+	if err != nil {
+		t.Errorf("could not parse: %s", err)
+	}
+	if b.Name != "my-network" {
+		t.Errorf("wrong network name: '%s'", b.Name)
+	}
+	if b.Domain.Name != "example.com" {
+		t.Errorf("wrong domain name: '%s'", b.Domain.Name)
+	}
+	if b.Forward.Mode != "nat" {
+		t.Errorf("wrong forward mode: '%s'", b.Forward.Mode)
+	}
+	if len(b.Forward.Nat.Addresses) == 0 {
+		t.Errorf("wrong number of addresses: %s", b.Forward.Nat.Addresses)
+	}
+	if b.Forward.Nat.Addresses[0].Start != "1.2.3.4" {
+		t.Errorf("wrong forward start address: %s", b.Forward.Nat.Addresses[0].Start)
+	}
+	if len(b.Ips) == 0 {
+		t.Errorf("wrong number of IPs: %d", len(b.Ips))
+	}
+	if bs, err := xmlMarshallIndented(b); err != nil {
+		t.Fatalf("marshalling error\n%s", spew.Sdump(b))
+	} else {
+		t.Logf("Marshalled:\n%s", bs)
+	}
+}

--- a/libvirt/network_interface_def.go
+++ b/libvirt/network_interface_def.go
@@ -2,9 +2,16 @@ package libvirt
 
 import (
 	"encoding/xml"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
+// An interface definition, as returned/understood by libvirt
+// (see https://libvirt.org/formatdomain.html#elementsNICS)
+//
+// Something like:
+//   <interface type='network'>
+//       <source network='default'/>
+//   </interface>
+//
 type defNetworkInterface struct {
 	XMLName xml.Name `xml:"interface"`
 	Type    string   `xml:"type,attr"`
@@ -13,68 +20,12 @@ type defNetworkInterface struct {
 	} `xml:"mac"`
 	Source struct {
 		Network string `xml:"network,attr"`
-	} `xml:"source"`
+		Bridge  string `xml:"bridge,attr"`
+		Dev  string `xml:"dev,attr"`
+		Mode  string `xml:"mode,attr"`
+	       } `xml:"source"`
 	Model struct {
 		Type string `xml:"type,attr"`
 	} `xml:"model"`
 	waitForLease bool
-}
-
-func networkAddressCommonSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"type": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"address": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"prefix": &schema.Schema{
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-	}
-}
-
-func networkInterfaceCommonSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"network": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  "default",
-			ForceNew: true,
-		},
-		"mac": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-			ForceNew: true,
-		},
-		"wait_for_lease": &schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"address": &schema.Schema{
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: networkAddressCommonSchema(),
-			},
-		},
-	}
-}
-
-func newDefNetworkInterface() defNetworkInterface {
-	iface := defNetworkInterface{}
-	iface.Type = "network"
-	//iface.Mac.Address = "52:54:00:36:c0:65"
-	iface.Source.Network = "default"
-	iface.Model.Type = "virtio"
-	iface.waitForLease = false
-	return iface
 }

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -19,6 +19,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"libvirt_domain":    resourceLibvirtDomain(),
 			"libvirt_volume":    resourceLibvirtVolume(),
+			"libvirt_network":   resourceLibvirtNetwork(),
 			"libvirt_cloudinit": resourceCloudInit(),
 		},
 

--- a/libvirt/resource_libvirt_domain_netiface.go
+++ b/libvirt/resource_libvirt_domain_netiface.go
@@ -1,0 +1,68 @@
+package libvirt
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func networkInterfaceCommonSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"network_id": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true,
+		},
+		"network_name": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true,
+		},
+		"bridge": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+		},
+		"vepa": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+		},
+		"macvtap": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true,
+		},
+		"passthrough": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+		},
+		"hostname": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: false,
+		},
+		"mac": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+		"wait_for_lease": &schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"addresses": &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: false,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -2,12 +2,13 @@ package libvirt
 
 import (
 	"fmt"
+	"log"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	//"gopkg.in/alexzorin/libvirt-go.v2"
 	libvirt "github.com/dmacvicar/libvirt-go"
-	"log"
-	"testing"
 )
 
 func TestAccLibvirtDomain_Basic(t *testing.T) {

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -1,0 +1,331 @@
+package libvirt
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	libvirt "github.com/dmacvicar/libvirt-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	netModeIsolated = "none"
+	netModeNat      = "nat"
+	netModeRoute    = "route"
+	netModeBridge   = "bridge"
+)
+
+// a libvirt network resource
+//
+// Resource example:
+//
+// resource "libvirt_network" "k8snet" {
+//    name = "k8snet"
+//    domain = "k8s.local"
+//    mode = "nat"
+//    addresses = ["10.17.3.0/24"]
+// }
+//
+// "addresses" can contain (0 or 1) ipv4 and (0 or 1) ipv6 ranges
+// "mode" can be one of: "nat" (default), "isolated"
+//
+func resourceLibvirtNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLibvirtNetworkCreate,
+		Read:   resourceLibvirtNetworkRead,
+		Delete: resourceLibvirtNetworkDelete,
+		Exists: resourceLibvirtNetworkExists,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"mode": &schema.Schema{ // can be "none", "nat" (default), "route", "bridge"
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  netModeNat,
+			},
+			"bridge": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"addresses": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Required: false,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceLibvirtNetworkExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return false, fmt.Errorf("The libvirt connection was nil.")
+	}
+	network, err := virConn.LookupNetworkByUUIDString(d.Id())
+	defer network.Free()
+	return err == nil, err
+}
+
+func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	// see https://libvirt.org/formatnetwork.html
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+
+	networkDef := newNetworkDef()
+	networkDef.Name = d.Get("name").(string)
+	networkDef.Domain = &defNetworkDomain{
+		Name: d.Get("domain").(string),
+	}
+
+	// use a bridge provided by the user, or create one otherwise (libvirt will assign on automatically when empty)
+	bridgeName := ""
+	if b, ok := d.GetOk("bridge"); ok {
+		bridgeName = b.(string)
+	}
+	networkDef.Bridge = &defNetworkBridge{
+		Name: bridgeName,
+		Stp:  "on",
+	}
+
+	// check the network mode
+	networkDef.Forward.Mode = strings.ToLower(d.Get("mode").(string))
+	if networkDef.Forward.Mode == netModeIsolated || networkDef.Forward.Mode == netModeNat || networkDef.Forward.Mode == netModeRoute {
+
+		// there is no mode when using an isolated network
+		if networkDef.Forward.Mode == netModeIsolated {
+			networkDef.Forward = nil
+		}
+
+		// some network modes require a DHCP/DNS server
+		// set the addresses for DHCP
+		if addresses, ok := d.GetOk("addresses"); ok {
+			ipsPtrsLst := []*defNetworkIp{}
+			for _, addressI := range addresses.([]interface{}) {
+				address := addressI.(string)
+				_, ipNet, err := net.ParseCIDR(address)
+				if err != nil {
+					return fmt.Errorf("Error parsing addresses definition '%s': %s", address, err)
+				}
+				ones, bits := ipNet.Mask.Size()
+				family := "ipv4"
+				if bits == (net.IPv6len * 8) {
+					family = "ipv6"
+				}
+				ipsRange := 2 ^ bits - 2 ^ ones
+				if ipsRange < 4 {
+					return fmt.Errorf("Netmask seems to be too strict: only %d IPs available (%s)", ipsRange-3, family)
+				}
+
+				// we should calculate the range served by DHCP. For example, for
+				// 192.168.121.0/24 we will serve 192.168.121.2 - 192.168.121.254
+				start, end := NetworkRange(ipNet)
+
+				// skip the .0, (for the network),
+				start[len(start)-1]++
+
+				// assign the .1 to the host interface
+				dni := defNetworkIp{
+					Address: start.String(),
+					Prefix:  ones,
+					Family:  family,
+				}
+
+				start[len(start)-1]++ // then skip the .1
+				end[len(end)-1]--     // and skip the .255 (for broadcast)
+
+				dni.Dhcp = &defNetworkIpDhcp{
+					Ranges: []*defNetworkIpDhcpRange{
+						&defNetworkIpDhcpRange{
+							Start: start.String(),
+							End:   end.String(),
+						},
+					},
+				}
+				ipsPtrsLst = append(ipsPtrsLst, &dni)
+			}
+			networkDef.Ips = ipsPtrsLst
+		}
+	} else if networkDef.Forward.Mode == netModeBridge {
+		if bridgeName == "" {
+			return fmt.Errorf("'bridge' must be provided when using the bridged network mode")
+		}
+	} else {
+		return fmt.Errorf("unsuppoorted network mode '%s'", networkDef.Forward.Mode)
+	}
+
+	// once we have the network defined, connect to libvirt and create it from the XML serialization
+	connectURI, err := virConn.GetURI()
+	if err != nil {
+		return fmt.Errorf("Error retrieving libvirt connection URI: %s", err)
+	}
+	log.Printf("[INFO] Creating libvirt network at %s", connectURI)
+
+	data, err := xmlMarshallIndented(networkDef)
+	if err != nil {
+		return fmt.Errorf("Error serializing libvirt network: %s", err)
+	}
+
+	log.Printf("[DEBUG] Creating libvirt network at %s: %s", connectURI, data)
+	network, err := virConn.NetworkDefineXML(data)
+	if err != nil {
+		return fmt.Errorf("Error defining libvirt network: %s - %s", err, data)
+	}
+	err = network.Create()
+	if err != nil {
+		return fmt.Errorf("Error crearing libvirt network: %s", err)
+	}
+	defer network.Free()
+
+	id, err := network.GetUUIDString()
+	if err != nil {
+		return fmt.Errorf("Error retrieving libvirt network id: %s", err)
+	}
+	d.SetId(id)
+
+	log.Printf("[INFO] Created network %s [%s]", networkDef.Name, d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"BUILD"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    waitForNetworkActive(network),
+		Timeout:    1 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for network to reach ACTIVE state: %s", err)
+	}
+
+	return resourceLibvirtNetworkRead(d, meta)
+}
+
+func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+
+	network, err := virConn.LookupNetworkByUUIDString(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error retrieving libvirt network: %s", err)
+	}
+	defer network.Free()
+
+	networkDef, err := newDefNetworkfromLibvirt(&network)
+	if err != nil {
+		return fmt.Errorf("Error reading libvirt network XML description: %s", err)
+	}
+
+	d.Set("name", networkDef.Name)
+	d.Set("domain", networkDef.Domain.Name)
+	d.Set("bridge", networkDef.Bridge.Name)
+
+	addresses := []string{}
+	for _, address := range networkDef.Ips {
+		// we get the host interface IP (ie, 10.10.8.1) but we want the network CIDR (ie, 10.10.8.0/24)
+		// so we need some transformations...
+		addr := net.ParseIP(address.Address)
+		if addr == nil {
+			return fmt.Errorf("Error parsing IP '%s': %s", address, err)
+		}
+		bits := net.IPv6len * 8
+		if addr.To4() != nil {
+			bits = net.IPv4len * 8
+		}
+		mask := net.CIDRMask(address.Prefix, bits)
+		network := addr.Mask(mask)
+		addresses = append(addresses, fmt.Sprintf("%s/%d", network, address.Prefix))
+	}
+	if len(addresses) > 0 {
+		d.Set("addresses", addresses)
+	}
+
+	// TODO: get any other parameters from the network and save them
+
+	log.Printf("[DEBUG] Network ID %s successfully read", d.Id())
+	return nil
+}
+
+func resourceLibvirtNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+	log.Printf("[DEBUG] Deleting network ID %s", d.Id())
+
+	network, err := virConn.LookupNetworkByUUIDString(d.Id())
+	if err != nil {
+		return fmt.Errorf("When destroying libvirt network: error retrieving %s", err)
+	}
+	defer network.Free()
+
+	if err := network.Destroy(); err != nil {
+		return fmt.Errorf("When destroying libvirt network: %s", err)
+	}
+
+	if err := network.Destroy(); err != nil {
+		return fmt.Errorf("When destroying libvirt network: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"ACTIVE"},
+		Target:     []string{"NOT-EXISTS"},
+		Refresh:    waitForNetworkDestroyed(virConn, d.Id()),
+		Timeout:    1 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for network to reach NOT-EXISTS state: %s", err)
+	}
+	return nil
+}
+
+func waitForNetworkActive(network libvirt.VirNetwork) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		active, err := network.IsActive()
+		if err != nil {
+			return nil, "", err
+		}
+		if active {
+			return network, "ACTIVE", nil
+		}
+		return network, "BUILD", err
+	}
+}
+
+// wait for network to be up and timeout after 5 minutes.
+func waitForNetworkDestroyed(virConn *libvirt.VirConnection, uuid string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("Waiting for network %s to be destroyed", uuid)
+		network, err := virConn.LookupNetworkByUUIDString(uuid)
+		if err.(libvirt.VirError).Code == libvirt.VIR_ERR_NO_NETWORK {
+			return virConn, "NOT-EXISTS", nil
+		}
+		defer network.Free()
+		return virConn, "ACTIVE", err
+	}
+}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -281,12 +281,24 @@ func resourceLibvirtNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 	defer network.Free()
 
-	if err := network.Destroy(); err != nil {
-		return fmt.Errorf("When destroying libvirt network: %s", err)
+	active, err := network.IsActive()
+	if err != nil {
+		return fmt.Errorf("Couldn't determine if network is active: %s", err)
+	}
+	if !active {
+		// we have to restart an inactive network, otherwise it won't be
+		// possible to remove it.
+		if err := network.Create(); err != nil {
+			return fmt.Errorf("Cannot restart an inactive network %s", err)
+		}
 	}
 
 	if err := network.Destroy(); err != nil {
 		return fmt.Errorf("When destroying libvirt network: %s", err)
+	}
+
+	if err := network.Undefine(); err != nil {
+		return fmt.Errorf("Couldn't undefine libvirt network: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/libvirt/utils_libvirt.go
+++ b/libvirt/utils_libvirt.go
@@ -1,0 +1,41 @@
+package libvirt
+
+import (
+	"log"
+
+	libvirt "github.com/dmacvicar/libvirt-go"
+)
+
+func getHostXMLDesc(ip, mac, name string) string {
+	dd := defNetworkIpDhcpHost{
+		Ip:   ip,
+		Mac:  mac,
+		Name: name,
+	}
+	xml, err := xmlMarshallIndented(dd)
+	if err != nil {
+		panic("could not marshall host")
+	}
+	return xml
+}
+
+// Adds a new static host to the network
+func addHost(n *libvirt.VirNetwork, ip, mac, name string) error {
+	xmlDesc := getHostXMLDesc(ip, mac, name)
+	log.Printf("Adding host with XML:\n%s", xmlDesc)
+	return n.UpdateXMLDesc(xmlDesc, libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_LAST, libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST)
+}
+
+// Removes a static host from the network
+func removeHost(n *libvirt.VirNetwork, ip, mac, name string) error {
+	xmlDesc := getHostXMLDesc(ip, mac, name)
+	log.Printf("Removing host with XML:\n%s", xmlDesc)
+	return n.UpdateXMLDesc(xmlDesc, libvirt.VIR_NETWORK_UPDATE_COMMAND_DELETE, libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST)
+}
+
+// Update a static host from the network
+func updateHost(n *libvirt.VirNetwork, ip, mac, name string) error {
+	xmlDesc := getHostXMLDesc(ip, mac, name)
+	log.Printf("Updating host with XML:\n%s", xmlDesc)
+	return n.UpdateXMLDesc(xmlDesc, libvirt.VIR_NETWORK_UPDATE_COMMAND_MODIFY, libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST)
+}

--- a/libvirt/utils_net.go
+++ b/libvirt/utils_net.go
@@ -1,0 +1,58 @@
+package libvirt
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+)
+
+const (
+	maxIfaceNum = 100
+)
+
+func RandomMACAddress() (string, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+
+	// set local bit and unicast
+	buf[0] = (buf[0] | 2) & 0xfe
+	// Set the local bit
+	buf[0] |= 2
+
+	// avoid libvirt-reserved addresses
+	if buf[0] == 0xfe {
+		buf[0] = 0xee
+	}
+
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
+}
+
+func FreeNetworkInterface(basename string) (string, error) {
+	for i := 0; i < maxIfaceNum; i++ {
+		ifaceName := fmt.Sprintf("%s%d", basename, i)
+		_, err := net.InterfaceByName(ifaceName)
+		if err != nil {
+			return ifaceName, nil
+		}
+	}
+	return "", fmt.Errorf("could not obtain a free network interface")
+}
+
+// Calculates the first and last IP addresses in an IPNet
+func NetworkRange(network *net.IPNet) (net.IP, net.IP) {
+	netIP := network.IP.To4()
+	lastIP := net.IPv4(0, 0, 0, 0).To4()
+	if netIP == nil {
+		netIP = network.IP.To16()
+		lastIP = net.IPv6zero.To16()
+	}
+	firstIP := netIP.Mask(network.Mask)
+	for i := 0; i < len(lastIP); i++ {
+		lastIP[i] = netIP[i] | ^network.Mask[i]
+	}
+	return firstIP, lastIP
+}

--- a/libvirt/utils_test.go
+++ b/libvirt/utils_test.go
@@ -1,6 +1,7 @@
 package libvirt
 
 import (
+	"net"
 	"testing"
 )
 
@@ -14,5 +15,20 @@ func TestDiskLetterForIndex(t *testing.T) {
 		if ret != names[i] {
 			t.Errorf("Expected %s, got %s for disk %d", names[i], ret, diskNumber)
 		}
+	}
+}
+
+func TestIPsRange(t *testing.T) {
+	_, net, err := net.ParseCIDR("192.168.18.1/24")
+	if err != nil {
+		t.Errorf("When parsing network: %s", err)
+	}
+
+	start, end := NetworkRange(net)
+	if start.String() != "192.168.18.0" {
+		t.Errorf("unexpected range start for '%s': %s", net, start)
+	}
+	if end.String() != "192.168.18.255" {
+		t.Errorf("unexpected range start for '%s': %s", net, start)
 	}
 }


### PR DESCRIPTION
### Overview:

This PR implements a `network` resource for the libvirt provider for Terraform. A network can be specified with something like this:

```
resource "libvirt_network" "network1" {
  # the name used by libvirt
  name = "k8snet"

  # mode can be: "nat" (deafult), "isolated", "route"
  mode = "nat"

  #  the domain used by the DNS server in this network
  domain = "k8s.local"

  # the addresses allowed for domains connected and served by the DHCP server
  addresses = ["10.17.3.0/24"]
}
```

This would create a network named `k8net`, with a DNS server running at `10.17.3.1` for the `k8s.local` domain and a DHCP server assigning IPs from the `10.17.3.0/24` pool. We could then add a machine to this network with:

```
resource "libvirt_domain" "domain1" {
  name = "domain1"
  ...
  network_interface {
    # the network to plug into (use "network_name" for pluging into an unmanaged network)
    network_id = "${libvirt_network.net1.id}"

    # an (optional) DNS name to assign to this host on this interface
    hostname = "master"

    # an (optional) IP address to force for this interface
    addresses = ["10.17.3.3"]

    # an (optional) MAC address to force for this interface
    mac = "AA:BB:CC:11:22:22"

    # wait until the DHCP lease is obtained
    wait_for_lease = 1
  }
}
```

The DNS server will resolve  `master.k8s.local` to `10.17.3.3` (note that machines are not automatically configured for using this DNS server though).

### Limitations

* the range of addresses assignable by the DHCP server is specified with a simple CIDR (ie, `10.17.3.0/24`) instead of using a `start-IP`-`end-IP` range.

### Pending:

- [x] resource `update()`
- [x] test & implement network modes other than DHCP & NAT
- [x] code cleanups and tests
- [ ] some proper integration tests (nice-to-have)

### Dependencies

* dmacvicar/libvirt-go#1

(builds will fail until merged...)
