### PR TITLE
CoreOS Ignition support updates

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -41,10 +41,15 @@ The following arguments are supported:
   cloud-init won't cause the domain to be recreated, however the change will
   have effect on the next reboot.
 
-The following extra argument is provided for CoreOS images:
+The optional `coreos_ignition` block is provided for CoreOS images.  This block contains
+the following parameters:
 
-* `coreos_ignition` - (Optional) This can be set to the name of an existing ignition
+* `content` - (Required) This can be set to the name of an existing ignition
 file or alternatively can be set to the rendered value of a Terraform ignition provider object.
+* `generated_ignition_file_dir` - (Optional) If `content` is set to the rendered value
+of a Terraform ignition provider object you can specify where to locate the resulting
+ignition file that will be loaded into the CoreOS vm.  If not set, "/tmp" is used.  These
+generated ignition files will be removed when the domain is destroyed.
 
 An example where a Terraform ignition provider object is used:
 ```
@@ -62,7 +67,10 @@ resource "ignition_config" "example" {
 }
 
 resource "libvirt_domain" "my_machine" {
-  coreos_ignition = "${ignition_config.example.rendered}"
+  coreos_ignition {
+      content = "${ignition_config.example.rendered}"
+      generated_ignition_file_dir = "/my/ignition/file/directory" (Optional)
+  }
   ...
 }
 ```

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -226,7 +226,9 @@ func TestAccLibvirtDomain_IgnitionObject(t *testing.T) {
 
 	    resource "libvirt_domain" "acceptance-test-domain" {
 		name = "terraform-test-domain"
-		coreos_ignition = "${ignition_config.acceptance-test-config.rendered}"
+		coreos_ignition {
+		        content = "${ignition_config.acceptance-test-config.rendered}"
+		}
 	    }
 	`)
 
@@ -310,7 +312,7 @@ func testAccCheckIgnitionFileNameExists(domain *libvirt.VirDomain) resource.Test
 			if rs.Type != "libvirt_domain" {
 				continue
 			}
-			ignStr = rs.Primary.Attributes["coreos_ignition"]
+			ignStr = rs.Primary.Attributes["coreos_ignition.content"]
 		}
 
 		xmlDesc, err := domain.GetXMLDesc(0)


### PR DESCRIPTION
Hopefully this patch is acceptable.  It changes the "coreos_ignition"
parameter introduced by a previous patch to a block.  I can redo the
patch if this change is deemed unacceptable.

This patch updates the CoreOS ignition support. "coreos_ignition"
is now a block, that looks as follows:

   coreos_ignition {
     content = <string> *Required*
     generated_ignition_file_dir = <string> *Optional*
   }

If the "coreos_ignition" block is present, then content must be
defined and can point to either the location of an existing
ignition file or the contents of a Terraform Ignition provider
object.  If the latter, you can also opitionally specify the
directory in which the ignition file will be written using
"generated_ignition_file_dir".  If this directory isn't specified,
"/tmp" will be used.