### PR TITLE
Adds fuller support for arch and machine settings

### DIFF
--- a/libvirt/utils_libvirt_test.go
+++ b/libvirt/utils_libvirt_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/xml"
 	"testing"
 
+	libvirt "github.com/libvirt/libvirt-go"
 	"github.com/libvirt/libvirt-go-xml"
+	"os"
 )
 
 func TestGetHostXMLDesc(t *testing.T) {
@@ -31,4 +33,82 @@ func TestGetHostXMLDesc(t *testing.T) {
 	if dd.Name != name {
 		t.Errorf("expected name %s, got %s", name, dd.Name)
 	}
+}
+
+func connect(t *testing.T) *libvirt.Connect {
+	conn, err := libvirt.NewConnect(os.Getenv("LIBVIRT_DEFAULT_URI"))
+	if err != nil {
+		t.Fatalf("Cannot connect")
+	}
+
+	return conn
+}
+
+func TestGetHostArchitecture(t *testing.T) {
+
+	conn := connect(t)
+	defer conn.Close()
+
+	arch, err := getHostArchitecture(conn)
+
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	t.Logf("[DEBUG] arch - %s", arch)
+
+	if arch == "" {
+		t.Errorf("arch is blank.")
+	}
+}
+
+func TestGetGuestMachines(t *testing.T) {
+	conn := connect(t)
+	defer conn.Close()
+
+	machines, err := getGuestMachines(conn, "x86_64")
+
+	if err != nil {
+		t.Log(err)
+		t.Fatalf("Could not get list of GuestMachines")
+	}
+
+	t.Logf("First is %s", machines[0].Name)
+}
+
+func TestGetCanonicalMachineName(t *testing.T) {
+
+	conn := connect(t)
+	defer conn.Close()
+	arch := "x86_64"
+	machine := "pc"
+	name, err := getCanonicalMachineName(conn, arch, machine)
+
+	if err != nil {
+		t.Errorf("Could not get canonical name for %s/%s", arch, machine)
+		return
+	}
+
+	t.Logf("Canonical name for %s/%s = %s", arch, machine, name)
+
+}
+
+func TestGetOriginalMachineName(t *testing.T) {
+	conn := connect(t)
+	defer conn.Close()
+	arch := "x86_64"
+	machine := "pc"
+	canonname, err := getCanonicalMachineName(conn, arch, machine)
+	if err != nil {
+		t.Error(err)
+	}
+	reversename, err := getOriginalMachineName(conn, arch, canonname)
+	if err != nil {
+		t.Error(err)
+	}
+	if reversename != machine {
+		t.Errorf("Cannot reverse canonical machine lookup")
+	}
+
+	t.Logf("Reverse canonical lookup for %s is %s which matches %s", canonname, reversename, machine)
 }


### PR DESCRIPTION
Allows updates to be tracked
Sets sensible defaults

Due to the way libvirt works if you specify machine types like pc,isapc
or q35 these get translated into 'canonical' forms, ie. the latest
version

When quering terraform will notice a change, as it would still be
looking for pc and will get something like pc-i440fx-2.9.
Code has been added to assume that if we see 'pc-i440fx-2.9' and it is
canonical for pc then we translate back to pc for terraform.
This could cause issues if you are specifically using pc-i440fx-2.9 as
the machine type in your terraform file.

The only other alternative was to translate pc > pc-i440fx-2.9 in
defDomain which would require a libvirt connection when one wouldn't
be available, this felt very hacky.