### PR TITLE
Dynamically start DHCP services on networks

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -186,8 +186,10 @@ The network will _NOT_ be managed by the Terraform/libvirt provider.
 * `network_id` - (Optional) The ID of a network resource to attach this interface to.
 The network will be under the control of the Terraform/libvirt provider.
 * `mac` - (Optional) The specific MAC address to use for this interface.
-* `addresses` - (Optional) An IP address for this domain in this network
+* `addresses` - (Optional) An IP address for this domain in this network. If specified,
+this will enable DHCP services on this network (when applicable).
 * `hostname` - (Optional) A hostname that will be assigned to this domain resource in this network.
+If specified, this will enable DHCP services on this network (when applicable).
 * `wait_for_lease`- (Optional) When creating the domain resource, wait until the network
 interface gets a DHCP lease from libvirt, so that the computed ip addresses will be available
 when the domain is up and the plan applied.

--- a/libvirt/libvirt_interfaces.go
+++ b/libvirt/libvirt_interfaces.go
@@ -8,4 +8,5 @@ type LibVirtDomain interface {
 
 type LibVirtNetwork interface {
 	GetXMLDesc(flags uint32) (string, error)
+	UpdateXMLDesc(xmldesc string, command, section int) error
 }

--- a/libvirt/libvirt_network_mock_test.go
+++ b/libvirt/libvirt_network_mock_test.go
@@ -1,10 +1,17 @@
 package libvirt
 
 type LibVirtNetworkMock struct {
-	GetXMLDescReply string
-	GetXMLDescError error
+	GetXMLDescReply     string
+	GetXMLDescError     error
+	UpdateXMLDescError  error
+	UpdateXMLDescCalled bool
 }
 
-func (n LibVirtNetworkMock) GetXMLDesc(flags uint32) (string, error) {
+func (n *LibVirtNetworkMock) GetXMLDesc(flags uint32) (string, error) {
 	return n.GetXMLDescReply, n.GetXMLDescError
+}
+
+func (n *LibVirtNetworkMock) UpdateXMLDesc(xmldesc string, command, section int) error {
+	n.UpdateXMLDescCalled = true
+	return n.UpdateXMLDescError
 }

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -133,7 +133,7 @@ func TestHasDHCPForwardSet(t *testing.T) {
 }
 
 func TestNetworkFromLibvirtError(t *testing.T) {
-	net := LibVirtNetworkMock{
+	net := &LibVirtNetworkMock{
 		GetXMLDescError: errors.New("boom"),
 	}
 
@@ -144,7 +144,7 @@ func TestNetworkFromLibvirtError(t *testing.T) {
 }
 
 func TestNetworkFromLibvirtWrongResponse(t *testing.T) {
-	net := LibVirtNetworkMock{
+	net := &LibVirtNetworkMock{
 		GetXMLDescReply: "wrong xml",
 	}
 
@@ -155,7 +155,7 @@ func TestNetworkFromLibvirtWrongResponse(t *testing.T) {
 }
 
 func TestNetworkFromLibvirt(t *testing.T) {
-	net := LibVirtNetworkMock{
+	net := &LibVirtNetworkMock{
 		GetXMLDescReply: `
 		<network>
 		  <name>default</name>

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -519,35 +519,6 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-// enableDHCP enables DHCP services on a given libvirt network
-func enableDHCP(network *libvirt.VirNetwork) error {
-	// mutex required due to concurrent access of the network definition
-	// (adding the same DHCP range twice causes an error while creating the libvirt domain)
-	dhcpMutex.Lock()
-	defer dhcpMutex.Unlock()
-	networkDef, err := newDefNetworkfromLibvirt(network)
-	if err != nil {
-		return err
-	}
-	for _, ip := range networkDef.Ips {
-		if ip.Dhcp == nil {
-			ipNet, err := GetIPNet(ip.Address, ip.Prefix)
-			if err != nil {
-				return err
-			}
-			start, end := NetworkRange(ipNet)
-
-			// skip the network, gateway, and broadcast addresses
-			start[len(start)-1] = start[len(start)-1] + 2
-			end[len(end)-1]--
-			if err := addDHCPRange(network, start.String(), end.String()); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Update resource libvirt_domain")
 

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -18,6 +19,7 @@ import (
 )
 
 var PoolSync = NewLibVirtPoolSync()
+var dhcpMutex = &sync.Mutex{}
 
 func init() {
 	spew.Config.Indent = "\t"
@@ -359,10 +361,23 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 			}
 
 			hostname := domainDef.Name
+			hostnameSet := false
 			if hostnameI, ok := d.GetOk(prefix + ".hostname"); ok {
 				hostname = hostnameI.(string)
+				hostnameSet = true
 			}
-			if addresses, ok := d.GetOk(prefix + ".addresses"); ok {
+			var addresses interface{}
+			addressesSet := false
+			if a, ok := d.GetOk(prefix + ".addresses"); ok {
+				addresses = a
+				addressesSet = true
+			}
+			if hostnameSet || addressesSet {
+				if err := enableDHCP(&network); err != nil {
+					return err
+				}
+			}
+			if addressesSet {
 				// some IP(s) provided
 				for _, addressI := range addresses.([]interface{}) {
 					address := addressI.(string)
@@ -378,9 +393,10 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 				}
 			} else {
 				// no IPs provided: if the hostname has been provided, wait until we get an IP
-				if len(hostname) > 0 {
+				if hostnameSet {
 					if !netIface.waitForLease {
-						return fmt.Errorf("Cannot map '%s': we are not waiting for lease and no IP has been provided", hostname)
+						return fmt.Errorf("Cannot map hostname '%s': we are not waiting for lease"+
+							" and no IP has been provided", hostname)
 					}
 					// the resource specifies a hostname but not an IP, so we must wait until we
 					// have a valid lease and then read the IP we have been assigned, so we can
@@ -500,6 +516,35 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	return nil
+}
+
+// enableDHCP enables DHCP services on a given libvirt network
+func enableDHCP(network *libvirt.VirNetwork) error {
+	// mutex required due to concurrent access of the network definition
+	// (adding the same DHCP range twice causes an error while creating the libvirt domain)
+	dhcpMutex.Lock()
+	defer dhcpMutex.Unlock()
+	networkDef, err := newDefNetworkfromLibvirt(network)
+	if err != nil {
+		return err
+	}
+	for _, ip := range networkDef.Ips {
+		if ip.Dhcp == nil {
+			ipNet, err := GetIPNet(ip.Address, ip.Prefix)
+			if err != nil {
+				return err
+			}
+			start, end := NetworkRange(ipNet)
+
+			// skip the network, gateway, and broadcast addresses
+			start[len(start)-1] = start[len(start)-1] + 2
+			end[len(end)-1]--
+			if err := addDHCPRange(network, start.String(), end.String()); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -183,7 +183,9 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		// some network modes require a DHCP/DNS server
-		// set the addresses for DHCP
+		// set the IP address and prefix required for DHCP
+		// Note: DHCP services aren't enabled until a domain is
+		// created with a specific address or hostname
 		if addresses, ok := d.GetOk("addresses"); ok {
 			ipsPtrsLst := []*defNetworkIp{}
 			for _, addressI := range addresses.([]interface{}) {
@@ -204,7 +206,7 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 
 				// we should calculate the range served by DHCP. For example, for
 				// 192.168.121.0/24 we will serve 192.168.121.2 - 192.168.121.254
-				start, end := NetworkRange(ipNet)
+				start, _ := NetworkRange(ipNet)
 
 				// skip the .0, (for the network),
 				start[len(start)-1]++
@@ -214,18 +216,6 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 					Address: start.String(),
 					Prefix:  ones,
 					Family:  family,
-				}
-
-				start[len(start)-1]++ // then skip the .1
-				end[len(end)-1]--     // and skip the .255 (for broadcast)
-
-				dni.Dhcp = &defNetworkIpDhcp{
-					Ranges: []*defNetworkIpDhcpRange{
-						&defNetworkIpDhcpRange{
-							Start: start.String(),
-							End:   end.String(),
-						},
-					},
 				}
 				ipsPtrsLst = append(ipsPtrsLst, &dni)
 			}
@@ -347,20 +337,13 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("running", active)
 
 	addresses := []string{}
-	for _, address := range networkDef.Ips {
-		// we get the host interface IP (ie, 10.10.8.1) but we want the network CIDR (ie, 10.10.8.0/24)
-		// so we need some transformations...
-		addr := net.ParseIP(address.Address)
-		if addr == nil {
-			return fmt.Errorf("Error parsing IP '%s': %s", address, err)
+	for _, ip := range networkDef.Ips {
+		// extract the CIDR notation using the address and prefix
+		ipNet, err := GetIPNet(ip.Address, ip.Prefix)
+		if err != nil {
+			return err
 		}
-		bits := net.IPv6len * 8
-		if addr.To4() != nil {
-			bits = net.IPv4len * 8
-		}
-		mask := net.CIDRMask(address.Prefix, bits)
-		network := addr.Mask(mask)
-		addresses = append(addresses, fmt.Sprintf("%s/%d", network, address.Prefix))
+		addresses = append(addresses, ipNet.String())
 	}
 	if len(addresses) > 0 {
 		d.Set("addresses", addresses)

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -1,0 +1,60 @@
+package libvirt
+
+import (
+	"testing"
+)
+
+func TestEnableDHCP(t *testing.T) {
+	network := &LibVirtNetworkMock{
+		GetXMLDescReply: `
+            <network>
+              <name>test-net</name>
+              <forward mode='nat'>
+                <nat>
+                  <port start='1024' end='65535'/>
+                </nat>
+              </forward>
+              <bridge name='testbr' stp='on' delay='0'/>
+              <mac address='41:d6:45:0b:94:38'/>
+              <ip family='ipv4' address='10.0.0.1' prefix='24'>
+              </ip>
+            </network>`,
+		UpdateXMLDescError: nil,
+	}
+
+	if err := enableDHCP(network); err != nil {
+		t.Errorf("error %v", err)
+	}
+	if !network.UpdateXMLDescCalled {
+		t.Error("Expected update of the xml description to enable DHCP")
+	}
+}
+
+func TestEnableDHCPAlreadyEnabled(t *testing.T) {
+	network := &LibVirtNetworkMock{
+		GetXMLDescReply: `
+            <network>
+              <name>test-net</name>
+              <forward mode='nat'>
+                <nat>
+                  <port start='1024' end='65535'/>
+                </nat>
+              </forward>
+              <bridge name='testbr' stp='on' delay='0'/>
+              <mac address='41:d6:45:0b:94:38'/>
+              <ip family='ipv4' address='10.0.0.1' prefix='24'>
+                <dhcp>
+                  <range start='10.0.0.2' end='10.0.0.254'/>
+                </dhcp>
+              </ip>
+            </network>`,
+		UpdateXMLDescError: nil,
+	}
+
+	if err := enableDHCP(network); err != nil {
+		t.Errorf("error %v", err)
+	}
+	if network.UpdateXMLDescCalled {
+		t.Error("Expected no update of the xml description (DHCP already enabled)")
+	}
+}

--- a/libvirt/utils_libvirt.go
+++ b/libvirt/utils_libvirt.go
@@ -20,6 +20,20 @@ func getHostXMLDesc(ip, mac, name string) string {
 	return xml
 }
 
+// addDHCPRange adds a DHCP range to the network
+func addDHCPRange(n *libvirt.VirNetwork, start, end string) error {
+	dr := defNetworkIpDhcpRange{
+		Start: start,
+		End:   end,
+	}
+	xml, err := xmlMarshallIndented(dr)
+	if err != nil {
+		panic("could not marshall dhcp range")
+	}
+	log.Printf("Adding dhcp range with XML:\n%s", xml)
+	return n.UpdateXMLDesc(xml, libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_FIRST, libvirt.VIR_NETWORK_SECTION_IP_DHCP_RANGE)
+}
+
 // Adds a new static host to the network
 func addHost(n *libvirt.VirNetwork, ip, mac, name string) error {
 	xmlDesc := getHostXMLDesc(ip, mac, name)

--- a/libvirt/utils_libvirt.go
+++ b/libvirt/utils_libvirt.go
@@ -21,7 +21,7 @@ func getHostXMLDesc(ip, mac, name string) string {
 }
 
 // addDHCPRange adds a DHCP range to the network
-func addDHCPRange(n *libvirt.VirNetwork, start, end string) error {
+func addDHCPRange(n LibVirtNetwork, start, end string) error {
 	dr := defNetworkIpDhcpRange{
 		Start: start,
 		End:   end,

--- a/libvirt/utils_libvirt_test.go
+++ b/libvirt/utils_libvirt_test.go
@@ -2,6 +2,7 @@ package libvirt
 
 import (
 	"encoding/xml"
+	"errors"
 	"testing"
 )
 
@@ -28,5 +29,23 @@ func TestGetHostXMLDesc(t *testing.T) {
 
 	if dd.Name != name {
 		t.Errorf("expected name %s, got %s", name, dd.Name)
+	}
+}
+
+func TestAddDHCPRange(t *testing.T) {
+	network := &LibVirtNetworkMock{
+		UpdateXMLDescError: nil,
+	}
+	if err := addDHCPRange(network, "10.0.0.2", "10.0.0.254"); err != nil {
+		t.Errorf("error %v", err)
+	}
+}
+
+func TestAddDHCPRangeError(t *testing.T) {
+	network := &LibVirtNetworkMock{
+		UpdateXMLDescError: errors.New("boom"),
+	}
+	if err := addDHCPRange(network, "invalid", "cidr"); err == nil {
+		t.Error("Expected error")
 	}
 }

--- a/libvirt/utils_net.go
+++ b/libvirt/utils_net.go
@@ -56,3 +56,13 @@ func NetworkRange(network *net.IPNet) (net.IP, net.IP) {
 	}
 	return firstIP, lastIP
 }
+
+// GetIPNet takes an IP address and prefix length and returns a pointer to the corresponding IPNet
+func GetIPNet(address string, prefixLen int) (*net.IPNet, error) {
+	cidr := fmt.Sprintf("%s/%d", address, prefixLen)
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing CIDR '%s': %s", cidr, err)
+	}
+	return ipNet, nil
+}


### PR DESCRIPTION
Rather than starting DHCP services on a network when it is created, they
should be started dynamically when domains are created with interfaces
on the network with requested addresses (or hostnames).

Because domains can be created in parallel, some read/write access to
the libvirt network definition must be synced to prevent an error that
occurs when a DHCP range is added twice to a network.