### PR TITLE
Adding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+#  Version Reports:
+
+### Distro  version of host:
+
+``` openSUSE 42.2/ Centos7/ Ubuntu.. ```
+
+### Terraform Version Report
+(Provided by running `terraform -v`.)
+
+### Libvirt version
+
+```virsh --version```
+
+### terraform-provider-libvirt plugin version (git-hash)
+
+``` git log```
+___
+# Description of Issue/Question
+
+### Setup
+(Please provide the full **main.tf** file for reproducing the issue (Be sure to remove sensitive info)
+
+### Steps to Reproduce Issue
+(Include debug logs if possible and relevant.)
+
+___
+# Additional Infos:
+
+Do you have SELinux or Apparmor/Firewall enabled? Some special configuration?
+Have you tried to reproduce the issue without them enabled?


### PR DESCRIPTION
it look like this:

https://github.com/MalloZup/terraform-provider-libvirt/issues/1

Additionally, it prevent also to not report  information like OS-Version and version of plugins/virsh etc that can't add the issue, and at least give a snapshot of issue

**examples**:
https://github.com/dmacvicar/terraform-provider-libvirt/issues/74  **good issue** but os-version is taken as implicit.
https://github.com/dmacvicar/terraform-provider-libvirt/issues/13 **version os and main.tf missed (partially)


