### PR TITLE
Bugfix: let libvirt populate channel source

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -44,9 +44,6 @@ func newDomainDef() libvirtxml.Domain {
 			Channels: []libvirtxml.DomainChannel{
 				libvirtxml.DomainChannel{
 					Type: "unix",
-					Source: &libvirtxml.DomainChardevSource{
-						Mode: "bind",
-					},
 					Target: &libvirtxml.DomainChannelTarget{
 						Type: "virtio",
 						Name: "org.qemu.guest_agent.0",


### PR DESCRIPTION
Current behavior is to set the source path to empty string, which blocks the Guest Agent from working correctly.