### PR TITLE
Better handling of errors while creating a domain

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -96,6 +96,13 @@ func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool
 func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create resource libvirt_domain")
 
+	// Ensure partial mode to save some relevant keys
+	d.Partial(true)
+
+	// the domain ID must always be saved, otherwise it won't be possible to cleanup a domain
+	// if something bad happens at provisioning time
+	d.SetPartial("id")
+
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf("The libvirt connection was nil.")


### PR DESCRIPTION
Sometimes if an error occurs at domain creation time, the resulting domain is **unknown** to terraform. That makes impossible to remove it, causing later runs of `terraform apply` to fail.

This commit marks the domain ID as a partial attribute that has to be saved to the `.tfstate` as soon as it's created.

That should fix issues like #67