### PR TITLE
Seed RNG with current time.

### DIFF
--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -3,7 +3,6 @@ package libvirt
 import (
 	"encoding/xml"
 	"math/rand"
-	"time"
 )
 
 const OUI = "05abcd"
@@ -60,7 +59,6 @@ func newCDROM() defDisk {
 
 func randomWWN(strlen int) string {
 	const chars = "abcdef0123456789"
-	rand.Seed(time.Now().UTC().UnixNano())
 	result := make([]byte, strlen)
 	for i := 0; i < strlen; i++ {
 		result[i] = chars[rand.Intn(len(chars))]

--- a/main.go
+++ b/main.go
@@ -3,10 +3,16 @@ package main
 import (
 	"github.com/dmacvicar/terraform-provider-libvirt/libvirt"
 	"github.com/hashicorp/terraform/plugin"
+	"math/rand"
+	"time"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: libvirt.Provider,
 	})
+}
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
 }


### PR DESCRIPTION
After upgrading the plugin (the previous version I used I had built a couple months ago) I kept getting VMs with MAC addresses repeated each time I run terraform.

I don't know why previously this was working. I have gone through almost entire history and I haven't found a call to `rand.Seed()` in `libvirt` subdir. Maybe this was set by some dependency and got changed recently.

In addition, to setting seed in main (pattern stolen from Packer code), I have removed call to `rand.Seed()` repeated every time WWN was needed for disk.

I have left call to `rand.Seed()` in `utils_net.go: RandomPort()`. This looks suspicious as well but it seems to be invoked only in tests and I am not that familiar with go and this project to be able to tell where it should be moved to (I suspect `init` for `main` package is not called for tests).