### PR TITLE
cloud-init user_data

### DIFF
--- a/docs/providers/libvirt/r/cloudinit.html.markdown
+++ b/docs/providers/libvirt/r/cloudinit.html.markdown
@@ -32,5 +32,9 @@ The following arguments are supported:
   the domain.
 * `ssh_authorized_key` - (Optional) A public ssh key that will be accepted by
   the `root` user.
+* `user_data` - (Optional) Raw cloud-init user data. This content will
+be merged automatically with the values specified in other arguments
+(like `local_hostname`, `ssh_authorized_key`, etc), but they cannot be
+specified in both places at the same time.
 
 Any change of the above fields will cause a new resource to be created.

--- a/docs/providers/libvirt/r/cloudinit.html.markdown
+++ b/docs/providers/libvirt/r/cloudinit.html.markdown
@@ -33,8 +33,8 @@ The following arguments are supported:
 * `ssh_authorized_key` - (Optional) A public ssh key that will be accepted by
   the `root` user.
 * `user_data` - (Optional) Raw cloud-init user data. This content will
-be merged automatically with the values specified in other arguments
-(like `local_hostname`, `ssh_authorized_key`, etc), but they cannot be
-specified in both places at the same time.
+  be merged automatically with the values specified in other arguments
+  (like `local_hostname`, `ssh_authorized_key`, etc). The contents of
+  `user_data` will take precedence over the ones defined by the other keys.
 
 Any change of the above fields will cause a new resource to be created.

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -23,7 +23,7 @@ import (
 const USERDATA string = "user-data"
 const METADATA string = "meta-data"
 
-type UserDataStruct struct {
+type CloudInitUserData struct {
 	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys"`
 }
 
@@ -35,7 +35,7 @@ type defCloudInit struct {
 		InstanceID    string `yaml:"instance-id"`
 	}
 	UserDataRaw string `yaml:"user_data"`
-	UserData    UserDataStruct
+	UserData    CloudInitUserData
 }
 
 // Creates a new cloudinit with the defaults
@@ -335,7 +335,7 @@ func downloadISO(virConn *libvirt.VirConnection, volume libvirt.VirStorageVol) (
 }
 
 // Convert a UserData instance to a map with string as key and interface as value
-func convertUserDataToMap(data UserDataStruct) (map[string]interface{}, error) {
+func convertUserDataToMap(data CloudInitUserData) (map[string]interface{}, error) {
 	userDataMap := make(map[string]interface{})
 
 	// This is required to get the right names expected by cloud-init
@@ -349,7 +349,7 @@ func convertUserDataToMap(data UserDataStruct) (map[string]interface{}, error) {
 	return userDataMap, err
 }
 
-func mergeUserDataIntoUserDataRaw(userData UserDataStruct, userDataRaw string) (string, error) {
+func mergeUserDataIntoUserDataRaw(userData CloudInitUserData, userDataRaw string) (string, error) {
 	userDataMap, err := convertUserDataToMap(userData)
 	if err != nil {
 		return "", err

--- a/libvirt/cloudinit_def_test.go
+++ b/libvirt/cloudinit_def_test.go
@@ -1,0 +1,173 @@
+package libvirt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestNewCloudInitDef(t *testing.T) {
+	ci := newCloudInitDef()
+
+	if ci.Metadata.InstanceID == "" {
+		t.Error("Expected metadata InstanceID not to be empty")
+	}
+}
+
+func TestTerraformKeyOps(t *testing.T) {
+	ci := newCloudInitDef()
+
+	volKey := "volume-key"
+
+	terraformId := ci.buildTerraformKey(volKey)
+	if terraformId == "" {
+		t.Error("key should not be empty")
+	}
+
+	actualKey, _ := getCloudInitVolumeKeyFromTerraformID(terraformId)
+	if actualKey != volKey {
+		t.Error("wrong key returned")
+	}
+}
+
+func TestCreateFiles(t *testing.T) {
+	ci := newCloudInitDef()
+
+	dir, err := ci.createFiles()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, file := range []string{USERDATA, METADATA} {
+		check, err := exists(filepath.Join(dir, file))
+		if !check {
+			t.Errorf("%s not found: %v", file, err)
+		}
+	}
+}
+
+func TestCreateISONoExteralTool(t *testing.T) {
+	path := os.Getenv("PATH")
+	defer os.Setenv("PATH", path)
+
+	os.Setenv("PATH", "/")
+
+	ci := newCloudInitDef()
+
+	iso, err := ci.createISO()
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	if iso != "" {
+		t.Errorf("Expected iso to be empty")
+	}
+}
+
+func TestConvertUserDataToMapPreservesCloudInitNames(t *testing.T) {
+	ud := UserDataStruct{
+		SSHAuthorizedKeys: []string{"key1"},
+	}
+
+	actual, err := convertUserDataToMap(ud)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	_, ok := actual["ssh_authorized_keys"]
+	if !ok {
+		t.Error("Could not found ssh_authorized_keys key")
+	}
+}
+
+func TestMergeEmptyUserDataIntoUserDataRaw(t *testing.T) {
+	ud := UserDataStruct{}
+
+	var userDataRaw = `
+new-key: new-value-set-by-extra
+ssh_authorized_keys:
+  - key2-from-extra-data
+`
+
+	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	actual := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(res), &actual)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	if _, ok := actual["ssh_authorized_keys"]; !ok {
+		t.Error("ssh_authorized_keys missing")
+	}
+
+	if _, ok := actual["new-key"]; !ok {
+		t.Error("new-key missing")
+	}
+}
+
+func TestMergeUserDataIntoEmptyUserDataRaw(t *testing.T) {
+	ud := UserDataStruct{
+		SSHAuthorizedKeys: []string{"key1"},
+	}
+	var userDataRaw string
+
+	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	actual := make(map[string]interface{})
+	err = yaml.Unmarshal([]byte(res), &actual)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	if _, ok := actual["ssh_authorized_keys"]; !ok {
+		t.Error("ssh_authorized_keys missing")
+	}
+}
+
+func TestMergeUserDataIntoUserDataRawGivesPrecedenceToRawData(t *testing.T) {
+	ud_key := "user-data-key"
+	ud := UserDataStruct{
+		SSHAuthorizedKeys: []string{ud_key},
+	}
+
+	var userDataRaw = `
+new-key: new-value-set-by-extra
+ssh_authorized_keys:
+  - key2-from-extra-data
+`
+
+	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
+	if err != nil {
+		t.Errorf("Unexpectd error %v", err)
+	}
+
+	if strings.Contains(res, ud_key) {
+		t.Error("Should not have found string defined by user data")
+	}
+
+	if !strings.Contains(res, "key2-from-extra-data") {
+		t.Error("Should have found string defined by raw data")
+	}
+}
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}

--- a/libvirt/cloudinit_def_test.go
+++ b/libvirt/cloudinit_def_test.go
@@ -69,7 +69,7 @@ func TestCreateISONoExteralTool(t *testing.T) {
 }
 
 func TestConvertUserDataToMapPreservesCloudInitNames(t *testing.T) {
-	ud := UserDataStruct{
+	ud := CloudInitUserData{
 		SSHAuthorizedKeys: []string{"key1"},
 	}
 
@@ -85,7 +85,7 @@ func TestConvertUserDataToMapPreservesCloudInitNames(t *testing.T) {
 }
 
 func TestMergeEmptyUserDataIntoUserDataRaw(t *testing.T) {
-	ud := UserDataStruct{}
+	ud := CloudInitUserData{}
 
 	var userDataRaw = `
 new-key: new-value-set-by-extra
@@ -114,7 +114,7 @@ ssh_authorized_keys:
 }
 
 func TestMergeUserDataIntoEmptyUserDataRaw(t *testing.T) {
-	ud := UserDataStruct{
+	ud := CloudInitUserData{
 		SSHAuthorizedKeys: []string{"key1"},
 	}
 	var userDataRaw string
@@ -137,7 +137,7 @@ func TestMergeUserDataIntoEmptyUserDataRaw(t *testing.T) {
 
 func TestMergeUserDataIntoUserDataRawGivesPrecedenceToRawData(t *testing.T) {
 	ud_key := "user-data-key"
-	ud := UserDataStruct{
+	ud := CloudInitUserData{
 		SSHAuthorizedKeys: []string{ud_key},
 	}
 

--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -29,6 +29,11 @@ func resourceCloudInit() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"user_data": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"ssh_authorized_key": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -47,6 +52,7 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 
 	cloudInit := newCloudInitDef()
 	cloudInit.Metadata.LocalHostname = d.Get("local_hostname").(string)
+	cloudInit.UserDataRaw = d.Get("user_data").(string)
 
 	if _, ok := d.GetOk("ssh_authorized_key"); ok {
 		sshKey := d.Get("ssh_authorized_key").(string)
@@ -86,6 +92,7 @@ func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("pool", ci.PoolName)
 	d.Set("name", ci.Name)
 	d.Set("local_hostname", ci.Metadata.LocalHostname)
+	d.Set("user_data", ci.UserDataRaw)
 
 	if err != nil {
 		return fmt.Errorf("Error while retrieving remote ISO: %s", err)


### PR DESCRIPTION
Provide a `user_data` argument for specifying raw user data.

The `user_data`  provided is merged with the other parameters we've been using so far (like the `ssh_authorized_keys`), so this allow us to still use some of those conveniences and, at the same time, it should be backwards compatible...

Closes #66 