### PR TITLE
Simplify volume attachment

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
    be used.
 * `vcpu` - (Optional) The amount of virtual CPUs. If not specified, a single CPU will be created.
 * `running` - (Optional) Use `false` to turn off the instance. If not specified, true is assumed and the instance, if stopped, will be started at next apply.
-* `disk` - (Optional) An array of one or more disks to attach to the domain. The `disk` object structure is documented below.
+* `volume_ids` - (Optional) An array of one or more volume IDs to attach to the domain
 * `network_interface` - (Optional) An array of one or more network interfaces to attach to the domain. The `network_interface` object structure is documented below.
 * `metadata` - (Optional) A string containing arbitrary data. This is going to be
   added to the final domain inside of the [metadata tag](https://libvirt.org/formatdomain.html#elementsMetadata).
@@ -62,9 +62,7 @@ resource "libvirt_domain" "my_machine" {
   firmware = "/usr/share/qemu/ovmf-x86_64-code.bin"
   memory = "2048"
 
-  disk {
-    volume_id = "${libvirt_volume.volume.id}"
-  }
+  volume_ids = ["${libvirt_volume.volume.id}"]
   ...
 }
 ```
@@ -76,10 +74,6 @@ nvram = [
    "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"
 ]
 ```
-
-The `disk` block supports:
-
-* `volume_id` - (Required) The volume id to use for this disk.
 
 If you have a volume with a template image, create a second volume using the image as the backing volume, and then use the new volume as the volume for the disk. This way the image will not be modified.
 
@@ -96,9 +90,7 @@ resource "libvirt_volume" "mydisk" {
 
 resource "libvirt_domain" "domain1" {
   name = "domain1"
-  disk {
-    volume_id = "${libvirt_volume.mydisk.id}"
-  }
+  volume_ids = ["${libvirt_volume.mydisk.id}"]
 
   network_interface {
     network_id = "${libvirt_network.net1.id}"

--- a/examples/count/libvirt.tf
+++ b/examples/count/libvirt.tf
@@ -15,9 +15,6 @@ resource "libvirt_volume" "volume" {
 
 resource "libvirt_domain" "domain" {
   name = "domain-${count.index}"
-  disk {
-       volume_id = "${element(libvirt_volume.volume.*.id, count.index)}"
-  }
+  volume_ids = ["${element(libvirt_volume.volume.*.id, count.index)}"]
   count = 4
 }
-

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -178,7 +178,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
             resource "libvirt_domain" "acceptance-test-domain" {
                     name = "terraform-test"
                     network_interface = {
-                            network = "default"
+                            network_name = "default"
                     }
                     network_interface = {
                             mac = "52:54:00:a9:f5:17"
@@ -198,7 +198,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain", &domain),
 					resource.TestCheckResourceAttr(
-						"libvirt_domain.acceptance-test-domain", "network_interface.0.network", "default"),
+						"libvirt_domain.acceptance-test-domain", "network_interface.0.network_name", "default"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain.acceptance-test-domain", "network_interface.1.mac", "52:54:00:a9:f5:17"),
 				),

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -181,6 +181,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
                             network_name = "default"
                     }
                     network_interface = {
+                            bridge = "br0"
                             mac = "52:54:00:a9:f5:17"
                     }
                     disk {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -80,9 +80,7 @@ func TestAccLibvirtDomain_Volume(t *testing.T) {
 
             resource "libvirt_domain" "acceptance-test-domain" {
                     name = "terraform-test"
-                    disk {
-                            volume_id = "${libvirt_volume.acceptance-test-volume.id}"
-                    }
+                    volume_ids = ["${libvirt_volume.acceptance-test-volume.id}"]
             }`)
 
 	var configVolDettached = fmt.Sprintf(`
@@ -128,13 +126,10 @@ func TestAccLibvirtDomain_VolumeTwoDisks(t *testing.T) {
 
             resource "libvirt_domain" "acceptance-test-domain" {
                     name = "terraform-test-domain"
-                    disk {
-                            volume_id = "${libvirt_volume.acceptance-test-volume1.id}"
-                    }
-
-                    disk {
-                            volume_id = "${libvirt_volume.acceptance-test-volume2.id}"
-                    }
+                    volume_ids = [
+                      "${libvirt_volume.acceptance-test-volume1.id}",
+                      "${libvirt_volume.acceptance-test-volume2.id}"
+                    ]
             }`)
 
 	var configVolDettached = fmt.Sprintf(`
@@ -184,9 +179,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
                             bridge = "br0"
                             mac = "52:54:00:A9:F5:17"
                     }
-                    disk {
-                            volume_id = "${libvirt_volume.acceptance-test-volume.id}"
-                    }
+                    volume_ids = ["${libvirt_volume.acceptance-test-volume.id}"]
             }`)
 
 	resource.Test(t, resource.TestCase{

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -182,7 +182,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
                     }
                     network_interface = {
                             bridge = "br0"
-                            mac = "52:54:00:a9:f5:17"
+                            mac = "52:54:00:A9:F5:17"
                     }
                     disk {
                             volume_id = "${libvirt_volume.acceptance-test-volume.id}"
@@ -201,7 +201,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_domain.acceptance-test-domain", "network_interface.0.network_name", "default"),
 					resource.TestCheckResourceAttr(
-						"libvirt_domain.acceptance-test-domain", "network_interface.1.mac", "52:54:00:a9:f5:17"),
+						"libvirt_domain.acceptance-test-domain", "network_interface.1.mac", "52:54:00:A9:F5:17"),
 				),
 			},
 		},


### PR DESCRIPTION
This changes the syntax to attach a volume to a domain from:

``` hcl
resource "libvirt_domain" "domain" {
  ...
  disk = {
    volume_id = "${libvirt_volume.volume1.id}"
  }
  disk = {
    volume_id = "${libvirt_volume.volume2.id}"
  }
}
```

to:

``` hcl
resource "libvirt_domain" "domain" {
  ...
  volume_ids = ["${libvirt_volume.volume1.id}, ${libvirt_volume.volume2.id}"]
}
```

Besides simplification, this has the advantage of allowing to use interpolation to create variable-volume resources. Example:

``` hcl

resource "libvirt_volume" "base_volume" {
  name = "base"
  base_volume_id = "${libvirt_volume.opensuse_leap.id}"
}

variable "data_volume_ids" {
  description = "array of ids of volumes additional to the base one"
  default = []
}

resource "libvirt_domain" "domain" {
  ...
  volume_ids = ["${concat(list(libvirt_volume.base_volume.id), var.data_volume_ids)}"]
}
```

Original motivation for this was to DRY-up the package-mirror and minion-swarm modules in [sumaform](https://github.com/moio/sumaform).

Please see the discussion in issue #79, I needed to get this fixed so after some days I attempted myself. I am a total newbie in Go and in this project so please bear with me :wink:!

Also note this is on top of PR #80.
