### PR TITLE
travis: fix build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: go
 
 go:
-  - 1.6
+  - 1.7
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
When building with Go 1.6, the build fails due to the missing "context"
package. Using Go 1.7 solves this issue.

Beside that, Terraform requires Go 1.7.

Signed-off-by: Thomas Hipp <thipp@suse.de>