### PR TITLE
Documentation: fix example qemu URI

### DIFF
--- a/docs/providers/libvirt/index.html.markdown
+++ b/docs/providers/libvirt/index.html.markdown
@@ -19,7 +19,7 @@ While libvirt can be used with several types of hypervisors, this provider focus
 ```
 # Configure the Libvirt provider
 provider "libvirt" {
-  uri = "qemu://system"
+  uri = "qemu:///system"
 }
 
 # Create a new domain


### PR DESCRIPTION
Two slashes instead of three lead to an obscure CA related error message:

http://wiki.libvirt.org/page/Failed_to_connect_to_the_hypervisor#Cannot_read_CA_certificate