### PR TITLE
Adding support for arch and machine type

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -147,6 +147,14 @@ func resourceLibvirtDomain() *schema.Resource {
 				Optional: true,
 				Required: false,
 			},
+			"machine": &schema.Schema{
+			        Type: schema.TypeString,
+				Optional: true,
+			},
+			"arch": &schema.Schema{
+			        Type: schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -239,6 +247,9 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	domainDef.OS.Type.Arch = d.Get("arch").(string)
+	domainDef.OS.Type.Machine = d.Get("machine").(string)
+	
 	if firmware, ok := d.GetOk("firmware"); ok {
 		firmwareFile := firmware.(string)
 		if _, err := os.Stat(firmwareFile); os.IsNotExist(err) {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -50,6 +50,11 @@ The following arguments are supported:
 * `coreos_ignition` - (Optional) The
   [libvirt_ignition](/docs/providers/libvirt/r/coreos_ignition.html) resource
   that is to be used by the CoreOS domain.
+* `arch` - (Optional) The architecture for the VM (probably x86_64 or i686),
+  you normally won't need to set this unless you are building a special VM
+* `machine` - (Optional) The machine type,
+  you normally won't need to set this unless you are running on a platform that
+  defaults to the wrong machine type for your template 
 
 ### UEFI images
 


### PR DESCRIPTION
This adds support for setting the architecture and machine type
of the created virtual machine by adding two new attributes
machine and arch to the domain definition

Resubmitted after @monstermunchkin comments