### PR TITLE
Documentation: add output attributes for domain and volume

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -196,3 +196,8 @@ resource "libvirt_domain" "my-domain" {
 **Warning:** the [Qemu guest agent](http://wiki.libvirt.org/page/Qemu_guest_agent)
 must be installed and running inside of the domain in order to discover the IP
 addresses of all the network interfaces attached to a LAN.
+
+## Attributes Reference
+
+* `id` - a unique identifier for the resource
+* `network_interface.<N>.addresses.<M>` - M-th IP address assigned to the N-th network interface

--- a/docs/providers/libvirt/r/volume.html.markdown
+++ b/docs/providers/libvirt/r/volume.html.markdown
@@ -36,3 +36,7 @@ The following arguments are supported:
 * `base_volume_id` - (Optional) The backing volume (CoW) to use for this volume.
 * `base_volume_name` - (Optional) The name of the backing volume (CoW) to use for this volume. Note well: when `base_volume_pool` is not specified the volume is going to be searched inside of `pool`.
 * `base_volume_pool` - (Optional) The name of the pool containing the volume defined by `base_volume_name`.
+
+## Attributes Reference
+
+* `id` - a unique identifier for the resource


### PR DESCRIPTION
Those attributes can be consumed in modules via output variables, eg.

```hcl
output "ip_salt" {
  value = "${libvirt_domain.salt.network_interface.0.addresses.0}"
}
```