### PR TITLE
Improve readme with information that are not implicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ dependencies.
 Ensure you have latest version of Go installed on your system, terraform usually
 takes advantage of fetures available only inside of the latest stable release.
 
+You need also need libvirt-dev(el) package installed.
+
 Run `go install` to build the binary. You will now find the binary at
 `$GOPATH/bin/terraform-provider-libvirt`.
 

--- a/README.md
+++ b/README.md
@@ -89,23 +89,15 @@ export TF_ACC=1
 go test ./...
 ```
 
-## Known Problems
+## Troubleshooting (aka you have a problem)
 
-* There is a [bug in libvirt](https://bugzilla.redhat.com/show_bug.cgi?id=1293804) that seems to be causing
-  problems to unlink volumes. Tracked [here](https://github.com/dmacvicar/terraform-provider-libvirt/issues/6).
+Have a look at [TROUBLESHOOTING](doc/TROUBLESHOOTING.md), and feel free to add a PR if you find out something is missing.
 
-  If you see something like:
-
-  ```console
-  cannot unlink file '/var/lib/libvirt/images/XXXXXXXXXXXX': Permission denied
-  ```
-  It is probably related and fixed in libvirt 1.3.3 (already available in openSUSE Tumbleweed).
-
-* On Ubuntu distros SELinux is enforced by qemu even if it is disabled globally, this might cause unexpected `Could not open '/var/lib/libvirt/images/<FILE_NAME>': Permission denied` errors. Double check that `security_driver = "none"` is uncommented in `/etc/libvirt/qemu.conf` and issue `sudo systemctl restart libvirt-bin` to restart the daemon.
-
-## Author
+## Authors
 
 * Duncan Mac-Vicar P. <dmacvicar@suse.de>
+
+See also the list of [contributors](https://github.com/dmacvicar/terraform-provider-libvirt/graphs/contributors) who participated in this project.
 
 The structure and boilerplate is inspired from the [Softlayer](https://github.com/finn-no/terraform-provider-softlayer) and [Google](https://github.com/hashicorp/terraform/tree/master/builtin/providers/google) Terraform provider sources.
 

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -1,0 +1,43 @@
+# Troubleshooting
+
+## You cannot build from source
+
+You run 
+
+```console
+glide install
+go build 
+```
+And you get:
+
+```console
+Package libvirt was not found in the pkg-config search path.
+Perhaps you should add the directory containing `libvirt.pc'
+to the PKG_CONFIG_PATH environment variable
+No package 'libvirt' found
+pkg-config: exit status 1
+```
+
+You probably need libvirt-dev(el) package installed.
+
+```console 
+apt install libvirt-dev
+```
+
+## Bug in libvirt
+
+* There is a [bug in libvirt](https://bugzilla.redhat.com/show_bug.cgi?id=1293804) that seems to be causing
+  problems to unlink volumes. Tracked [here](https://github.com/dmacvicar/terraform-provider-libvirt/issues/6).
+
+  If you see something like:
+
+  ```console
+  cannot unlink file '/var/lib/libvirt/images/XXXXXXXXXXXX': Permission denied
+  ```
+  It is probably related and fixed in libvirt 1.3.3 (already available in openSUSE Tumbleweed).
+
+## Selinux on Debian distros
+
+* On Debian distros SELinux is enforced by qemu even if it is disabled globally, this might cause unexpected `Could not open '/var/lib/libvirt/images/<FILE_NAME>': Permission denied` errors. Double check that `security_driver = "none"` is uncommented in `/etc/libvirt/qemu.conf` and issue `sudo systemctl restart libvirt-bin` to restart the daemon.
+
+


### PR DESCRIPTION
Added troubleshooting for libvirt-devel pkg that is a requirement.
Seperate some doc from readme, referenced;
and finally, added a small reference about the contributors on author section

Read this [here](https://github.com/MalloZup/terraform-provider-libvirt/tree/impr-layout#troubleshooting-aka-you-have-a-problem)

A good readme is always encouraging new contributors.