### PR TITLE
We don't need to force format here

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -365,7 +365,6 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 			},
 			Driver: &libvirtxml.DomainDiskDriver{
 				Name: "qemu",
-				Type: "qcow2",
 			},
 		}
 


### PR DESCRIPTION
Hi,

The format should be specified on volume creation, this reset the utilization of raw format, and kvm is supposed to be anyway able to detect a disk format if not specified.

Best regards,