### PR TITLE
Add scsi controller option and wwn to virtual disks

### DIFF
--- a/docs/providers/libvirt/r/domain.html.markdown
+++ b/docs/providers/libvirt/r/domain.html.markdown
@@ -109,6 +109,10 @@ nvram = [
 The `disk` block supports:
 
 * `volume_id` - (Required) The volume id to use for this disk.
+* `scsi` - (Optional) Use a scsi controller for this disk.  The controller
+model is set to `virtio-scsi`
+* `wwn` - (Optional) Specify a WWN to use for the disk if the disk is using
+a scsi controller, if not specified then a random wwn is generated for the disk
 
 If you have a volume with a template image, create a second volume using the image as the backing volume, and then use the new volume as the volume for the disk. This way the image will not be modified.
 
@@ -127,6 +131,7 @@ resource "libvirt_domain" "domain1" {
   name = "domain1"
   disk {
     volume_id = "${libvirt_volume.mydisk.id}"
+    scsi = "yes"
   }
 
   network_interface {

--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -2,12 +2,17 @@ package libvirt
 
 import (
 	"encoding/xml"
+	"math/rand"
+	"time"
 )
+
+const OUI = "05abcd"
 
 type defDisk struct {
 	XMLName xml.Name `xml:"disk"`
 	Type    string   `xml:"type,attr"`
 	Device  string   `xml:"device,attr"`
+	Wwn     string   `xml:"wwn,omitempty"`
 	Format  struct {
 		Type string `xml:"type,attr"`
 	} `xml:"format"`
@@ -49,4 +54,14 @@ func newCDROM() defDisk {
 	disk.Driver.Type = "raw"
 
 	return disk
+}
+
+func randomWWN(strlen int) string {
+	const chars = "abcdef0123456789"
+	rand.Seed(time.Now().UTC().UnixNano())
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return OUI + string(result)
 }

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -23,6 +23,7 @@ type defDomain struct {
 		Pae  string `xml:"pae"`
 	} `xml:"features"`
 	Devices struct {
+		Controller        []defController       `xml:"controller,omitempty"`
 		Disks             []defDisk             `xml:"disk"`
 		NetworkInterfaces []defNetworkInterface `xml:"interface"`
 		Console           []defConsole          `xml:"console"`
@@ -100,6 +101,11 @@ type defLoader struct {
 // <nvram>/var/lib/libvirt/qemu/nvram/sled12sp1_VARS.fd</nvram>
 type defNvRam struct {
 	File string `xml:",chardata"`
+}
+
+type defController struct {
+	Type  string `xml:"type,attr,omitempty"`
+	Model string `xml:"model,attr,omitempty"`
 }
 
 type defConsole struct {


### PR DESCRIPTION
We've added the facility to define a disk bus type of scsi to the
specification of a disk in the domain definition.  If the disk is
a scsi disk, a random wwn is generated unless a wwn is provided for
that disk.

The disk stanza now looks as follows:

   disk {
     volume_id = "${libvirt_volume.mydisk.id}"
     scsi = "yes"
     wwn = "05abcd123456789a"
   }

Having "scsi" present with any value will specify a scsi bus for
the disk.  If "wwn" is present for a scsci disk then the value of
"wwn" is used for the disk wwn, otherwise a random value is generated.