### PR TITLE
ensure volumes are free'd if there are no errors

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -804,11 +804,11 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 
 			virVol, err = virPool.LookupStorageVolByName(diskDef.Source.Volume)
 		}
-		defer virVol.Free()
 
 		if err != nil {
 			return fmt.Errorf("Error retrieving volume for disk: %s", err)
 		}
+		defer virVol.Free()
 
 		virVolKey, err := virVol.GetKey()
 		if err != nil {


### PR DESCRIPTION
Make sure to only then free volumes if there are no errors.

This fixes #151.

Signed-off-by: Thomas Hipp <thipp@suse.de>