### PR TITLE
Cloudinit

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -35,6 +35,10 @@ The following arguments are supported:
   added to the final domain inside of the [metadata tag](https://libvirt.org/formatdomain.html#elementsMetadata).
   This can be used to integrate terraform into other tools by inspecting the
   the contents of the `terraform.tf` file.
+* `cloudinit` - (Optional) The `libvirt_cloudinit` disk that has to be used by
+  the domain. This is going to be attached as a CDROM ISO. Changing the
+  cloud-init won't cause the domain to be recreated, however the change will
+  have effect on the next reboot.
 
 The `disk` block supports:
 

--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -31,6 +31,10 @@ The following arguments are supported:
 * `vcpu` - (Optional) The amount of virtual CPUs. If not specified, a single CPU will be created.
 * `disk` - (Optional) An array of one or more disks to attach to the domain. The `disk` object structure is documented below.
 * `network_interface` - (Optional) An array of one or more network interfaces to attach to the domain. The `network_interface` object structure is documented below.
+* `metadata` - (Optional) A string containing valid XML data. This is going to be
+  added to the final domain inside of the [metadata tag](https://libvirt.org/formatdomain.html#elementsMetadata).
+  This can be used to integrate terraform into other tools by inspecting the
+  the contents of the `terraform.tf` file.
 
 The `disk` block supports:
 

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -1,0 +1,304 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+	libvirt "github.com/dmacvicar/libvirt-go"
+	"github.com/hooklift/iso9660"
+	"gopkg.in/yaml.v2"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// names of the files expected by cloud-init
+const USERDATA string = "user-data"
+const METADATA string = "meta-data"
+
+type defCloudInit struct {
+	Name     string
+	PoolName string
+	Metadata struct {
+		LocalHostname string `yaml:"local-hostname"`
+		InstanceID    string `yaml:"instance-id"`
+	}
+	UserData struct {
+		SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys"`
+	}
+}
+
+// Creates a new cloudinit with the defaults
+// the provider uses
+func newCloudInitDef() defCloudInit {
+	ci := defCloudInit{}
+	ci.Metadata.InstanceID = fmt.Sprintf("created-at-%s", time.Now().String())
+
+	return ci
+}
+
+// Create a ISO file based on the contents of the CloudInit instance and
+// uploads it to the libVirt pool
+// Returns a string holding the ID of the volume
+func (ci *defCloudInit) CreateAndUpload(virConn *libvirt.VirConnection) (string, error) {
+	iso, err := ci.createISO()
+	if err != nil {
+		return "", err
+	}
+
+	pool, err := virConn.LookupStoragePoolByName(ci.PoolName)
+	if err != nil {
+		return "", fmt.Errorf("can't find storage pool '%s'", ci.PoolName)
+	}
+	defer pool.Free()
+
+	// Refresh the pool of the volume so that libvirt knows it is
+	// not longer in use.
+	WaitForSuccess("Error refreshing pool for volume", func() error {
+		return pool.Refresh(0)
+	})
+
+	volumeDef := newDefVolume()
+	volumeDef.Name = ci.Name
+
+	// an existing image was given, this mean we can't choose size
+	img, err := newImage(iso)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		// Remove the tmp directory holding the ISO
+		if err = os.RemoveAll(filepath.Dir(iso)); err != nil {
+			log.Printf("Error while removing tmp directory holding the ISO file: %s", err)
+		}
+	}()
+
+	size, err := img.Size()
+	if err != nil {
+		return "", err
+	}
+
+	volumeDef.Capacity.Unit = "B"
+	volumeDef.Capacity.Amount = size
+
+	volumeDefXml, err := xml.Marshal(volumeDef)
+	if err != nil {
+		return "", fmt.Errorf("Error serializing libvirt volume: %s", err)
+	}
+
+	// create the volume
+	volume, err := pool.StorageVolCreateXML(string(volumeDefXml), 0)
+	if err != nil {
+		return "", fmt.Errorf("Error creating libvirt volume: %s", err)
+	}
+	defer volume.Free()
+
+	// upload ISO file
+	stream, err := libvirt.NewVirStream(virConn, 0)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	volume.Upload(stream, 0, uint64(volumeDef.Capacity.Amount), 0)
+	err = img.WriteToStream(stream)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := volume.GetKey()
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving volume key: %s", err)
+	}
+
+	return key, nil
+}
+
+// Create the ISO holding all the cloud-init data
+// Returns a string with the full path to the ISO file
+func (ci *defCloudInit) createISO() (string, error) {
+	log.Print("Creating new ISO")
+	tmpDir, err := ci.createFiles()
+	if err != nil {
+		return "", err
+	}
+
+	isoDestination := filepath.Join(tmpDir, ci.Name)
+	cmd := exec.Command(
+		"genisoimage",
+		"-output",
+		isoDestination,
+		"-volid",
+		"cidata",
+		"-joliet",
+		"-rock",
+		filepath.Join(tmpDir, USERDATA),
+		filepath.Join(tmpDir, METADATA))
+
+	log.Print("About to execute cmd: %+v", cmd)
+	if err = cmd.Start(); err != nil {
+		return "", fmt.Errorf("Error while starting the creation of CloudInit's ISO image: %s", err)
+	}
+	if err = cmd.Wait(); err != nil {
+		return "", fmt.Errorf("Error while creating CloudInit's ISO image: %s", err)
+	}
+	log.Print("ISO created at %s", isoDestination)
+
+	return isoDestination, nil
+}
+
+// Dumps the userdata and the metadata into two dedicated yaml files.
+// The files are created inside of a temporary directory
+// Returns a string containing the name of the temporary directory and an error
+// object
+func (ci *defCloudInit) createFiles() (string, error) {
+	log.Print("Creating ISO contents")
+	tmpDir, err := ioutil.TempDir("", "cloudinit")
+	if err != nil {
+		return "", fmt.Errorf("Cannot create tmp directory for cloudinit ISO generation: %s",
+			err)
+	}
+
+	// Create files required by ISO file
+	ud, err := yaml.Marshal(&ci.UserData)
+	if err != nil {
+		return "", fmt.Errorf("Error dumping cloudinit's user data: %s", err)
+	}
+	userdata := fmt.Sprintf("#cloud-config\n%s", string(ud))
+	if err = ioutil.WriteFile(
+		filepath.Join(tmpDir, USERDATA),
+		[]byte(userdata),
+		os.ModePerm); err != nil {
+		return "", fmt.Errorf("Error while writing user-data to file: %s", err)
+	}
+
+	metadata, err := yaml.Marshal(&ci.Metadata)
+	if err != nil {
+		return "", fmt.Errorf("Error dumping cloudinit's meta data: %s", err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(tmpDir, METADATA), metadata, os.ModePerm); err != nil {
+		return "", fmt.Errorf("Error while writing meta-data to file: %s", err)
+	}
+
+	log.Print("ISO contents created")
+
+	return tmpDir, nil
+}
+
+func newCloudInitDefFromRemoteISO(virConn *libvirt.VirConnection, key string) (defCloudInit, error) {
+	ci := defCloudInit{}
+
+	volume, err := virConn.LookupStorageVolByKey(key)
+	if err != nil {
+		return ci, fmt.Errorf("Can't retrieve volume %s", key)
+	}
+	defer volume.Free()
+
+	ci.Name, err = volume.GetName()
+	if err != nil {
+		return ci, fmt.Errorf("Error retrieving volume name: %s", err)
+	}
+
+	volPool, err := volume.LookupPoolByVolume()
+	if err != nil {
+		return ci, fmt.Errorf("Error retrieving pool for volume: %s", err)
+	}
+	defer volPool.Free()
+
+	ci.PoolName, err = volPool.GetName()
+	if err != nil {
+		return ci, fmt.Errorf("Error retrieving pool name: %s", err)
+	}
+
+	file, err := downloadISO(virConn, volume)
+	if file != nil {
+		defer os.Remove(file.Name())
+		defer file.Close()
+	}
+	if err != nil {
+		return ci, err
+	}
+
+	// read ISO contents
+	isoReader, err := iso9660.NewReader(file)
+	if err != nil {
+		return ci, fmt.Errorf("Error initializing ISO reader: %s", err)
+	}
+
+	for {
+		f, err := isoReader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return ci, err
+		}
+
+		log.Printf("ISO reader: processing file %s", f.Name())
+
+		//TODO: the iso9660 has a bug...
+		if f.Name() == "/user_dat." {
+			data, err := ioutil.ReadAll(f.Sys().(io.Reader))
+			if err != nil {
+				return ci, fmt.Errorf("Error while reading %s: %s", USERDATA, err)
+			}
+			if err := yaml.Unmarshal(data, &ci.UserData); err != nil {
+				return ci, fmt.Errorf("Error while unmarshalling user-data: %s", err)
+			}
+		}
+
+		//TODO: the iso9660 has a bug...
+		if f.Name() == "/meta_dat." {
+			data, err := ioutil.ReadAll(f.Sys().(io.Reader))
+			if err != nil {
+				return ci, fmt.Errorf("Error while reading %s: %s", METADATA, err)
+			}
+			if err := yaml.Unmarshal(data, &ci.Metadata); err != nil {
+				return ci, fmt.Errorf("Error while unmarshalling user-data: %s", err)
+			}
+		}
+	}
+
+	log.Printf("Read cloud-init from file: %+v", ci)
+
+	return ci, nil
+}
+
+// Downloads the ISO identified by `key` to a local tmp file.
+// Returns a pointer to the ISO file. Note well: you have to close this file
+// pointer when you are done.
+func downloadISO(virConn *libvirt.VirConnection, volume libvirt.VirStorageVol) (*os.File, error) {
+	// get Volume info (required to get size later)
+	info, err := volume.GetInfo()
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving info for volume: %s", err)
+	}
+
+	// create tmp file for the ISO
+	file, err := ioutil.TempFile("", "cloudinit")
+	if err != nil {
+		return nil, fmt.Errorf("Cannot create tmp file: %s", err)
+	}
+
+	// download ISO file
+	stream, err := libvirt.NewVirStream(virConn, 0)
+	if err != nil {
+		return file, err
+	}
+	defer stream.Close()
+
+	volume.Download(stream, 0, info.GetCapacityInBytes(), 0)
+
+	n, err := io.Copy(file, stream)
+	if err != nil {
+		return file, fmt.Errorf("Error while copying remote volume to local disk: %s", err)
+	}
+	file.Seek(0, 0)
+	log.Printf("%d bytes downloaded", n)
+
+	return file, nil
+}

