### PR TITLE
Support for NVRAM template

### DIFF
--- a/examples/uefi/libvirt.tf
+++ b/examples/uefi/libvirt.tf
@@ -1,0 +1,38 @@
+provider "libvirt" {
+    uri = "qemu:///system"
+}
+
+resource "libvirt_volume" "ubuntu-cloud-uefi" {
+  name = "ubuntu-cloud-uefi"
+  source = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-uefi1.img"
+}
+
+resource "libvirt_volume" "volume" {
+  name = "vm${count.index}"
+  base_volume_id = "${libvirt_volume.ubuntu-cloud-uefi.id}"
+  count = 1
+}
+
+resource "libvirt_domain" "domain" {
+  count = 2
+  name = "ubuntu-cloud-${count.index}"
+  memory = "512"
+  vcpu = 1
+  # This file is usually present as part of the ovmf firmware package in many
+  # Linux distributions.
+  firmware = "/usr/share/OVMF/OVMF_CODE.fd"
+  nvram {
+    # This is the file which will back the UEFI NVRAM content.
+    file = "/var/lib/libvirt/qemu/nvram/vm${count.index}_VARS.fd"
+    # This file needs to be provided by the user.
+    template = "/srv/provisioning/terraform/debian-stable-uefi_VARS.fd"
+  }
+  disk {
+    volume_id = "${element(libvirt_volume.volume.*.id, count.index)}"
+  }
+  graphics {
+    type = "spice"
+    listen_type = "address"
+    autoport = true
+  }
+

--- a/travis/setup-guest
+++ b/travis/setup-guest
@@ -13,7 +13,7 @@ while check_network ; [ $? -ne 0 ];do
 done
 
 apt-get -qq update
-apt-get install -y qemu libvirt-bin libvirt-dev golang-1.8
+apt-get install -y qemu libvirt-bin libvirt-dev golang-1.8 ovmf
 echo -e "<pool type='dir'>\n<name>default</name>\n<target>\n<path>/pool-default</path>\n</target>\n</pool>" > pool.xml
 mkdir /pool-default
 chmod a+rwx /pool-default

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -59,11 +59,14 @@ Some extra arguments are also provided for using UEFI images:
 environment. Users should usually specify one of the standard _Open Virtual Machine
 Firmware_ (_OVMF_) images available for their distributions. The file will be opened
 read-only.
-* `nvram` - (Optional) the _nvram_ variables file corresponding to the firmware. When provided,
-this file must be writable and specific to this domain, as it will be updated when running
-the domain. However, `libvirt` can manage this automatically (and this is the recommended solution)
-if a mapping for the firmware to a _variables file_ exists in `/etc/libvirt/qemu.conf:nvram`.
-In that case, `libvirt` will copy that variables file into a file specific for this domain.
+* `nvram` - (Optional) this block allows specifying the following attributes related to the _nvram_:
+  * `file` - path to the file backing the NVRAM store for non-volatile variables. When provided, 
+  this file must be writable and specific to this domain, as it will be updated when running the 
+  domain. However, `libvirt` can  manage this automatically (and this is the recommended solution) 
+  if a mapping for the firmware to a _variables file_ exists in `/etc/libvirt/qemu.conf:nvram`.
+  In that case, `libvirt` will copy that variables file into a file specific for this domain.
+  * `template` - (Optional) path to the file used to override variables from the master NVRAM 
+  store.
 
 So you should typically use the firmware as this,
 
@@ -86,6 +89,46 @@ and `/etc/libvirt/qemu.conf` should contain:
 nvram = [
    "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"
 ]
+```
+
+In case you need (or want) to specify the path for the NVRAM store, the domain definition should 
+look like this:
+
+```hcl
+resource "libvirt_domain" "my_machine" {
+  name = "my_machine"
+  firmware = "/usr/share/qemu/ovmf-x86_64-code.bin"
+  nvram {
+    file = "/usr/local/share/qemu/custom-vars.bin"
+  }
+  memory = "2048"
+
+  disk {
+    volume_id = "${libvirt_volume.volume.id}"
+  }
+  ...
+}
+
+```
+
+Finally, if you want the initial values for the NVRAM to be overridden by custom initial values
+coming from a template, the domain definition should look like this:
+
+```hcl
+resource "libvirt_domain" "my_machine" {
+  name = "my_machine"
+  firmware = "/usr/share/qemu/ovmf-x86_64-code.bin"
+  nvram {
+    file = "/usr/local/share/qemu/custom-vars.bin"
+    template = "/usr/local/share/qemu/template-vars.bin"
+  }
+  memory = "2048"
+
+  disk {
+    volume_id = "${libvirt_volume.volume.id}"
+  }
+  ...
+}
 ```
 
 ### Handling disks


### PR DESCRIPTION
Hey all,

When working on deploying some UEFI VMs I stumbled upon the problem that the boot entry was not being carried over to the newly provisioned VMs. Thanks to this, every single new UEFI VM was stuck at the UEFI shell after boot instead of booting the system. 

A solution for this would be to use the [NVRAM template attribute](https://libvirt.org/formatdomain.html#elementsOSBIOS) offered by libvirt, allowing a preconfigured set of UEFI variables to be carried over to the new domain. 

What this pull request does is to add such support to this plugin together with an example of how to use it.

Could you please review it and tell me what you think? 