### PR TITLE
Dont print debug info if tests are ok

### DIFF
--- a/libvirt/disk_def_test.go
+++ b/libvirt/disk_def_test.go
@@ -14,28 +14,20 @@ func init() {
 
 func TestDefaultDiskMarshall(t *testing.T) {
 	b := newDefDisk()
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed default disk:\n%s", prettyB)
-
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(b); err != nil {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
-	t.Logf("Marshalled default disk:\n%s", buf.String())
 }
 
 func TestDefaultCDROMMarshall(t *testing.T) {
 	b := newCDROM()
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed default cdrom:\n%s", prettyB)
-
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(b); err != nil {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
-	t.Logf("Marshalled default cdrom:\n%s", buf.String())
 }

--- a/libvirt/domain_def_test.go
+++ b/libvirt/domain_def_test.go
@@ -14,14 +14,10 @@ func init() {
 
 func TestDefaultDomainMarshall(t *testing.T) {
 	b := newDomainDef()
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed default domain:\n%s", prettyB)
-
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(b); err != nil {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
-	t.Logf("Marshalled default domain:\n%s", buf.String())
 }

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -16,16 +16,12 @@ func init() {
 
 func TestDefaultNetworkMarshall(t *testing.T) {
 	b := newNetworkDef()
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed default network:\n%s", prettyB)
-
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(b); err != nil {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
-	t.Logf("Marshalled default network:\n%s", buf.String())
 }
 
 func TestNetworkDefUnmarshall(t *testing.T) {
@@ -64,8 +60,6 @@ func TestNetworkDefUnmarshall(t *testing.T) {
 	`
 
 	b, err := newDefNetworkFromXML(text)
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed:\n%s", prettyB)
 	if err != nil {
 		t.Errorf("could not parse: %s", err)
 	}
@@ -87,10 +81,9 @@ func TestNetworkDefUnmarshall(t *testing.T) {
 	if len(b.IPs) == 0 {
 		t.Errorf("wrong number of IPs: %d", len(b.IPs))
 	}
-	if bs, err := xmlMarshallIndented(b); err != nil {
+	_, err2 := xmlMarshallIndented(b)
+	if err2 != nil {
 		t.Fatalf("marshalling error\n%s", spew.Sdump(b))
-	} else {
-		t.Logf("Marshalled:\n%s", bs)
 	}
 }
 

--- a/libvirt/volume_def_test.go
+++ b/libvirt/volume_def_test.go
@@ -52,17 +52,14 @@ func TestVolumeUnmarshal(t *testing.T) {
 	</volume>
 	`
 
-	def, err := newDefVolumeFromXML(xmlDesc)
+	_, err := newDefVolumeFromXML(xmlDesc)
 	if err != nil {
 		t.Fatalf("could not unmarshall volume definition:\n%s", err)
 	}
-	t.Logf("Unmarshalled volume:\n%s", spew.Sdump(def))
 }
 
 func TestDefaultVolumeMarshall(t *testing.T) {
 	b := newDefVolume()
-	prettyB := spew.Sdump(b)
-	t.Logf("Parsed default volume:\n%s", prettyB)
 
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
@@ -70,5 +67,4 @@ func TestDefaultVolumeMarshall(t *testing.T) {
 	if err := enc.Encode(b); err != nil {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
-	t.Logf("Marshalled default volume:\n%s", buf.String())
 }


### PR DESCRIPTION
the main motivation for this pr, is that we don't need debug info for a passing tests.

When a test fail we are looking for debug info. Otherwise debug a failed test become more diffult with noisy and non relevant information.
**Note:*** i removed only the bigdumps, this took a lot of lines, like more then 13 lines pro test, the 2-3 lines debug are ok imho, but i can remove them of course, but i think they are fine.

I was thinking to having an extra env. variable for printing debug info, but this complicate the whole design for a testsuite.
Imho a testsuite acceptance, should be simple as possible, for maintaining it longterm.
When a test fail, we have debug infos, otherwise the tests are there only for catching regression, so if it pass we don't need extra infos. ( we just want that they pass before merging pr).

Additional extra info on a test, from my POV is a code-smell, in a sense that there is either a lack of an addtional test, or the test is doing to much. (additional info when passing )

Thx for any review and feedback