### PR TITLE
Add DNS forwarder blocks to network resource definition

### DIFF
--- a/docs/providers/libvirt/r/network.markdown
+++ b/docs/providers/libvirt/r/network.markdown
@@ -31,6 +31,13 @@ resource "libvirt_network" "network1" {
   # which will be used to construct the virtual network.
   # (only necessary in "bridge" mode)
   # bridge = "br7"
+
+  # (Optional) one or more DNS forwarder entries.  One or both of
+  # "address" and "domain" must be specified.  The format is:
+  # dns_forwarder {
+  #   address = "my address"
+  #   domain = "my domain"
+  # }
 }
 ```
 
@@ -63,5 +70,36 @@ The following arguments are supported:
 * `bridge` - (Optional) The bridge device defines the name of a bridge
    device which will be used to construct the virtual network (when not provided,
    it will be automatically obtained by libvirt in `none`, `nat` and `route` modes).
+*  `dns_forwarder` - (Optional) a DNS forwarder entry block.  You can have
+   one or mode of these blocks in your network definition.  You must specify one or
+   both of `address` and `domain`.  You can use either of the forms below to
+   specify dns_forwarders:
 
+```
+resource "libvirt_network" "my_network" {
+  ...
+  dns_forwarder {
+    address = "my address"
+  }
+  dns_forwarder {
+    address = "my address 1"
+    domain = "my domain"
+  }
+}
+```
+
+```
+resource "libvirt_network" "my_network" {
+  ...
+  dns_forwarder = [
+    {
+      address = "my address"
+    },
+    {
+      address = "my address 1"
+      domain = "my domain
+    }
+  ]
+}
+```
 

--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -69,13 +69,18 @@ type defNetworkForward struct {
 }
 
 type defNetworkDns struct {
-	Host []*struct {
-		Ip       string   `xml:"ip,attr"`
-		HostName []string `xml:"hostname"`
-	} `xml:"host,omitempty"`
-	Forwarder []*struct {
-		Address string `xml:"addr,attr"`
-	} `xml:"forwarder,omitempty"`
+	Host      []*defDnsHost      `xml:"host,omitempty"`
+	Forwarder []*defDnsForwarder `xml:"forwarder,omitempty"`
+}
+
+type defDnsHost struct {
+	Ip       string   `xml:"ip,attr"`
+	HostName []string `xml:"hostname"`
+}
+
+type defDnsForwarder struct {
+	Domain  string `xml:"domain,attr,omitempty"`
+	Address string `xml:"addr,attr,omitempty"`
 }
 
 // network definition in XML, compatible with what libvirt expects


### PR DESCRIPTION
There can be one or more of these optional blocks.  Each block
looks as follows:

   dns_forwarder {
      address = "my address"
      domain = "my domain"
   }

One or both of "address" and "domain" can be specified in each block.