### PR TITLE
Add support for CoreOS ignition and console blocks

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -41,6 +41,13 @@ The following arguments are supported:
   cloud-init won't cause the domain to be recreated, however the change will
   have effect on the next reboot.
 
+The following extra argument is provided for CoreOS images:
+
+* `coreos_ignition` - (Optional) The name of a CoreOS Ignition file.
+
+Note that to make use of Ignition files with CoreOS the host must be running
+QEMU v2.6 or greater.
+
 Some extra arguments are also provided for using UEFI images:
 
 * `firmware` - (Optional) The UEFI rom images for exercising UEFI secure boot in a qemu
@@ -145,6 +152,7 @@ resource "libvirt_domain" "my_machine" {
 }
 ```
 
+
 The `network_interface` specifies a network interface that can be connected either to
 a virtual network (the preferred method on hosts with dynamic / wireless networking
 configs) or directly to a LAN.
@@ -196,6 +204,51 @@ resource "libvirt_domain" "my-domain" {
 **Warning:** the [Qemu guest agent](http://wiki.libvirt.org/page/Qemu_guest_agent)
 must be installed and running inside of the domain in order to discover the IP
 addresses of all the network interfaces attached to a LAN.
+
+The optional `graphics` block allows you to override the default graphics settings.  The
+block supports:
+
+* `type` - the type of graphics emulation (default is "spice")
+* `autoport` - defaults to "yes"
+* `listen_type` - "listen type", defaults to "none"
+
+On occasion we have found it necessary to set a `type` of "vnc" and a `listen_type` of "address"
+with certain builds of QEMU.
+
+The `graphics` block will look as follows:
+```
+resource "libvirt_domain" "my_machine" {
+  ...
+  graphics {
+    type = "vnc"
+    listen_type = "address"
+  }
+}
+```
+
+The optional `console` block allows you to define a console for the domain.  The block
+looks as follows:
+```
+resource "libvirt_domain" "my_machine" {
+  ...
+  console {
+    type = "pty"
+    target_port = "0"
+    target_type = <"serial" or "virtio">
+    source_path = "/dev/pts/4"
+  }
+}
+```
+
+Note the following:
+* You can repeat the `console` block to create more than one console, in the same way
+that you can repeat `disk` blocks (see above)
+* The `target_type` is optional for the first console
+* All subsequent `console` blocks must specify a `target_type` of `virtio`
+* The `source_path` is optional for all consoles
+
+See [libvirt Domain XML Console element](https://libvirt.org/formatdomain.html#elementsConsole)
+for more information.
 
 ## Attributes Reference
 

--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -43,7 +43,29 @@ The following arguments are supported:
 
 The following extra argument is provided for CoreOS images:
 
-* `coreos_ignition` - (Optional) The name of a CoreOS Ignition file.
+* `coreos_ignition` - (Optional) This can be set to the name of an existing ignition
+file or alternatively can be set to the rendered value of a Terraform ignition provider object.
+
+An example where a Terraform ignition provider object is used:
+```
+# Systemd unit resource containing the unit definition
+resource "ignition_systemd_unit" "example" {
+  name = "example.service"
+  content = "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
+}
+
+# Ignition config include the previous defined systemd unit resource
+resource "ignition_config" "example" {
+  systemd = [
+      "${ignition_systemd_unit.example.id}",
+  ]
+}
+
+resource "libvirt_domain" "my_machine" {
+  coreos_ignition = "${ignition_config.example.rendered}"
+  ...
+}
+```
 
 Note that to make use of Ignition files with CoreOS the host must be running
 QEMU v2.6 or greater.

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -57,8 +57,9 @@ type defDomain struct {
 }
 
 type defMetadata struct {
-	XMLName xml.Name `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
-	Xml     string   `xml:",cdata"`
+	XMLName      xml.Name `xml:"http://github.com/dmacvicar/terraform-provider-libvirt/ user_data"`
+	Xml          string   `xml:",cdata"`
+	IgnitionFile string   `xml:",ignition_file,omitempty"`
 }
 
 type defOs struct {
@@ -143,3 +144,4 @@ func newDomainDef() defDomain {
 
 	return domainDef
 }
+

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -8,6 +8,7 @@ type defDomain struct {
 	XMLName  xml.Name  `xml:"domain"`
 	Name     string    `xml:"name"`
 	Type     string    `xml:"type,attr"`
+	Xmlns    string    `xml:"xmlns:qemu,attr"`
 	Os       defOs     `xml:"os"`
 	Memory   defMemory `xml:"memory"`
 	VCpu     defVCpu   `xml:"vcpu"`
@@ -23,7 +24,8 @@ type defDomain struct {
 	Devices struct {
 		Disks             []defDisk             `xml:"disk"`
 		NetworkInterfaces []defNetworkInterface `xml:"interface"`
-		Graphics struct {
+		Console           []defConsole          `xml:"console"`
+		Graphics          struct {
 			Type     string `xml:"type,attr"`
 			Autoport string `xml:"autoport,attr"`
 			Listen   struct {
@@ -48,6 +50,10 @@ type defDomain struct {
 			} `xml:"backend"`
 		} `xml:"rng"`
 	} `xml:"devices"`
+	CmdLine struct {
+		XMLName xml.Name `xml:"qemu:commandline"`
+		Cmd     []defCmd `xml:"qemu:arg"`
+	}
 }
 
 type defMetadata struct {
@@ -77,6 +83,10 @@ type defVCpu struct {
 	Amount    int    `xml:",chardata"`
 }
 
+type defCmd struct {
+	Value string `xml:"value,attr"`
+}
+
 type defLoader struct {
 	ReadOnly string `xml:"readonly,attr,omitempty"`
 	Type     string `xml:"type,attr,omitempty"`
@@ -88,12 +98,24 @@ type defNvRam struct {
 	File string `xml:",chardata"`
 }
 
+type defConsole struct {
+	Type   string `xml:"type,attr"`
+	Source struct {
+		Path string `xml:"path,attr,omitempty"`
+	} `xml:"source"`
+	Target struct {
+		Type string `xml:"type,attr,omitempty"`
+		Port string `xml:"port,attr"`
+	} `xml:"target"`
+}
+
 // Creates a domain definition with the defaults
 // the provider uses
 func newDomainDef() defDomain {
 	// libvirt domain definition
 	domainDef := defDomain{}
 	domainDef.Type = "kvm"
+	domainDef.Xmlns = ""
 
 	domainDef.Os = defOs{}
 	domainDef.Os.Type = defOsType{}

--- a/libvirt/provider_test.go
+++ b/libvirt/provider_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	ignition "github.com/hashicorp/terraform/builtin/providers/ignition"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -15,6 +16,7 @@ func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"libvirt": testAccProvider,
+		"ignition": ignition.Provider(),
 	}
 }
 

--- a/libvirt/resource_libvirt_domain_console.go
+++ b/libvirt/resource_libvirt_domain_console.go
@@ -1,0 +1,34 @@
+package libvirt
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func consoleSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"type": &schema.Schema{
+			Type: schema.TypeString,
+			Optional: false,
+			Required: true,
+			ForceNew: true,
+		},
+		"source_path": &schema.Schema{
+			Type: schema.TypeString,
+			Optional: true,
+			Required: false,
+			ForceNew: true,
+		},
+		"target_port": &schema.Schema{
+			Type: schema.TypeString,
+			Optional: false,
+			Required: true,
+			ForceNew: true,
+		},
+		"target_type": &schema.Schema{
+			Type: schema.TypeString,
+			Optional: true,
+			Required: false,
+			ForceNew: true,
+		},
+	}
+}

--- a/vendor.yml
+++ b/vendor.yml
@@ -23,7 +23,7 @@ vendors:
 - path: github.com/hashicorp/logutils
   rev: 0dc08b1671f34c4250ce212759ebd880f743d883
 - path: github.com/hashicorp/terraform
-  rev: v0.8.0
+  rev: v0.8.5
 - path: github.com/hooklift/assert
   rev: c7786599453421cddf9aa8a3a7b537f567d1ac1b
 - path: github.com/hooklift/iso9660


### PR DESCRIPTION
A few changes here:

1.  CoreOS Ignition support:  A CoreOS Ignition file can be
    specified for a domain using the "coreos_ignition"
    parameter.  This requires the emission of additional
    XML and also the setting of the XML name-space to
    "http://libvirt.org/schemas/domain/qemu/1.0"
2.  "graphics" block:  A "graphics" block can be specified
    in a domain definition.  We've added this because we've
    found that for some builds of qemu the default "spice"
    emulator doesn't work and results in failure to boot the
    VMs.
3.  "console" block: One or more "console" blocks can be
    specified in a domain definition.  Note the description
    in domain.html.markdown, and the description in
    https://libvirt.org/formatdomain.html#elementsConsole