--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -48,3 +48,16 @@ func newDefDisk() defDisk {
 
 	return disk
 }
+
+func newCDROM() defDisk {
+	disk := defDisk{}
+	disk.Type = "volume"
+	disk.Device = "cdrom"
+	disk.Target.Dev = "hda"
+	disk.Target.Bus = "ide"
+
+	disk.Driver.Name = "qemu"
+	disk.Driver.Type = "raw"
+
+	return disk
+}

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -11,6 +11,7 @@ type defDomain struct {
 	Os       defOs     `xml:"os"`
 	Memory   defMemory `xml:"memory"`
 	VCpu     defVCpu   `xml:"vcpu"`
+	Metadata defMetadata
 	Features struct {
 		Acpi string `xml:"acpi"`
 		Apic string `xml:"apic"`
@@ -24,6 +25,13 @@ type defDomain struct {
 			Autoport string `xml:"autoport,attr"`
 		} `xml:"graphics"`
 	} `xml:"devices"`
+}
+
+type defMetadata struct {
+	XMLName          xml.Name `xml:"metadata"`
+	TerraformLibvirt struct {
+		Xml string `xml:",cdata"`
+	} `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
 }
 
 type defOs struct {

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -17,8 +17,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"libvirt_domain": resourceLibvirtDomain(),
-			"libvirt_volume": resourceLibvirtVolume(),
+			"libvirt_domain":         resourceLibvirtDomain(),
+			"libvirt_volume":         resourceLibvirtVolume(),
+			"libvirt_cloud_init_iso": resourceCloudInitISO(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -17,9 +17,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"libvirt_domain":         resourceLibvirtDomain(),
-			"libvirt_volume":         resourceLibvirtVolume(),
-			"libvirt_cloud_init_iso": resourceCloudInitISO(),
+			"libvirt_domain":    resourceLibvirtDomain(),
+			"libvirt_volume":    resourceLibvirtVolume(),
+			"libvirt_cloudinit": resourceCloudInit(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -95,5 +95,10 @@ func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("The libvirt connection was nil.")
 	}
 
-	return RemoveVolume(virConn, d.Id())
+	key, err := getCloudInitVolumeKeyFromTerraformID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	return RemoveVolume(virConn, key)
 }

--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -6,11 +6,11 @@ import (
 	"log"
 )
 
-func resourceCloudInitISO() *schema.Resource {
+func resourceCloudInit() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudInitISOCreate,
-		Read:   resourceCloudInitISORead,
-		Delete: resourceCloudInitISODelete,
+		Create: resourceCloudInitCreate,
+		Read:   resourceCloudInitRead,
+		Delete: resourceCloudInitDelete,
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -37,7 +37,7 @@ func resourceCloudInitISO() *schema.Resource {
 	}
 }
 
-func resourceCloudInitISOCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")
@@ -64,10 +64,10 @@ func resourceCloudInitISOCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.SetId(key)
 
-	return resourceCloudInitISORead(d, meta)
+	return resourceCloudInitRead(d, meta)
 }
 
-func resourceCloudInitISORead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")
@@ -89,7 +89,7 @@ func resourceCloudInitISORead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceCloudInitISODelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")

--- a/libvirt/resource_cloud_init_iso.go
+++ b/libvirt/resource_cloud_init_iso.go
@@ -1,0 +1,99 @@
+package libvirt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func resourceCloudInitISO() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudInitISOCreate,
+		Read:   resourceCloudInitISORead,
+		Delete: resourceCloudInitISODelete,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"pool": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"local_hostname": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ssh_authorized_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceCloudInitISOCreate(d *schema.ResourceData, meta interface{}) error {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+
+	cloudInit := newCloudInitDef()
+	cloudInit.Metadata.LocalHostname = d.Get("local_hostname").(string)
+
+	if _, ok := d.GetOk("ssh_authorized_key"); ok {
+		sshKey := d.Get("ssh_authorized_key").(string)
+		cloudInit.UserData.SSHAuthorizedKeys = append(
+			cloudInit.UserData.SSHAuthorizedKeys,
+			sshKey)
+	}
+
+	cloudInit.Name = d.Get("name").(string)
+	cloudInit.PoolName = d.Get("pool").(string)
+
+	log.Printf("[INFO] cloudInit: %+v", cloudInit)
+
+	key, err := cloudInit.CreateAndUpload(virConn)
+	if err != nil {
+		return err
+	}
+	d.SetId(key)
+
+	return resourceCloudInitISORead(d, meta)
+}
+
+func resourceCloudInitISORead(d *schema.ResourceData, meta interface{}) error {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+
+	ci, err := newCloudInitDefFromRemoteISO(virConn, d.Id())
+	d.Set("pool", ci.PoolName)
+	d.Set("name", ci.Name)
+	d.Set("local_hostname", ci.Metadata.LocalHostname)
+
+	if err != nil {
+		return fmt.Errorf("Error while retrieving remote ISO: %s", err)
+	}
+
+	if len(ci.UserData.SSHAuthorizedKeys) == 1 {
+		d.Set("ssh_authorized_key", ci.UserData.SSHAuthorizedKeys[0])
+	}
+
+	return nil
+}
+
+func resourceCloudInitISODelete(d *schema.ResourceData, meta interface{}) error {
+	virConn := meta.(*Client).libvirt
+	if virConn == nil {
+		return fmt.Errorf("The libvirt connection was nil.")
+	}
+
+	return RemoveVolume(virConn, d.Id())
+}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -45,7 +45,7 @@ func resourceLibvirtDomain() *schema.Resource {
 				Default:  true,
 				ForceNew: false,
 			},
-			"cloud_init": &schema.Schema{
+			"cloudinit": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: false,
 				Optional: true,
@@ -110,7 +110,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		disks = append(disks, disk)
 	}
 
-	if cloudinit, ok := d.GetOk("cloud_init"); ok {
+	if cloudinit, ok := d.GetOk("cloudinit"); ok {
 		disk, err := newDiskForCloudInit(virConn, cloudinit.(string))
 		if err != nil {
 			return err
@@ -244,8 +244,8 @@ func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("cloud_init") {
-		cloudinit, err := newDiskForCloudInit(virConn, d.Get("cloud_init").(string))
+	if d.HasChange("cloudinit") {
+		cloudinit, err := newDiskForCloudInit(virConn, d.Get("cloudinit").(string))
 		if err != nil {
 			return err
 		}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -375,36 +375,5 @@ func resourceLibvirtVolumeDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("The libvirt connection was nil.")
 	}
 
-	volume, err := virConn.LookupStorageVolByKey(d.Id())
-	if err != nil {
-		return fmt.Errorf("Can't retrieve volume %s", d.Id())
-	}
-	defer volume.Free()
-
-	// Refresh the pool of the volume so that libvirt knows it is
-	// not longer in use.
-	volPool, err := volume.LookupPoolByVolume()
-	if err != nil {
-		return fmt.Errorf("Error retrieving pool for volume: %s", err)
-	}
-	defer volPool.Free()
-
-	WaitForSuccess("Error refreshing pool for volume", func() error {
-		return volPool.Refresh(0)
-	})
-
-	// Workaround for redhat#1293804
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1293804#c12
-	// Does not solve the problem but it makes it happen less often.
-	_, err = volume.GetXMLDesc(0)
-	if err != nil {
-		return fmt.Errorf("Can't retrieve volume %s XML desc: %s", d.Id(), err)
-	}
-
-	err = volume.Delete(0)
-	if err != nil {
-		return fmt.Errorf("Can't delete volume %s: %s", d.Id(), err)
-	}
-
-	return nil
+	return RemoveVolume(virConn, d.Id())
 }

--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -3,6 +3,7 @@ package libvirt
 import (
 	"crypto/rand"
 	"fmt"
+	libvirt "github.com/dmacvicar/libvirt-go"
 	"log"
 	"time"
 )
@@ -52,4 +53,41 @@ func RandomMACAddress() (string, error) {
 	buf[0] |= 2
 
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
+}
+
+// Remove the volume identified by `key` from libvirt
+func RemoveVolume(virConn *libvirt.VirConnection, key string) error {
+	volume, err := virConn.LookupStorageVolByKey(key)
+	if err != nil {
+		return fmt.Errorf("Can't retrieve volume %s", key)
+	}
+	defer volume.Free()
+
+	// Refresh the pool of the volume so that libvirt knows it is
+	// not longer in use.
+	volPool, err := volume.LookupPoolByVolume()
+	if err != nil {
+		return fmt.Errorf("Error retrieving pool for volume: %s", err)
+	}
+	defer volPool.Free()
+
+	WaitForSuccess("Error refreshing pool for volume", func() error {
+		return volPool.Refresh(0)
+	})
+
+	// Workaround for redhat#1293804
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1293804#c12
+	// Does not solve the problem but it makes it happen less often.
+	_, err = volume.GetXMLDesc(0)
+	if err != nil {
+		return fmt.Errorf("Can't retrieve volume %s XML desc: %s", key, err)
+	}
+
+	err = volume.Delete(0)
+	if err != nil {
+		return fmt.Errorf("Can't delete volume %s: %s", key, err)
+	}
+
+	return nil
+
 }


### PR DESCRIPTION
This is PR introduces support for cloudinit. This allows to set a custom hostname and a custom authorized key for the root user as requested [here](https://github.com/dmacvicar/terraform-provider-libvirt/issues/4).

## How it works

The user has to define a `libvirt_cloudinit` resource and associate it with a domain. Behind the scene the code will:
  * create the cloud-init related files
  * create a new ISO file containing these files
  * upload the ISO file to the desired pool
  * add a CDROM drive to the domain

## Requirements

The `genisoimage` command is required at runtime to generate the cloud-init ISO. I tried to understand how to use `libisofs` but I honestly gave up, it seemed an incredible waste of time...

I also had to include new external libraries. Once we are done with this PR I'll go back the the other one about govend, the situation is about to escape our control...

## Future work

Cloud-init is a can of worms, right now I decided to support only 2 types of attributes (local host and ssh keys). I was thinking to further expend the cloud-init support by allowing the user to enter custom values for the `user-data` and `meta-data` files via custom strings. What do you think about that?