### PR TITLE
Fix simple networking

### DIFF
--- a/libvirt/network_interface_def.go
+++ b/libvirt/network_interface_def.go
@@ -19,11 +19,11 @@ type defNetworkInterface struct {
 		Address string `xml:"address,attr"`
 	} `xml:"mac"`
 	Source struct {
-		Network string `xml:"network,attr"`
-		Bridge  string `xml:"bridge,attr"`
-		Dev  string `xml:"dev,attr"`
-		Mode  string `xml:"mode,attr"`
-	       } `xml:"source"`
+		Network string `xml:"network,attr,omitempty"`
+		Bridge  string `xml:"bridge,attr,omitempty"`
+		Dev     string `xml:"dev,attr,omitempty"`
+		Mode    string `xml:"mode,attr"`
+	} `xml:"source"`
 	Model struct {
 		Type string `xml:"type,attr"`
 	} `xml:"model"`


### PR DESCRIPTION
Some of the new attributes have to be omitted when not being used,
otherwise the simple networking with the default libvirt network won't
work