### PR TITLE
Avoid randomly assigning MAC addresses that libvirt does not like

### DIFF
--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -51,5 +51,10 @@ func RandomMACAddress() (string, error) {
 	// Set the local bit
 	buf[0] |= 2
 
+	// avoid libvirt-reserved addresses
+	if buf[0] == 0xfe {
+		buf[0] = 0xee
+	}
+
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
 }


### PR DESCRIPTION
Works around the following error:

```
* libvirt_domain.<NAME>: Error crearing libvirt domain: [Code-67] [Domain-0] unsupported configuration: Unable to use MAC address starting with reserved value 0xFE - 'fe:d3:99:09:98:f6' - 
```
