### PR TITLE
Start storage pool if volume was not found

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -349,6 +349,14 @@ func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
 			}
 			defer volPool.Free()
 
+			active, err := volPool.IsActive()
+			if err != nil {
+				return fmt.Errorf("Error retrieving status of pool %s for volume %s: %s", volPoolName, volId, err)
+			}
+			if active {
+				return fmt.Errorf("Can't retrieve volume %s", d.Id())
+			}
+
 			err = volPool.Create(0)
 			if err != nil {
 				return fmt.Errorf("Error starting pool %s: %s", volPoolName, err)


### PR DESCRIPTION
libvirt storage pools are not necessarily started by the time you call `terraform plan`.

In case they are not, you get this slightly misleading error:

```
Error refreshing state: 1 error(s) occurred:

* libvirt_volume.data_disk: Can't retrieve volume <STORAGE_PATH>/<VOLUME_NAME>
```

Fact that volume can't be retrieved is just because the pool has not been started yet.

Currently you would have to connect to the libvirt host via `virt-manager` or `virsh`, lookup the correct pool name and start it.

With this patch the provider will attempt to do that automatically, which improves UI/UX.