### PR TITLE
Be more verbose/precise by debugging failures.

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -379,7 +379,7 @@ func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		// attempt a new lookup
 		volume, err = virConn.LookupStorageVolByKey(d.Id())
 		if err != nil {
-			return fmt.Errorf("Can't retrieve volume %s", d.Id())
+			return fmt.Errorf("Second attempt: Can't retrieve volume %s", d.Id())
 		}
 	}
 	defer volume.Free()


### PR DESCRIPTION
We have a race condition here, see issue 88 and printing same string
for two differents error in code is not the best solution for debug.