### PR TITLE
 Add support of filesystem device to domain

### DIFF
--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -52,7 +52,7 @@ func xmlMarshallIndented(b interface{}) (string, error) {
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(b); err != nil {
-		fmt.Errorf("could not marshall this:\n%s", spew.Sdump(b))
+		return "", fmt.Errorf("could not marshall this:\n%s", spew.Sdump(b))
 	}
 	return buf.String(), nil
 }


### PR DESCRIPTION
Allow sharing of directories of the host with the guest by using the filesystem device.

Thanks to this code it's possible to mount a directory of the host inside of the guest without having to run any service like `nfs`. See [this](https://www.suse.com/documentation/sles-12/book_virt/data/sec_libvirt_storage_share.html) explanation.

This makes the whole terraform-libvirt-provider feel a bit more "vagrant-like" 😄 
