### PR TITLE
Support for raw volumes

### DIFF
--- a/examples/format/libvirt.tf
+++ b/examples/format/libvirt.tf
@@ -1,0 +1,72 @@
+provider "libvirt" {
+    uri = "qemu:///system"
+}
+
+resource "libvirt_network" "tf" {
+   name = "tf"
+   domain = "tf.local"
+   mode = "nat"
+   addresses = ["10.0.100.0/24"]
+}
+
+# raw image from file
+resource "libvirt_volume" "debian8-raw" {
+  name = "debian8-raw"
+  format = "raw"
+  source = "http://localhost:8000/debian8.img"
+}
+
+# qcow2 image from file
+resource "libvirt_volume" "debian8-qcow2" {
+  name = "debian8-qcow2"
+  source = "http://localhost:8000/debian8.qcow2"
+}
+
+# volume with raw backing storage
+resource "libvirt_volume" "vol-debian8-raw" {
+  name = "vol-debian8-raw"
+  base_volume_id = "${libvirt_volume.debian8-raw.id}"
+  base_volume_format = "raw"
+}
+
+# volume with qcow2 backing storage
+resource "libvirt_volume" "vol-debian8-qcow2" {
+  name = "vol-debian8-qcow2"
+  base_volume_id = "${libvirt_volume.debian8-qcow2.id}"
+}
+
+# domain using raw-backed volume
+resource "libvirt_domain" "domain-debian8-raw" {
+  name = "domain-debian8-raw"
+  memory = "256"
+  vcpu = 1
+  network_interface {
+    network_name = "tf"
+  }
+  disk {
+    volume_id = "${libvirt_volume.vol-debian8-raw.id}"
+  }
+  graphics {
+    type = "spice"
+    listen_type = "address"
+    autoport = true
+  }
+}
+
+# domain using qcow2-backed volume
+resource "libvirt_domain" "domain-debian8-qcow2" {
+  name = "domain-debian8-qcow2"
+  memory = "256"
+  vcpu = 1
+  network_interface {
+    network_name = "tf"
+  }
+  disk {
+    volume_id = "${libvirt_volume.vol-debian8-qcow2.id}"
+  }
+  graphics {
+    type = "spice"
+    listen_type = "address"
+    autoport = true
+  }
+}

--- a/examples/format/libvirt.tf
+++ b/examples/format/libvirt.tf
@@ -26,7 +26,6 @@ resource "libvirt_volume" "debian8-qcow2" {
 resource "libvirt_volume" "vol-debian8-raw" {
   name = "vol-debian8-raw"
   base_volume_id = "${libvirt_volume.debian8-raw.id}"
-  base_volume_format = "raw"
 }
 
 # volume with qcow2 backing storage

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -35,6 +35,11 @@ func volumeCommonSchema() map[string]*schema.Schema {
 			Computed: true,
 			ForceNew: true,
 		},
+		"format": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 		"base_volume_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
@@ -46,6 +51,11 @@ func volumeCommonSchema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"base_volume_name": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"base_volume_format": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 			ForceNew: true,
@@ -105,6 +115,12 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	if name, ok := d.GetOk("name"); ok {
 		volumeDef.Name = name.(string)
 	}
+
+	volumeFormat := "qcow2"
+	if _, ok := d.GetOk("format"); ok {
+		volumeFormat = d.Get("format").(string)
+	}
+	volumeDef.Target.Format.Type = volumeFormat
 
 	var (
 		img    image
@@ -171,7 +187,12 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 
 		volume = nil
 		volumeDef.BackingStore = new(defBackingStore)
-		volumeDef.BackingStore.Format.Type = "qcow2"
+
+		baseVolumeFormat := "qcow2"
+		if _, ok := d.GetOk("base_volume_format"); ok {
+			baseVolumeFormat = d.Get("base_volume_format").(string)
+		}
+		volumeDef.BackingStore.Format.Type = baseVolumeFormat
 		baseVolume, err := virConn.LookupStorageVolByKey(baseVolumeId.(string))
 		if err != nil {
 			return fmt.Errorf("Can't retrieve volume %s", baseVolumeId.(string))

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -178,31 +178,3 @@ func TestAccLibvirtVolume_Format(t *testing.T) {
 		},
 	})
 }
-
-func TestAccLibvirtVolume_BaseVolumeFormat(t *testing.T) {
-	var volume libvirt.StorageVol
-
-	const testAccCheckLibvirtVolumeConfig_format = `
-		resource "libvirt_volume" "terraform-acceptance-test-4" {
-		    name = "terraform-test"
-		    base_volume_format = "raw"
-		}`
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckLibvirtVolumeConfig_format,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-4", &volume),
-					resource.TestCheckResourceAttr(
-						"libvirt_volume.terraform-acceptance-test-4", "name", "terraform-test"),
-					resource.TestCheckResourceAttr(
-						"libvirt_volume.terraform-acceptance-test-4", "base_volume_format", "raw"),
-				),
-			},
-		},
-	})
-}

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -147,3 +147,62 @@ func TestAccLibvirtVolume_DownloadFromSource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLibvirtVolume_Format(t *testing.T) {
+	var volume libvirt.StorageVol
+
+	const testAccCheckLibvirtVolumeConfig_format = `
+		resource "libvirt_volume" "terraform-acceptance-test-3" {
+		    name = "terraform-test"
+		    format = "raw"
+		    size =  1073741824
+		}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckLibvirtVolumeConfig_format,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-3", &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "name", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "size", "1073741824"),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "format", "raw"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtVolume_BaseVolumeFormat(t *testing.T) {
+	var volume libvirt.StorageVol
+
+	const testAccCheckLibvirtVolumeConfig_format = `
+		resource "libvirt_volume" "terraform-acceptance-test-4" {
+		    name = "terraform-test"
+		    base_volume_format = "raw"
+		}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckLibvirtVolumeConfig_format,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-4", &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-4", "name", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-4", "base_volume_format", "raw"),
+				),
+			},
+		},
+	})
+}

--- a/libvirt/volume_def.go
+++ b/libvirt/volume_def.go
@@ -101,3 +101,18 @@ func newDefVolumeFromLibvirt(volume *libvirt.StorageVol) (defVolume, error) {
 	}
 	return volumeDef, nil
 }
+
+func newDefBackingStoreFromLibvirt(baseVolume *libvirt.StorageVol) (defBackingStore, error) {
+	baseVolumeDef, err := newDefVolumeFromLibvirt(baseVolume)
+	if err != nil {
+		return defBackingStore{}, fmt.Errorf("could not get volume: %s.", err)
+	}
+	baseVolPath, err := baseVolume.GetPath()
+	if err != nil {
+		return defBackingStore{}, fmt.Errorf("could not get base image path: %s", err)
+	}
+	var backingStoreDef defBackingStore
+	backingStoreDef.Path = baseVolPath
+	backingStoreDef.Format.Type = baseVolumeDef.Target.Format.Type
+	return backingStoreDef, nil
+}


### PR DESCRIPTION
When trying to use the provider I found out that it was hardcoded to default to always create and use qcow2 volumes. 

While I can understand why this default was picked up, I am faced with an use case where I actually want to use raw volumes. For this reason I amended the code to support the `format` and `base_volume_format` as optional, configurable items for new volumes.

I've also added one example about how to use it, which is actually the one I used to test this modification.

Could you please give it a look and tell me what you think?