### PR TITLE
Get address of lan interfaces

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -120,3 +120,7 @@ resource "libvirt_domain" "my-domain" {
   }
 }
 ```
+
+**Warning:** the [Qemu guest agent](http://wiki.libvirt.org/page/Qemu_guest_agent)
+must be installed and running inside of the domain in order to discover the IP
+addresses of all the network interfaces attached to a LAN.

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -27,6 +27,17 @@ type defDomain struct {
 			Type     string `xml:"type,attr"`
 			Autoport string `xml:"autoport,attr"`
 		} `xml:"graphics"`
+		// QEMU guest agent channel
+		QemuGAChannel struct {
+			Type   string `xml:"type,attr"`
+			Source struct {
+				Mode string `xml:"mode,attr"`
+			} `xml:"source"`
+			Target struct {
+				Type string `xml:"type,attr"`
+				Name string `xml:"name,attr"`
+			} `xml:"target"`
+		} `xml:"channel"`
 	} `xml:"devices"`
 }
 
@@ -76,6 +87,11 @@ func newDomainDef() defDomain {
 
 	domainDef.Devices.Spice.Type = "spice"
 	domainDef.Devices.Spice.Autoport = "yes"
+
+	domainDef.Devices.QemuGAChannel.Type = "unix"
+	domainDef.Devices.QemuGAChannel.Source.Mode = "bind"
+	domainDef.Devices.QemuGAChannel.Target.Type = "virtio"
+	domainDef.Devices.QemuGAChannel.Target.Name = "org.qemu.guest_agent.0"
 
 	return domainDef
 }

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -1,0 +1,90 @@
+package libvirt
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+
+	libvirt "github.com/dmacvicar/libvirt-go"
+)
+
+type QemuAgentInterfacesResponse struct {
+	Interfaces []QemuAgentInterface `json:"return"`
+}
+
+type QemuAgentInterface struct {
+	Name        string `json:"name"`
+	Hwaddr      string `json:"hardware-address"`
+	IpAddresses []struct {
+		Type    string `json:"ip-address-type"`
+		Address string `json:"ip-address"`
+		Prefix  uint   `json:"prefix"`
+	} `json:"ip-addresses"`
+}
+
+// Retrieve all the interfaces attached to a domain and their addresses. Only
+// the interfaces with at least an IP address are returned.
+// When wait4ipv4 is turned on the code will not report interfaces that don't
+// have a ipv4 address set. This is useful when a domain gets the ipv6 address
+// before the ipv4 one.
+func getDomainInterfacesViaQemuAgent(domain *libvirt.VirDomain, wait4ipv4 bool) []libvirt.VirDomainInterface {
+	log.Print("[DEBUG] get network interfaces using qemu agent")
+
+	var interfaces []libvirt.VirDomainInterface
+
+	result := domain.QemuAgentCommand(
+		"{\"execute\":\"guest-network-get-interfaces\"}",
+		libvirt.VIR_DOMAIN_QEMU_AGENT_COMMAND_DEFAULT,
+		0)
+
+	log.Printf("[DEBUG] qemu-agent response: %s", result)
+
+	response := QemuAgentInterfacesResponse{}
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		log.Printf("[DEBUG] Error converting Qemu agent response about domain interfaces: %s", err)
+		log.Printf("[DEBUG] Original message: %s", response)
+		log.Print("[DEBUG] Returning an empty list of interfaces")
+		return interfaces
+	}
+	log.Printf("[DEBUG] Parsed response %+v", response)
+
+	for _, iface := range response.Interfaces {
+		if iface.Name == "lo" {
+			// ignore loopback interface
+			continue
+		}
+
+		libVirtIface := libvirt.VirDomainInterface{}
+		libVirtIface.Name = iface.Name
+		libVirtIface.Hwaddr = iface.Hwaddr
+
+		ipv4Assigned := false
+		for _, addr := range iface.IpAddresses {
+			if addr.Address == "" {
+				// ignore interfaces without an address (eg. waiting for dhcp lease)
+				continue
+			}
+
+			libVirtAddr := libvirt.VirDomainIPAddress{}
+			libVirtAddr.Addr = addr.Address
+			libVirtAddr.Prefix = addr.Prefix
+			switch strings.ToLower(addr.Type) {
+			case "ipv4":
+				libVirtAddr.Type = libvirt.VIR_IP_ADDR_TYPE_IPV4
+				ipv4Assigned = true
+			case "ipv6":
+				libVirtAddr.Type = libvirt.VIR_IP_ADDR_TYPE_IPV6
+			default:
+				log.Printf("[ERROR] Cannot handle unknown address type %s", addr.Type)
+			}
+			libVirtIface.Addrs = append(libVirtIface.Addrs, libVirtAddr)
+		}
+		if len(libVirtIface.Addrs) > 0 && (ipv4Assigned || !wait4ipv4) {
+			interfaces = append(interfaces, libVirtIface)
+		}
+	}
+
+	log.Printf("[DEBUG] Interfaces obtained via qemu Agent: %+v", interfaces)
+
+	return interfaces
+}

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -65,9 +65,11 @@ func getDomainInterfacesViaQemuAgent(domain *libvirt.VirDomain, wait4ipv4 bool) 
 				continue
 			}
 
-			libVirtAddr := libvirt.VirDomainIPAddress{}
-			libVirtAddr.Addr = addr.Address
-			libVirtAddr.Prefix = addr.Prefix
+			libVirtAddr := libvirt.VirDomainIPAddress{
+				Addr:   addr.Address,
+				Prefix: addr.Prefix,
+			}
+
 			switch strings.ToLower(addr.Type) {
 			case "ipv4":
 				libVirtAddr.Type = libvirt.VIR_IP_ADDR_TYPE_IPV4

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -168,9 +168,10 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		netIface.Model.Type = "virtio"
 
 		// calculate the MAC address
-		macI, ok := d.GetOk(prefix + ".mac")
-		mac := strings.ToUpper(macI.(string))
-		if !ok {
+		var mac string
+		if macI, ok := d.GetOk(prefix + ".mac"); ok {
+			mac = strings.ToUpper(macI.(string))
+		} else {
 			var err error
 			mac, err = RandomMACAddress()
 			if err != nil {
@@ -324,8 +325,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	for i := 0; i < netIfacesCount; i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
 
-		macI := d.Get(prefix + ".mac")
-		mac := strings.ToUpper(macI.(string))
+		mac := strings.ToUpper(d.Get(prefix + ".mac").(string))
 
 		// if we were waiting for an IP address for this MAC, go ahead.
 		if pending, ok := partialNetIfaces[mac]; ok {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -238,8 +238,8 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 					// have a valid lease and then read the IP we have been assigned, so we can
 					// do the mapping
 					log.Printf("[DEBUG] Will wait for an IP for hostname '%s'...", hostname)
-					partialNetIfaces[mac] = pendingMapping{
-						mac:      mac,
+					partialNetIfaces[strings.ToUpper(mac)] = pendingMapping{
+						mac:      strings.ToUpper(mac),
 						hostname: hostname,
 						network:  &network,
 					}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -82,6 +82,8 @@ func resourceLibvirtDomain() *schema.Resource {
 }
 
 func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	log.Printf("[DEBUG] Check if resource libvirt_domain exists")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return false, fmt.Errorf("The libvirt connection was nil.")
@@ -92,6 +94,8 @@ func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool
 }
 
 func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Create resource libvirt_domain")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")
@@ -345,6 +349,8 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Update resource libvirt_domain")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")
@@ -443,6 +449,8 @@ func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Read resource libvirt_domain")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")
@@ -616,6 +624,8 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLibvirtDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Delete resource libvirt_domain")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")


### PR DESCRIPTION
When a network card is attached to a LAN the `domain.ListAllInterfaceAddresses` API cannot be used to get the IP address associated with the interfaces.

The only solution to this problem is to use the [Qemu guest agent](http://wiki.libvirt.org/page/Qemu_guest_agent) to fetch this information.

This PR will take advantage of the qemu guest ageint (when installed inside of the domain) to workaround the limitations of the `domain.ListAllInterfaceAddresses`.

In theory this PR could also allow to relax the required version of libvirt.

The PR includes already the fix shipped with https://github.com/dmacvicar/terraform-provider-libvirt/pull/48, I'll do a rebase once the code is merged into master.
