### PR TITLE
Build against released terraform 0.6.16 instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ $ terraform destroy
 2.  [Set up Gopath](https://golang.org/doc/code.html)
 3.  `git clone` this repository into `$GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt`
 4.  Run `go get` to get dependencies
-5.  Run `go install` to build the binary. You will now find the
+5.  Switch the terraform project back to the stable version, otherwise you will get a `Incompatible API version with plugin. Plugin version: 1, Ours: 2` error at runtime:
+```
+cd $GOPATH/src/github.com/hashicorp/terraform
+git checkout v0.6.16
+cd $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+```
+6.  Run `go install` to build the binary. You will now find the
     binary at `$GOPATH/bin/terraform-provider-libvirt`.
 
 ## Running


### PR DESCRIPTION
Current build instructions are broken, when running `terraform` you get the following error:

> Incompatible API version with plugin. Plugin version: 1, Ours: 2

This happens because `go get`, by default, [will always use the `master` branch for dependencies](stackoverflow.com/questions/24855081/how-do-i-import-a-specific-version-of-a-package-using-go-get?answertab=votes#tab-top) and at the same time [terraform developers changed the plugin API to 2](https://groups.google.com/forum/#!topic/terraform-tool/a1agp4CAEDk) in `master`.

This patch informs the user to build against the released `terraform` version.

This patch should be reverted as soon as 0.7 is actually released.