### PR TITLE
fix LibVirtPoolSync

### DIFF
--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -65,7 +65,11 @@ func (ci *defCloudInit) CreateAndUpload(virConn *libvirt.Connect) (string, error
 	}
 	defer pool.Free()
 
-	PoolSync.AcquireLock(ci.PoolName)
+	for {
+		if PoolSync.AcquireLock(ci.PoolName) {
+			break
+		}
+	}
 	defer PoolSync.ReleaseLock(ci.PoolName)
 
 	// Refresh the pool of the volume so that libvirt knows it is

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -69,6 +69,7 @@ func (ci *defCloudInit) CreateAndUpload(virConn *libvirt.Connect) (string, error
 		if PoolSync.AcquireLock(ci.PoolName) {
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	defer PoolSync.ReleaseLock(ci.PoolName)
 

--- a/libvirt/coreos_ignition_def.go
+++ b/libvirt/coreos_ignition_def.go
@@ -38,7 +38,11 @@ func (ign *defIgnition) CreateAndUpload(virConn *libvirt.Connect) (string, error
 	}
 	defer pool.Free()
 
-	PoolSync.AcquireLock(ign.PoolName)
+	for {
+		if PoolSync.AcquireLock(ign.PoolName) {
+			break
+		}
+	}
 	defer PoolSync.ReleaseLock(ign.PoolName)
 
 	// Refresh the pool of the volume so that libvirt knows it is

--- a/libvirt/coreos_ignition_def.go
+++ b/libvirt/coreos_ignition_def.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	libvirt "github.com/libvirt/libvirt-go"
 	"github.com/mitchellh/packer/common/uuid"
@@ -42,6 +43,7 @@ func (ign *defIgnition) CreateAndUpload(virConn *libvirt.Connect) (string, error
 		if PoolSync.AcquireLock(ign.PoolName) {
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	defer PoolSync.ReleaseLock(ign.PoolName)
 

--- a/libvirt/pool_sync.go
+++ b/libvirt/pool_sync.go
@@ -1,8 +1,6 @@
 package libvirt
 
-import (
-	"sync"
-)
+import "sync"
 
 // LVirtPoolSync makes possible to synchronize operations
 // against libvirt pools.
@@ -10,40 +8,49 @@ import (
 // a volume into the pool causes errors inside of libvirtd
 type LVirtPoolSync struct {
 	PoolLocks     map[string]*sync.Mutex
+	poolLocked    map[string]bool
 	internalMutex sync.Mutex
 }
 
 // NewLVirtPoolSync allocates a new instance of LVirtPoolSync
-func NewLVirtPoolSync() LVirtPoolSync {
+func NewLVirtPoolSync() *LVirtPoolSync {
 	pool := LVirtPoolSync{}
 	pool.PoolLocks = make(map[string]*sync.Mutex)
+	pool.poolLocked = make(map[string]bool)
 
-	return pool
+	return &pool
 }
 
-// AcquireLock acquires a lock for the specified pool
-func (ps LVirtPoolSync) AcquireLock(pool string) {
+// AcquireLock acquires a lock for the specified pool. If the mutex is already
+// locked, the method returns false, and does not block. It returns true, if
+// the lock could be acquired.
+func (ps *LVirtPoolSync) AcquireLock(pool string) bool {
 	ps.internalMutex.Lock()
 	defer ps.internalMutex.Unlock()
 
-	lock, exists := ps.PoolLocks[pool]
-	if !exists {
-		lock = new(sync.Mutex)
-		ps.PoolLocks[pool] = lock
+	if ps.PoolLocks[pool] == nil {
+		ps.PoolLocks[pool] = new(sync.Mutex)
+	} else {
+		if ps.poolLocked[pool] {
+			return false
+		}
 	}
 
-	lock.Lock()
+	ps.PoolLocks[pool].Lock()
+	ps.poolLocked[pool] = true
+
+	return true
 }
 
 // ReleaseLock releases the look for the specified pool
-func (ps LVirtPoolSync) ReleaseLock(pool string) {
+func (ps *LVirtPoolSync) ReleaseLock(pool string) {
 	ps.internalMutex.Lock()
 	defer ps.internalMutex.Unlock()
 
-	lock, exists := ps.PoolLocks[pool]
-	if !exists {
+	if ps.PoolLocks[pool] == nil {
 		return
 	}
 
-	lock.Unlock()
+	ps.PoolLocks[pool].Unlock()
+	ps.poolLocked[pool] = false
 }

--- a/libvirt/pool_sync.go
+++ b/libvirt/pool_sync.go
@@ -2,55 +2,56 @@ package libvirt
 
 import "sync"
 
-// LVirtPoolSync makes possible to synchronize operations
-// against libvirt pools.
-// Doing pool.Refresh() operations while uploading or removing
-// a volume into the pool causes errors inside of libvirtd
-type LVirtPoolSync struct {
-	PoolLocks     map[string]*sync.Mutex
-	poolLocked    map[string]bool
-	internalMutex sync.Mutex
+type LVirtPool struct {
+	sync.Mutex
+	locked bool
 }
 
-// NewLVirtPoolSync allocates a new instance of LVirtPoolSync
-func NewLVirtPoolSync() *LVirtPoolSync {
-	pool := LVirtPoolSync{}
-	pool.PoolLocks = make(map[string]*sync.Mutex)
-	pool.poolLocked = make(map[string]bool)
+// LVirtPoolSync makes possible to synchronize operations against libvirt
+// pools. Doing pool.Refresh() operations while uploading or removing a volume
+// into the pool causes errors inside of libvirtd.
+type LVirtPoolSync struct {
+	sync.Mutex
+	pools map[string]*LVirtPool
+}
 
-	return &pool
+// NewLVirtPoolSync allocates a new instance of LibVirtPoolSync.
+func NewLVirtPoolSync() *LVirtPoolSync {
+	return &LVirtPoolSync{
+		pools: make(map[string]*LVirtPool),
+	}
 }
 
 // AcquireLock acquires a lock for the specified pool. If the mutex is already
 // locked, the method returns false, and does not block. It returns true, if
 // the lock could be acquired.
 func (ps *LVirtPoolSync) AcquireLock(pool string) bool {
-	ps.internalMutex.Lock()
-	defer ps.internalMutex.Unlock()
+	ps.Lock()
+	defer ps.Unlock()
 
-	if ps.PoolLocks[pool] == nil {
-		ps.PoolLocks[pool] = new(sync.Mutex)
+	if ps.pools[pool] == nil {
+		ps.pools[pool] = &LVirtPool{}
 	} else {
-		if ps.poolLocked[pool] {
+		if ps.pools[pool].locked {
 			return false
 		}
 	}
 
-	ps.PoolLocks[pool].Lock()
-	ps.poolLocked[pool] = true
+	ps.pools[pool].Lock()
+	ps.pools[pool].locked = true
 
 	return true
 }
 
-// ReleaseLock releases the look for the specified pool
+// ReleaseLock releases the look for the specified pool.
 func (ps *LVirtPoolSync) ReleaseLock(pool string) {
-	ps.internalMutex.Lock()
-	defer ps.internalMutex.Unlock()
+	ps.Lock()
+	defer ps.Unlock()
 
-	if ps.PoolLocks[pool] == nil {
+	if ps.pools[pool] == nil {
 		return
 	}
 
-	ps.PoolLocks[pool].Unlock()
-	ps.poolLocked[pool] = false
+	ps.pools[pool].Unlock()
+	ps.pools[pool].locked = false
 }

--- a/libvirt/pool_sync_test.go
+++ b/libvirt/pool_sync_test.go
@@ -7,11 +7,7 @@ import (
 func TestAcquireLock(t *testing.T) {
 	ps := NewLVirtPoolSync()
 
-	ps.AcquireLock("test")
-
-	_, found := ps.PoolLocks["test"]
-
-	if !found {
+	if !ps.AcquireLock("test") {
 		t.Errorf("lock not found")
 	}
 }
@@ -19,28 +15,17 @@ func TestAcquireLock(t *testing.T) {
 func TestReleaseLock(t *testing.T) {
 	ps := NewLVirtPoolSync()
 
-	ps.AcquireLock("test")
-
-	_, found := ps.PoolLocks["test"]
-	if !found {
+	if !ps.AcquireLock("test") {
 		t.Errorf("lock not found")
 	}
 
 	ps.ReleaseLock("test")
-	_, found = ps.PoolLocks["test"]
-	if !found {
-		t.Errorf("lock not found")
-	}
 }
 
 func TestReleaseNotExistingLock(t *testing.T) {
 	ps := NewLVirtPoolSync()
 
 	ps.ReleaseLock("test")
-	_, found := ps.PoolLocks["test"]
-	if found {
-		t.Errorf("lock found")
-	}
 	// moreover there should be no runtime error because
 	// we are not trying to unlock a not-locked mutex
 }

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -90,7 +90,11 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 		poolName = d.Get("pool").(string)
 	}
 
-	PoolSync.AcquireLock(poolName)
+	for {
+		if PoolSync.AcquireLock(poolName) {
+			break
+		}
+	}
 	defer PoolSync.ReleaseLock(poolName)
 
 	pool, err := virConn.LookupStoragePoolByName(poolName)

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"
@@ -94,6 +95,7 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 		if PoolSync.AcquireLock(poolName) {
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	defer PoolSync.ReleaseLock(poolName)
 

--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -85,7 +85,11 @@ func RemoveVolume(virConn *libvirt.Connect, key string) error {
 		return fmt.Errorf("Error retrieving name of volume: %s", err)
 	}
 
-	PoolSync.AcquireLock(poolName)
+	for {
+		if PoolSync.AcquireLock(poolName) {
+			break
+		}
+	}
 	defer PoolSync.ReleaseLock(poolName)
 
 	WaitForSuccess("Error refreshing pool for volume", func() error {

--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -89,6 +89,7 @@ func RemoveVolume(virConn *libvirt.Connect, key string) error {
 		if PoolSync.AcquireLock(poolName) {
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	defer PoolSync.ReleaseLock(poolName)
 


### PR DESCRIPTION
Declare methods of LibVirtPoolSync as pointers since otherwise the
entire construct is ineffective. Callers of `AcquireLock` are now
responsible for making sure that the mutex is locked.

This will prevent the following errors:
	* fatal error: concurrent map writes
	* panic: sync: unlock of unlocked mutex

This fixes #121.

Signed-off-by: Thomas Hipp <thipp@suse.de>