### PR TITLE
Set default network name properly

### DIFF
--- a/libvirt/network_interface_def.go
+++ b/libvirt/network_interface_def.go
@@ -45,6 +45,7 @@ func networkInterfaceCommonSchema() map[string]*schema.Schema {
 		"network": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
+			Default:  "default",
 			ForceNew: true,
 		},
 		"mac": &schema.Schema{


### PR DESCRIPTION
When defining a network interface without specifying a name, eg.

```hcl
  network_interface {
    wait_for_lease = true
  }
```

We get the following output from the second `terraform apply` on:
```
sumaform$ terraform apply 
libvirt_volume.terraform_sles11sp3: Refreshing state... (ID: /var/lib/libvirt/images/sles11sp3)
libvirt_volume.terraform_test_disk: Refreshing state... (ID: /var/lib/libvirt/images/terraform_test_disk)
libvirt_domain.terraform_test: Refreshing state... (ID: 3cd7953c-8f18-48e1-a905-bca460744085)
libvirt_domain.terraform_test: Modifying...
  network_interface.0.network: "default" => ""
libvirt_domain.terraform_test: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
Note that the network name is changed to an empty string.

With this patch:
```
sumaform$ terraform apply 
libvirt_volume.terraform_sles11sp3: Refreshing state... (ID: /var/lib/libvirt/images/sles11sp3)
libvirt_volume.terraform_test_disk: Refreshing state... (ID: /var/lib/libvirt/images/terraform_test_disk)
libvirt_domain.terraform_test: Refreshing state... (ID: 7444b7d4-6622-4a2a-be27-62d669c521ee)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
No changes.