### PR TITLE
Allow to use maps for disk definitions

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -110,6 +110,41 @@ resource "libvirt_domain" "domain1" {
 }
 ```
 
+Also note that the `disk` block is actually a list of maps, so it is possible to declare several, use the literal list and map syntax or variables and interpolations, as in the following examples.
+
+```
+resource "libvirt_domain" "my_machine" {
+  ...
+  disk {
+    volume_id = "${libvirt_volume.volume1.id}"
+  }
+  disk {
+    volume_id = "${libvirt_volume.volume2.id}"
+  }
+}
+```
+
+```
+resource "libvirt_domain" "my_machine" {
+  ...
+  disk = [
+    {
+      volume_id = "${libvirt_volume.volume1.id}"
+    },
+    {
+      volume_id = "${libvirt_volume.volume2.id}"
+    }
+  ]
+}
+```
+
+```
+resource "libvirt_domain" "my_machine" {
+  ...
+  disk = ["${var.disk_map_list}"]
+}
+```
+
 The `network_interface` specifies a network interface that can be connected either to
 a virtual network (the preferred method on hosts with dynamic / wireless networking
 configs) or directly to a LAN.

--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -2,7 +2,6 @@ package libvirt
 
 import (
 	"encoding/xml"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 type defDisk struct {
@@ -24,16 +23,6 @@ type defDisk struct {
 		Name string `xml:"name,attr"`
 		Type string `xml:"type,attr"`
 	} `xml:"driver"`
-}
-
-func diskCommonSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"volume_id": &schema.Schema{
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-		},
-	}
 }
 
 func newDefDisk() defDisk {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -78,8 +78,8 @@ func resourceLibvirtDomain() *schema.Resource {
 				Optional: true,
 				Required: false,
 				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: diskCommonSchema(),
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
 				},
 			},
 			"network_interface": &schema.Schema{
@@ -151,11 +151,12 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	disksCount := d.Get("disk.#").(int)
 	var disks []defDisk
 	for i := 0; i < disksCount; i++ {
-		prefix := fmt.Sprintf("disk.%d", i)
 		disk := newDefDisk()
 		disk.Target.Dev = fmt.Sprintf("vd%s", DiskLetterForIndex(i))
 
-		volumeKey := d.Get(prefix + ".volume_id").(string)
+		diskKey := fmt.Sprintf("disk.%d", i)
+		diskMap := d.Get(diskKey).(map[string]interface{})
+		volumeKey := diskMap["volume_id"].(string)
 		diskVolume, err := virConn.LookupStorageVolByKey(volumeKey)
 		if err != nil {
 			return fmt.Errorf("Can't retrieve volume %s", volumeKey)


### PR DESCRIPTION
This changes the disk block in the domain resource to be defined as a map, instead of an object. There is no difference in the standard use case, but it allows to generate disk maps via interpolations and variables
which is useful in modules.

Example:
```hcl
resource "libvirt_domain" "my_machine" {
  ...
  disk = ["${var.disk_map_list}"]
}
```