### PR TITLE
Use If-Modified-Since for downloading images

### DIFF
--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -1,0 +1,120 @@
+package libvirt
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// network transparent image
+type image interface {
+	Size() (uint64, error)
+	Import(func(io.Reader) error, defVolume) error
+	String() string
+}
+
+type localImage struct {
+	path string
+}
+
+func (i *localImage) String() string {
+	return i.path
+}
+
+func (i *localImage) Size() (uint64, error) {
+	file, err := os.Open(i.path)
+	if err != nil {
+		return 0, err
+	}
+
+	fi, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(fi.Size()), nil
+}
+
+func (i *localImage) Import(copier func(io.Reader) error, vol defVolume) error {
+
+	file, err := os.Open(i.path)
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("Error while opening %s: %s", i.path, err)
+	}
+
+	if fi, err := file.Stat(); err != nil {
+		return err
+	} else {
+		// we can skip the upload if the modification times are the same
+		if vol.Target.Timestamps != nil && vol.Target.Timestamps.Modification != nil {
+			modTime := UnixTimestamp{fi.ModTime()}
+			if modTime == *vol.Target.Timestamps.Modification {
+				log.Printf("Modification time is the same: skipping image copy")
+				return nil
+			}
+		}
+	}
+
+	return copier(file)
+}
+
+type httpImage struct {
+	url *url.URL
+}
+
+func (i *httpImage) String() string {
+	return i.url.String()
+}
+
+func (i *httpImage) Size() (uint64, error) {
+	response, err := http.Head(i.url.String())
+	if err != nil {
+		return 0, err
+	}
+	length, err := strconv.Atoi(response.Header.Get("Content-Length"))
+	if err != nil {
+		return 0, err
+	}
+	return uint64(length), nil
+}
+
+func (i *httpImage) Import(copier func(io.Reader) error, vol defVolume) error {
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", i.url.String(), nil)
+
+	if vol.Target.Timestamps != nil && vol.Target.Timestamps.Modification != nil {
+		t := vol.Target.Timestamps.Modification.UTC().Format(http.TimeFormat)
+		req.Header.Set("If-Modified-Since", t)
+	}
+	response, err := client.Do(req)
+	defer response.Body.Close()
+
+	if err != nil {
+		return fmt.Errorf("Error while downloading %s: %s", i.url.String(), err)
+	}
+	if response.StatusCode == http.StatusNotModified {
+		return nil
+	}
+
+	return copier(response.Body)
+}
+
+func newImage(source string) (image, error) {
+	url, err := url.Parse(source)
+	if err != nil {
+		return nil, fmt.Errorf("Can't parse source '%s' as url: %s", source, err)
+	}
+
+	if strings.HasPrefix(url.Scheme, "http") {
+		return &httpImage{url: url}, nil
+	} else if url.Scheme == "file" || url.Scheme == "" {
+		return &localImage{path: url.Path}, nil
+	} else {
+		return nil, fmt.Errorf("Don't know how to read from '%s': %s", url.String(), err)
+	}
+}

