### PR TITLE
FIX graphics autoport setting in examples

### DIFF
--- a/examples/format/libvirt.tf
+++ b/examples/format/libvirt.tf
@@ -66,6 +66,6 @@ resource "libvirt_domain" "domain-debian8-qcow2" {
   graphics {
     type = "spice"
     listen_type = "address"
-    autoport = true
+    autoport = "yes"
   }
 }

--- a/examples/uefi/libvirt.tf
+++ b/examples/uefi/libvirt.tf
@@ -33,6 +33,6 @@ resource "libvirt_domain" "domain" {
   graphics {
     type = "spice"
     listen_type = "address"
-    autoport = true
+    autoport = "yes"
   }
 


### PR DESCRIPTION

![screenshot from 2017-09-07 17-20-45](https://user-images.githubusercontent.com/3425238/30162091-f928a5e8-93f0-11e7-9596-b0ede738d9f2.png)
The examples are using spice for display with autoport value as
`true`. This causes no connection to VM display. In fact
any value except "yes" makes autoport to be set to "no" in the
VM XML configuration.