### PR TITLE
Bugfix: metadata always need refreshing

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -11,7 +11,10 @@ type defDomain struct {
 	Os       defOs     `xml:"os"`
 	Memory   defMemory `xml:"memory"`
 	VCpu     defVCpu   `xml:"vcpu"`
-	Metadata defMetadata
+	Metadata struct {
+		XMLName          xml.Name `xml:"metadata"`
+		TerraformLibvirt defMetadata
+	}
 	Features struct {
 		Acpi string `xml:"acpi"`
 		Apic string `xml:"apic"`
@@ -28,10 +31,8 @@ type defDomain struct {
 }
 
 type defMetadata struct {
-	XMLName          xml.Name `xml:"metadata"`
-	TerraformLibvirt struct {
-		Xml string `xml:",cdata"`
-	} `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
+	XMLName xml.Name `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
+	Xml     string   `xml:",cdata"`
 }
 
 type defOs struct {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -226,9 +226,8 @@ func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("metadata") {
-		//terraform-libvirt:user_data xmlns:terraform-libvirt="http://github.com/dmacvicar/terraform-provider-libvirt/"
 		metadata := defMetadata{}
-		metadata.TerraformLibvirt.Xml = d.Get("metadata").(string)
+		metadata.Xml = d.Get("metadata").(string)
 		metadataToXml, err := xml.Marshal(metadata)
 		if err != nil {
 			return fmt.Errorf("Error serializing libvirt metadata: %s", err)


### PR DESCRIPTION
Reproducer:
 - write a `.tf` file that includes a domain without metadata
 - `terraform apply`
 - update the `.tf` file to add metadata
 - subsequent calls `terraform apply` will not add the metadata

Symptoms:
```
silvio@lenovo:~/repos/sumaform$ terraform apply
[...]
module.package_mirror.libvirt_domain.domain: Modifying...
  metadata: "" => "package-mirror.vagrant.local"
module.package_mirror.libvirt_domain.domain: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate



silvio@lenovo:~/repos/sumaform$ terraform apply
[...]
module.package_mirror.libvirt_domain.domain: Modifying...
  metadata: "" => "package-mirror.vagrant.local"
module.package_mirror.libvirt_domain.domain: Modifications complete

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate
silvio@lenovo:~/repos/sumaform$
```

Problem is that a new machine will result in the following `virsh dumpxml`:

```xml
<name>package-mirror</name>
<uuid>e9a900c7-32e7-41fe-b508-d2310f810ce0</uuid>
<metadata>
  <terraform-libvirt:metadata xmlns:terraform-libvirt="http://github.com/dmacvicar/terraform-provider-libvirt/">
    <user_data xmlns="http://github.com/dmacvicar/terraform-provider-libvirt/"><![CDATA[package-mirror.vagrant.local]]></user_data>
  </terraform-libvirt:metadata>
</metadata>
```

Here there is a `<metadata>` tag nested into another `<metadata>` tag. The correct `virsh dumpxml`, which you obtain by destroying and re-creating the resource, would be:
```xml
<name>package-mirror</name>
<uuid>e9a900c7-32e7-41fe-b508-d2310f810ce0</uuid>
<metadata>
  <user_data xmlns="http://github.com/dmacvicar/terraform-provider-libvirt/" xmlns:terraform-libvirt="http://github.com/dmacvicar/terraform-provider-libvirt/"><![CDATA[package-mirror.vagrant.local]]></user_data>
</metadata>
```

This patch changes the way metadata is updated and avoids the double tag.