### PR TITLE
domain: Add support for DomainBootDevice.

### DIFF
--- a/examples/boot/libvirt.tf
+++ b/examples/boot/libvirt.tf
@@ -1,0 +1,33 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+// blank 10GB image for net install.
+resource "libvirt_volume" "debian9-qcow2" {
+  name = "debian9-qcow2"
+  pool = "default"
+  format = "qcow2"
+  size = 10000000000
+}
+
+// set boot order hd, network
+resource "libvirt_domain" "domain-debian9-qcow2" {
+  name = "debian9"
+  memory = "1024"
+  vcpu = 1
+
+  network_interface {
+       bridge = "br0"
+       mac = "52:54:00:b2:2f:86"
+  }
+  boot_devices {
+      dev = [ "hd", "network"]
+  }
+  disk {
+       volume_id = "${libvirt_volume.debian9-qcow2.id}"
+  }
+  graphics {
+    type = "vnc"
+    listen_type = "address"
+  }
+}

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `machine` - (Optional) The machine type,
   you normally won't need to set this unless you are running on a platform that
   defaults to the wrong machine type for your template 
+* `boot_device` - (Optional) A list of devices (dev) which sets boot order
 
 ### UEFI images
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -55,7 +55,8 @@ The following arguments are supported:
 * `machine` - (Optional) The machine type,
   you normally won't need to set this unless you are running on a platform that
   defaults to the wrong machine type for your template 
-* `boot_device` - (Optional) A list of devices (dev) which sets boot order
+* `boot_device` - (Optional) A list of devices (dev) which defines boot order. Example
+   [below](#define-boot-device-order).
 
 ### UEFI images
 
@@ -404,6 +405,16 @@ This can be automated inside of `/etc/fstab`:
 ```hcl
 tmp /host/tmp 9p  trans=virtio,version=9p2000.L,rw  0 0
 proc /host/proc  9p  trans=virtio,version=9p2000.L,r  0 0
+```
+
+### Define Boot Device Order
+
+Set hd as default and fallback to network.
+
+```hcl
+boot_devices {
+  dev = [ "hd", "network"]
+}
 ```
 
 ## Attributes Reference


### PR DESCRIPTION
Hello, this PR adds support for defining DomainBootDevice. A usecase would be declaring the domain to hd boot by default then fallback to network as shown below.

usage
```
resource "libvirt_domain" "domain" {
    boot_device {
        dev = [ "hd", "network"]
    }
}
```
Thank you for your consideration.