### PR TITLE
Fix string format of network addresses

### DIFF
--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -381,7 +381,7 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 		prefix, _ := strconv.Atoi(address.Prefix)
 		mask := net.CIDRMask(prefix, bits)
 		network := addr.Mask(mask)
-		addresses = append(addresses, fmt.Sprintf("%s/%d", network, address.Prefix))
+		addresses = append(addresses, fmt.Sprintf("%s/%s", network, address.Prefix))
 	}
 	if len(addresses) > 0 {
 		d.Set("addresses", addresses)


### PR DESCRIPTION
Network addresses when trying to format the prefix as an int,
while it is a string

Fixes: #160