### PR TITLE
create domain without graphics device

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -248,6 +248,10 @@ resource "libvirt_domain" "my_machine" {
 }
 ```
 
+Note the following:
+* The `graphics` block is ignored for the architectures `s390x` and `ppc64`.
+
+
 The optional `console` block allows you to define a console for the domain.  The block
 looks as follows:
 ```

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -25,13 +25,7 @@ type defDomain struct {
 		Disks             []defDisk             `xml:"disk"`
 		NetworkInterfaces []defNetworkInterface `xml:"interface"`
 		Console           []defConsole          `xml:"console"`
-		Graphics          struct {
-			Type     string `xml:"type,attr"`
-			Autoport string `xml:"autoport,attr"`
-			Listen   struct {
-				Type string `xml:"type,attr"`
-			} `xml:"listen"`
-		} `xml:"graphics"`
+		Graphics          *defGraphics          `xml:"graphics,omitempty"`
 		// QEMU guest agent channel
 		QemuGAChannel struct {
 			Type   string `xml:"type,attr"`
@@ -54,6 +48,14 @@ type defDomain struct {
 		XMLName xml.Name `xml:"qemu:commandline"`
 		Cmd     []defCmd `xml:"qemu:arg"`
 	}
+}
+
+type defGraphics struct {
+	Type     string `xml:"type,attr"`
+	Autoport string `xml:"autoport,attr"`
+	Listen   struct {
+		Type string `xml:"type,attr"`
+	} `xml:"listen"`
 }
 
 type defMetadata struct {
@@ -130,6 +132,7 @@ func newDomainDef() defDomain {
 	domainDef.VCpu.Placement = "static"
 	domainDef.VCpu.Amount = 1
 
+	domainDef.Devices.Graphics = &defGraphics{}
 	domainDef.Devices.Graphics.Type = "spice"
 	domainDef.Devices.Graphics.Autoport = "yes"
 	domainDef.Devices.Graphics.Listen.Type = "none"

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -191,16 +191,25 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		domainDef.Xmlns = "http://libvirt.org/schemas/domain/qemu/1.0"
 	}
 
-	if graphics, ok := d.GetOk("graphics"); ok {
-		graphics_map := graphics.(map[string]interface{})
-		if graphics_type, ok := graphics_map["type"]; ok {
-			domainDef.Devices.Graphics.Type = graphics_type.(string)
-		}
-		if autoport, ok := graphics_map["autoport"]; ok {
-			domainDef.Devices.Graphics.Type = autoport.(string)
-		}
-		if listen_type, ok := graphics_map["listen_type"]; ok {
-			domainDef.Devices.Graphics.Listen.Type = listen_type.(string)
+	arch, err := getHostArchitecture(virConn)
+	if err != nil {
+		return fmt.Errorf("Error retrieving host architecture: %s", err)
+	}
+
+	if arch == "s390x" || arch == "ppc64" {
+		domainDef.Devices.Graphics = nil
+	} else {
+		if graphics, ok := d.GetOk("graphics"); ok {
+			graphics_map := graphics.(map[string]interface{})
+			if graphics_type, ok := graphics_map["type"]; ok {
+				domainDef.Devices.Graphics.Type = graphics_type.(string)
+			}
+			if autoport, ok := graphics_map["autoport"]; ok {
+				domainDef.Devices.Graphics.Autoport = autoport.(string)
+			}
+			if listen_type, ok := graphics_map["listen_type"]; ok {
+				domainDef.Devices.Graphics.Listen.Type = listen_type.(string)
+			}
 		}
 	}
 

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -208,6 +208,44 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtDomain_Graphics(t *testing.T) {
+	var domain libvirt.VirDomain
+
+	var config = fmt.Sprintf(`
+            resource "libvirt_volume" "acceptance-test-graphics" {
+                    name = "terraform-test"
+            }
+
+            resource "libvirt_domain" "acceptance-test-domain" {
+                    name = "terraform-test"
+                    graphics {
+                            type = "spice"
+                            autoport = "yes"
+                            listen_type = "none"
+                    }
+            }`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain", &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain", "graphics.type", "spice"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain", "graphics.autoport", "yes"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain", "graphics.listen_type", "none"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtDomain_IgnitionObject(t *testing.T) {
 	var domain libvirt.VirDomain
 


### PR DESCRIPTION
When a graphics device is specified, a video device is automatically
added as well. This can cause problems on some exotic machines.

In order to prevent the issues, it should be possible to specify domains
without these devices.

**Note:** there will be no graphics per default, instead this setting has to be specified explicitly if one wants graphics support.

Signed-off-by: Thomas Hipp <thipp@suse.de>