### PR TITLE
Add network option to disable DHCP services

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -186,7 +186,9 @@ The network will _NOT_ be managed by the Terraform/libvirt provider.
 * `network_id` - (Optional) The ID of a network resource to attach this interface to.
 The network will be under the control of the Terraform/libvirt provider.
 * `mac` - (Optional) The specific MAC address to use for this interface.
-* `addresses` - (Optional) An IP address for this domain in this network
+* `addresses` - (Optional) An IP address for this domain in this network.
+Note: if this network has DHCP disabled (`dhcp = false`), specifying an address before creation
+will override that setting and enable DHCP services on this network.
 * `hostname` - (Optional) A hostname that will be assigned to this domain resource in this network.
 * `wait_for_lease`- (Optional) When creating the domain resource, wait until the network
 interface gets a DHCP lease from libvirt, so that the computed ip addresses will be available

--- a/docs/providers/libvirt/r/network.markdown
+++ b/docs/providers/libvirt/r/network.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `domain` - The domain used by the DNS server.
 * `addresses` - A list of (0 or 1) ipv4 and (0 or 1) ipv6 subnets in CIDR notation
    format for being served by the DHCP server. Address of subnet should be used.
+* `dhcp` - (Optional) Enable DHCP services on this network (default is `true`).
 * `mode` -  One of:
     - `none`: the guests can talk to each other and the host OS, but cannot reach
     any other machines on the LAN.

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -369,9 +369,10 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 				}
 			} else {
 				// no IPs provided: if the hostname has been provided, wait until we get an IP
-				if len(hostname) > 0 {
+				if _, ok := d.GetOk(prefix + ".hostname"); ok {
 					if !netIface.waitForLease {
-						return fmt.Errorf("Cannot map '%s': we are not waiting for lease and no IP has been provided", hostname)
+						return fmt.Errorf("Cannot map hostname '%s': we are not waiting for lease"+
+							" and no IP has been provided", hostname)
 					}
 					// the resource specifies a hostname but not an IP, so we must wait until we
 					// have a valid lease and then read the IP we have been assigned, so we can

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -87,6 +87,12 @@ func resourceLibvirtNetwork() *schema.Resource {
 					Schema: dnsForwarderSchema(),
 				},
 			},
+			"dhcp": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -219,13 +225,15 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 				start[len(start)-1]++ // then skip the .1
 				end[len(end)-1]--     // and skip the .255 (for broadcast)
 
-				dni.Dhcp = &defNetworkIpDhcp{
-					Ranges: []*defNetworkIpDhcpRange{
-						&defNetworkIpDhcpRange{
-							Start: start.String(),
-							End:   end.String(),
+				if d.Get("dhcp").(bool) {
+					dni.Dhcp = &defNetworkIpDhcp{
+						Ranges: []*defNetworkIpDhcpRange{
+							&defNetworkIpDhcpRange{
+								Start: start.String(),
+								End:   end.String(),
+							},
 						},
-					},
+					}
 				}
 				ipsPtrsLst = append(ipsPtrsLst, &dni)
 			}


### PR DESCRIPTION
When creating a VM with multiple network interfaces on different
networks, you typically don't want a DHCP server running on every
network. For example, a CoreOS VM will send out a DHCP request on every
network interface by default when it boots up (given no other config
from say, Ignition). This is problematic for the VM's networking
because it will end up with multiple default routes.

An example use case of this is a VM with DHCP enabled on one NIC (to be
used as the "management" network), from which the rest of the VM's
interfaces will be configured.