### PR TITLE
[RFC] Add support for macvlan network interfaces

### DIFF
--- a/libvirt/network_interface_def.go
+++ b/libvirt/network_interface_def.go
@@ -12,7 +12,9 @@ type defNetworkInterface struct {
 		Address string `xml:"address,attr"`
 	} `xml:"mac"`
 	Source struct {
-		Network string `xml:"network,attr"`
+		Network string `xml:"network,attr,omitempty"`
+		Dev     string `xml:"dev,attr,omitempty"`
+		Mode    string `xml:"mode,attr,omitempty"`
 	} `xml:"source"`
 	Model struct {
 		Type string `xml:"type,attr"`
@@ -45,7 +47,6 @@ func networkInterfaceCommonSchema() map[string]*schema.Schema {
 		"network": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  "default",
 			ForceNew: true,
 		},
 		"mac": &schema.Schema{
@@ -66,14 +67,17 @@ func networkInterfaceCommonSchema() map[string]*schema.Schema {
 				Schema: networkAddressCommonSchema(),
 			},
 		},
+		"bridge": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 	}
 }
 
 func newDefNetworkInterface() defNetworkInterface {
 	iface := defNetworkInterface{}
-	iface.Type = "network"
 	//iface.Mac.Address = "52:54:00:36:c0:65"
-	iface.Source.Network = "default"
 	iface.Model.Type = "virtio"
 	iface.waitForLease = false
 	return iface


### PR DESCRIPTION
**Note well: this is a WIP PR**

This allows the network card to use the macvlan driver to bridge over a physical device (eg: eth0, wlan0). This is a quick way to bridge a domain to an existing network.

The `vagrant-libvirt` driver uses macvtap too, in some cases this can be pretty useful (eg: a laptop where libvirt cannot create real bridges because of network-manager).

There are however some drawbacks:
  * It's not possible to reach the guest from the host. This is a known limitation of macvlan
  * It's not possible to get the address of the guest from the host. This breaks the `wait_for_lease` feature

What do you think about that?

## Example of domain definition

```json
resource "libvirt_domain" "macvtap" {
  name = "macvtap"
  disk {
    volume_id = "${libvirt_volume.volume.id}"
  }
  network_interface {
    bridge = "eth0"
    mac = "AA:BB:CC:11:22:33"
  }
}
```