### PR TITLE
Fix crash occuring when domain is in state file but doesn't exist in libvirt.

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -156,9 +156,17 @@ func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool
 	if virConn == nil {
 		return false, fmt.Errorf("The libvirt connection was nil.")
 	}
+
 	domain, err := virConn.LookupDomainByUUIDString(d.Id())
+	if err != nil {
+		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
+			return false, nil
+		}
+		return false, err
+	}
 	defer domain.Free()
-	return err == nil, err
+
+	return true, nil
 }
 
 func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This commit fixes crash that occurs if a domain resource is present in Terraform's state file but does not exist in libvirt.

One problem with this change is that I am not sure how to add exposing/regression test for this bug. Could anyone briefly explain how I could add such test?