### PR TITLE
Enable gofmt check for golang pkg on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
   - sudo bash ./travis/setup-host
   - sudo lxc exec libvirt -- bash /code/travis/setup-guest
 script:
+  - bash ./travis/gofmtcheck.sh
   - sudo lxc exec libvirt -- bash /code/travis/run-tests-inside-guest
   - sudo lxc file pull libvirt/root/go/src/github.com/dmacvicar/terraform-provider-libvirt/profile.cov .
   - goveralls -coverprofile=profile.cov -service=travis-ci

--- a/libvirt/utils_domain_def.go
+++ b/libvirt/utils_domain_def.go
@@ -34,7 +34,6 @@ func getCanonicalMachineName(caps libvirtxml.Caps, arch string, virttype string,
 	return "", fmt.Errorf("[WARN] Cannot find machine type %s for %s/%s in %v", targetmachine, virttype, arch, caps)
 }
 
-
 func getOriginalMachineName(caps libvirtxml.Caps, arch string, virttype string, targetmachine string) (string, error) {
 	guest, err := getGuestForArchType(caps, arch, virttype)
 	if err != nil {

--- a/libvirt/utils_libvirt_test.go
+++ b/libvirt/utils_libvirt_test.go
@@ -71,11 +71,11 @@ func TestGetCanonicalMachineName(t *testing.T) {
 	virttype := "hvm"
 	machine := "pc"
 
-	caps,err := getHostCapabilities(conn)
+	caps, err := getHostCapabilities(conn)
 	if err != nil {
 		t.Error(err)
 	}
-	
+
 	name, err := getCanonicalMachineName(caps, arch, virttype, machine)
 
 	if err != nil {
@@ -93,7 +93,7 @@ func TestGetOriginalMachineName(t *testing.T) {
 	virttype := "hvm"
 	machine := "pc"
 
-	caps,err := getHostCapabilities(conn)
+	caps, err := getHostCapabilities(conn)
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,7 +117,7 @@ func TestGetHostCapabilties(t *testing.T) {
 	start := time.Now()
 	conn := connect(t)
 	defer conn.Close()
-	caps,err := getHostCapabilities(conn)
+	caps, err := getHostCapabilities(conn)
 	if err != nil {
 		t.Errorf("Can't get host capabilties")
 	}

--- a/travis/gofmtcheck.sh
+++ b/travis/gofmtcheck.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+GOPKG="libvirt"
+
+lint_pkg () {
+  cd $1
+  echo "*** checking pkg $1 with gofmt"
+  if [ -n "$(go fmt ./...)" ]; then
+    echo "Go code on pkg $1 is   not formatted well, run 'go fmt on pkg $1'" 
+    exit 1
+  fi
+  echo " pkg $1 has no lint gofmt errors!"
+  cd ..
+}
+
+lint_main () {
+  echo '*** running gofmt on main.go'
+  if [ -n "$(go fmt main.go)" ]; then
+    echo "Go code on main.go is not formatted,  please run 'go fmt main.go'" 
+    exit 1
+  fi
+}
+
+echo "==> Checking that code complies with gofmt requirements..."
+lint_pkg $GOPKG
+echo 
+lint_main
+echo '==> go fmt OK !!! ***'
+exit 0


### PR DESCRIPTION
add a check gofmt for PR. 

For the time beeing this is for libvirt pkg golang only (since there is only 1 pkg atm)