--- a/libvirt/utils_volume_test.go
+++ b/libvirt/utils_volume_test.go
@@ -1,0 +1,88 @@
+package libvirt
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLocalImageDownload(t *testing.T) {
+	content := []byte("this is a qcow image... well, it is not")
+	tmpfile, err := ioutil.TempFile("", "test-image-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	t.Logf("Adding some content to %s", tmpfile.Name())
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpfileStat, err := tmpfile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url := fmt.Sprintf("file://%s", tmpfile.Name())
+	image, err := newImage(url)
+	if err != nil {
+		t.Errorf("Could not create local image: %v", err)
+	}
+
+	t.Logf("Importing %s", url)
+	vol := newDefVolume()
+	modTime := UnixTimestamp{tmpfileStat.ModTime()}
+	vol.Target.Timestamps = &defTimestamps{
+		Modification: &modTime,
+	}
+
+	copier := func(r io.Reader) error {
+		t.Fatalf("ERROR: starting copy of %s... but the file is the same!", url)
+		return nil
+	}
+	if err = image.Import(copier, vol); err != nil {
+		t.Fatal("Could not copy image from %s: %v", url, err)
+	}
+	t.Log("File not copied because modification time was the same")
+}
+
+func TestRemoteImageDownload(t *testing.T) {
+	content := []byte("this is a qcow image... well, it is not")
+	fws := fileWebServer{}
+	if err := fws.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer fws.Stop()
+
+	url, tmpfile, err := fws.AddFile(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpfileStat, err := tmpfile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	image, err := newImage(url)
+	if err != nil {
+		t.Errorf("Could not create local image: %v", err)
+	}
+
+	t.Logf("Importing %s", url)
+	vol := newDefVolume()
+	modTime := UnixTimestamp{tmpfileStat.ModTime()}
+	vol.Target.Timestamps = &defTimestamps{
+		Modification: &modTime,
+	}
+	copier := func(r io.Reader) error {
+		t.Fatalf("ERROR: starting copy of %s... but the file is the same!", url)
+		return nil
+	}
+	if err = image.Import(copier, vol); err != nil {
+		t.Fatal("Could not copy image from %s: %v", url, err)
+	}
+	t.Log("File not copied because modification time was the same")
+
+}

--- a/libvirt/volume_def.go
+++ b/libvirt/volume_def.go
@@ -2,13 +2,49 @@ package libvirt
 
 import (
 	"encoding/xml"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	libvirt "github.com/dmacvicar/libvirt-go"
 )
+
+type UnixTimestamp struct{ time.Time }
+
+func (t *UnixTimestamp) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var content string
+	if err := d.DecodeElement(&content, &start); err != nil {
+		return err
+	}
+
+	ts, err := strconv.ParseFloat(content, 64)
+	if err != nil {
+		return err
+	}
+	s, ns := math.Modf(ts)
+	*t = UnixTimestamp{time.Time(time.Unix(int64(s), int64(ns)))}
+	return nil
+}
+
+func (t *UnixTimestamp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	s := t.UTC().Unix()
+	ns := t.UTC().UnixNano()
+	return e.EncodeElement(fmt.Sprintf("%d.%d", s, ns), start)
+}
+
+type defTimestamps struct {
+	Change       *UnixTimestamp `xml:"ctime,omitempty"`
+	Modification *UnixTimestamp `xml:"mtime,omitempty"`
+	Access       *UnixTimestamp `xml:"atime,omitempty"`
+}
 
 type defBackingStore struct {
 	Path   string `xml:"path"`
 	Format struct {
 		Type string `xml:"type,attr"`
 	} `xml:"format"`
+	Timestamps *defTimestamps `xml:"timestamps,omitempty"`
 }
 
 type defVolume struct {
@@ -21,11 +57,12 @@ type defVolume struct {
 		Permissions struct {
 			Mode int `xml:"mode,omitempty"`
 		} `xml:"permissions,omitempty"`
+		Timestamps *defTimestamps `xml:"timestamps,omitempty"`
 	} `xml:"target"`
 	Allocation int `xml:"allocation"`
 	Capacity   struct {
 		Unit   string `xml:"unit,attr"`
-		Amount int64  `xml:"chardata"`
+		Amount uint64 `xml:"chardata"`
 	} `xml:"capacity"`
 	BackingStore *defBackingStore `xml:"backingStore,omitempty"`
 }
@@ -37,4 +74,30 @@ func newDefVolume() defVolume {
 	volumeDef.Capacity.Unit = "bytes"
 	volumeDef.Capacity.Amount = 1
 	return volumeDef
+}
+
+// Creates a volume definition from a XML
+func newDefVolumeFromXML(s string) (defVolume, error) {
+	var volumeDef defVolume
+	err := xml.Unmarshal([]byte(s), &volumeDef)
+	if err != nil {
+		return defVolume{}, err
+	}
+	return volumeDef, nil
+}
+
+func newDefVolumeFromLibvirt(volume *libvirt.VirStorageVol) (defVolume, error) {
+	name, err := volume.GetName()
+	if err != nil {
+		return defVolume{}, fmt.Errorf("could not get name for volume: %s.", err)
+	}
+	volumeDefXml, err := volume.GetXMLDesc(0)
+	if err != nil {
+		return defVolume{}, fmt.Errorf("could not get XML description for volume %s: %s.", name, err)
+	}
+	volumeDef, err := newDefVolumeFromXML(volumeDefXml)
+	if err != nil {
+		return defVolume{}, fmt.Errorf("could not get a volume definition from XML for %s: %s.", volumeDef.Name, err)
+	}
+	return volumeDef, nil
 }

--- a/libvirt/volume_def_test.go
+++ b/libvirt/volume_def_test.go
@@ -12,6 +12,54 @@ func init() {
 	spew.Config.Indent = "\t"
 }
 
+
+func TestVolumeUnmarshal(t *testing.T) {
+	xmlDesc := `
+	<volume type='file'>
+	  <name>caasp_master.img</name>
+	  <key>/home/user/.libvirt/images/image.img</key>
+	  <source>
+	  </source>
+	  <capacity unit='bytes'>42949672960</capacity>
+	  <allocation unit='bytes'>900800512</allocation>
+	  <target>
+	    <path>/home/user/.libvirt/images/image.img</path>
+	    <format type='qcow2'/>
+	    <permissions>
+	      <mode>0644</mode>
+	      <owner>480</owner>
+	      <group>473</group>
+	    </permissions>
+	    <timestamps>
+	      <atime>1488789260.012293492</atime>
+	      <mtime>1488802938.454893390</mtime>
+	      <ctime>1488802938.454893390</ctime>
+	    </timestamps>
+	  </target>
+	  <backingStore>
+	    <path>/home/user/.libvirt/images/image.img</path>
+	    <format type='qcow2'/>
+	    <permissions>
+	      <mode>0644</mode>
+	      <owner>480</owner>
+	      <group>473</group>
+	    </permissions>
+	    <timestamps>
+	      <atime>1488541864.606322102</atime>
+	      <mtime>1488541858.638308597</mtime>
+	      <ctime>1488541864.526321921</ctime>
+	    </timestamps>
+	  </backingStore>
+	</volume>
+	`
+
+	def, err := newDefVolumeFromXML(xmlDesc)
+	if err != nil {
+		t.Fatalf("could not unmarshall volume definition:\n%s", err)
+	}
+	t.Logf("Unmarshalled volume:\n%s", spew.Sdump(def))
+}
+
 func TestDefaultVolumeMarshall(t *testing.T) {
 	b := newDefVolume()
 	prettyB := spew.Sdump(b)


### PR DESCRIPTION
The idea is to use `If-Modified-Since` when downloading an image from a `source`, so we can skip the download when _a)_ the image was downloaded in the past and _b)_ the modification time is the same

Closes #109 