### PR TITLE
Use file type definition for disks

### DIFF
--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -17,8 +17,10 @@ type defDisk struct {
 		Type string `xml:"type,attr"`
 	} `xml:"format"`
 	Source struct {
-		Pool   string `xml:"pool,attr"`
-		Volume string `xml:"volume,attr"`
+		File   string `xml:"file,attr,omitempty"`
+		// retain Pool/Volume for compatibility with existing tfstate
+		Pool   string `xml:"pool,attr,omitempty"`
+		Volume string `xml:"volume,attr,omitempty"`
 	} `xml:"source"`
 	Target struct {
 		Dev string `xml:"dev,attr"`
@@ -32,7 +34,7 @@ type defDisk struct {
 
 func newDefDisk() defDisk {
 	disk := defDisk{}
-	disk.Type = "volume"
+	disk.Type = "file"
 	disk.Device = "disk"
 	disk.Format.Type = "qcow2"
 	disk.Target.Bus = "virtio"
@@ -45,7 +47,7 @@ func newDefDisk() defDisk {
 
 func newCDROM() defDisk {
 	disk := defDisk{}
-	disk.Type = "volume"
+	disk.Type = "file"
 	disk.Device = "cdrom"
 	disk.Target.Dev = "hda"
 	disk.Target.Bus = "ide"


### PR DESCRIPTION
Using file type definition for disks allows virt-aa-helper to identify
the backing file correctly from the generated XML and add the necessary
permissions to permit qemu to be able to access the storage disk
provided it is located within a storage pool.

Ensure that reading of existing tfstate using pool/volume definition
remains working for upgrade compatibility by checking first if `File` is
a non-zero string.

Fixes #126