### PR TITLE
Add configurable timeouts

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -1,9 +1,9 @@
 package libvirt
 
 import (
-	"encoding/xml"
-	"encoding/hex"
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
 	"fmt"
 	"log"
 	"net"
@@ -941,6 +941,8 @@ func getDomainState(domain libvirt.VirDomain) (string, error) {
 		stateStr = "pmsuspended"
 	case libvirt.VIR_DOMAIN_SHUTOFF:
 		stateStr = "shutoff"
+	default:
+		stateStr = fmt.Sprintf("unknown: %v", state[0])
 	}
 
 	return stateStr, nil


### PR DESCRIPTION
Terraform supports configurable timeouts since v0.9.0.

With this commit, it's possible to configure the timeout for the
creation of a libvirt domain. It defaults to 5 minutes, but can be as
short as 10 seconds.