### PR TITLE
fix XML name of DHCP host element

### DIFF
--- a/libvirt/utils_libvirt.go
+++ b/libvirt/utils_libvirt.go
@@ -14,7 +14,11 @@ func getHostXMLDesc(ip, mac, name string) string {
 		MAC:  mac,
 		Name: name,
 	}
-	xml, err := xmlMarshallIndented(dd)
+	tmp := struct {
+		XMLName xml.Name `xml:"host"`
+		libvirtxml.NetworkDHCPHost
+	}{xml.Name{}, dd}
+	xml, err := xmlMarshallIndented(tmp)
 	if err != nil {
 		panic("could not marshall host")
 	}


### PR DESCRIPTION
Use `<host/>` instead of `<NetworkDHCPHost/>` as libvirt complains
about the latter.

Signed-off-by: Thomas Hipp <thipp@suse.de>