### PR TITLE
Full support for arch,machine & emulator settings

### DIFF
--- a/libvirt/utils_domain_def.go
+++ b/libvirt/utils_domain_def.go
@@ -1,0 +1,49 @@
+package libvirt
+
+import (
+	"fmt"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
+	"log"
+)
+
+func getGuestForArchType(caps libvirtxml.Caps, arch string, virttype string) (libvirtxml.CapsGuest, error) {
+	for _, guest := range caps.Guests {
+		log.Printf("[TRACE] Checking for %s/%s against %s/%s\n", arch, virttype, guest.Arch.Name, guest.OSType)
+		if guest.Arch.Name == arch && guest.OSType == virttype {
+			log.Printf("[DEBUG] Found %d machines in guest for %s/%s", len(guest.Arch.Machines), arch, virttype)
+			return guest, nil
+		}
+	}
+	return libvirtxml.CapsGuest{}, fmt.Errorf("[DEBUG] Could not find any guests for architecure type %s/%s", virttype, arch)
+}
+
+func getCanonicalMachineName(caps libvirtxml.Caps, arch string, virttype string, targetmachine string) (string, error) {
+	guest, err := getGuestForArchType(caps, arch, virttype)
+	if err != nil {
+		return "", err
+	}
+
+	for _, machine := range guest.Arch.Machines {
+		if machine.Name == targetmachine {
+			if machine.Canonical != nil {
+				return *machine.Canonical, nil
+			}
+			return machine.Name, nil
+		}
+	}
+	return "", fmt.Errorf("[WARN] Cannot find machine type %s for %s/%s in %v", targetmachine, virttype, arch, caps)
+}
+
+func getOriginalMachineName(caps libvirtxml.Caps, arch string, virttype string, targetmachine string) (string, error) {
+	guest, err := getGuestForArchType(caps, arch, virttype)
+	if err != nil {
+		return "", err
+	}
+
+	for _, machine := range guest.Arch.Machines {
+		if machine.Canonical != nil && *machine.Canonical == targetmachine {
+			return machine.Name, nil
+		}
+	}
+	return targetmachine, nil // There wasn't a canonical mapping to this
+}

--- a/libvirt/utils_libvirt.go
+++ b/libvirt/utils_libvirt.go
@@ -4,8 +4,10 @@ import (
 	"encoding/xml"
 	"log"
 
+	"errors"
+	"fmt"
 	libvirt "github.com/libvirt/libvirt-go"
-	"github.com/libvirt/libvirt-go-xml"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 func getHostXMLDesc(ip, mac, name string) string {
@@ -67,4 +69,17 @@ func getHostArchitecture(virConn *libvirt.Connect) (string, error) {
 	xml.Unmarshal([]byte(info), &capabilities)
 
 	return capabilities.Host.CPU.Arch, nil
+}
+
+func getHostCapabilities(virConn *libvirt.Connect) (libvirtxml.Caps, error) {
+	// We should perhaps think of storing this on the connect object
+	// on first call to avoid the back and forth
+	caps := libvirtxml.Caps{}
+	capsXML, err := virConn.GetCapabilities()
+	if err != nil {
+		return caps, err
+	}
+	xml.Unmarshal([]byte(capsXML), &caps)
+	log.Printf("[TRACE] Capabilities of host \n %+v", caps)
+	return caps, nil
 }

--- a/libvirt/utils_libvirt_test.go
+++ b/libvirt/utils_libvirt_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/xml"
 	"testing"
 
+	libvirt "github.com/libvirt/libvirt-go"
 	"github.com/libvirt/libvirt-go-xml"
+	"os"
 )
 
 func TestGetHostXMLDesc(t *testing.T) {
@@ -31,4 +33,82 @@ func TestGetHostXMLDesc(t *testing.T) {
 	if dd.Name != name {
 		t.Errorf("expected name %s, got %s", name, dd.Name)
 	}
+}
+
+func connect(t *testing.T) *libvirt.Connect {
+	conn, err := libvirt.NewConnect(os.Getenv("LIBVIRT_DEFAULT_URI"))
+	if err != nil {
+		t.Fatalf("Cannot connect")
+	}
+
+	return conn
+}
+
+func TestGetHostArchitecture(t *testing.T) {
+
+	conn := connect(t)
+	defer conn.Close()
+
+	arch, err := getHostArchitecture(conn)
+
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	t.Logf("[DEBUG] arch - %s", arch)
+
+	if arch == "" {
+		t.Errorf("arch is blank.")
+	}
+}
+
+func TestGetGuestMachines(t *testing.T) {
+	conn := connect(t)
+	defer conn.Close()
+
+	machines, err := getGuestMachines(conn, "x86_64")
+
+	if err != nil {
+		t.Log(err)
+		t.Fatalf("Could not get list of GuestMachines")
+	}
+
+	t.Logf("First is %s", machines[0].Name)
+}
+
+func TestGetCanonicalMachineName(t *testing.T) {
+
+	conn := connect(t)
+	defer conn.Close()
+	arch := "x86_64"
+	machine := "pc"
+	name, err := getCanonicalMachineName(conn, arch, machine)
+
+	if err != nil {
+		t.Errorf("Could not get canonical name for %s/%s", arch, machine)
+		return
+	}
+
+	t.Logf("Canonical name for %s/%s = %s", arch, machine, name)
+
+}
+
+func TestGetOriginalMachineName(t *testing.T) {
+	conn := connect(t)
+	defer conn.Close()
+	arch := "x86_64"
+	machine := "pc"
+	canonname, err := getCanonicalMachineName(conn, arch, machine)
+	if err != nil {
+		t.Error(err)
+	}
+	reversename, err := getOriginalMachineName(conn, arch, canonname)
+	if err != nil {
+		t.Error(err)
+	}
+	if reversename != machine {
+		t.Errorf("Cannot reverse canonical machine lookup")
+	}
+
+	t.Logf("Reverse canonical lookup for %s is %s which matches %s", canonname, reversename, machine)
 }

--- a/travis/setup-guest
+++ b/travis/setup-guest
@@ -13,7 +13,7 @@ while check_network ; [ $? -ne 0 ];do
 done
 
 apt-get -qq update
-apt-get install -y qemu libvirt-bin libvirt-dev golang-1.8 ovmf
+apt-get install -y qemu-system-common libvirt-bin libvirt-dev golang-1.8 ovmf
 echo -e "<pool type='dir'>\n<name>default</name>\n<target>\n<path>/pool-default</path>\n</target>\n</pool>" > pool.xml
 mkdir /pool-default
 chmod a+rwx /pool-default

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
   defaults to the wrong machine type for your template 
 * `boot_device` - (Optional) A list of devices (dev) which defines boot order. Example
    [below](#define-boot-device-order).
+* `emulator` - (Optional) The path of the emulator to use
 
 ### UEFI images
 


### PR DESCRIPTION
Sorry for new PR, couldn't seem to reopen #174 

Add emulator setting support

Completes support from arch and machine when reading current status

Adds a new function newDomainDefForConnection that takes
a domainDef and populates with defaults from the current host
which is more sensible than guessing across distributions

Maps canonical machine types <> actual to avoid changes

Due to the way libvirt works if you specific machine types like pc,isapc
or q35 these get translated into 'canonical' forms, ie. the latest
version

When quering terraform will notice a change, as it would still be
looking for pc and will get something like pc-i440fx-2.9.
Code has been added to assume that if we see 'pc-i440fx-2.9' and it is
canonical for pc then we translate back to pc for terraform.
This could cause issues if you are specifically using pc-i440fx-2.9 as
the machine type in your terraform file.