### PR TITLE
Supports disks from the network using QEMU curl backend

### DIFF
--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -9,7 +9,7 @@ import (
 
 const oui = "05abcd"
 
-func newDefDisk() libvirtxml.DomainDisk {
+func newDefDisk(i int) libvirtxml.DomainDisk {
 	return libvirtxml.DomainDisk{
 		Type:   "file",
 		Device: "disk",

--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -1,6 +1,7 @@
 package libvirt
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/libvirt/libvirt-go-xml"
@@ -14,6 +15,7 @@ func newDefDisk() libvirtxml.DomainDisk {
 		Device: "disk",
 		Target: &libvirtxml.DomainDiskTarget{
 			Bus: "virtio",
+			Dev: fmt.Sprintf("vd%s", DiskLetterForIndex(i)),
 		},
 		Driver: &libvirtxml.DomainDiskDriver{
 			Name: "qemu",

--- a/libvirt/disk_def_test.go
+++ b/libvirt/disk_def_test.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 func TestDefaultDiskMarshall(t *testing.T) {
-	b := newDefDisk()
+	b := newDefDisk(0)
 	buf := new(bytes.Buffer)
 	enc := xml.NewEncoder(buf)
 	enc.Indent("  ", "    ")

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -368,18 +368,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	var disks []libvirtxml.DomainDisk
 	var scsiDisk = false
 	for i := 0; i < disksCount; i++ {
-		disk := libvirtxml.DomainDisk{
-			Type:   "file",
-			Device: "disk",
-			Target: &libvirtxml.DomainDiskTarget{
-				Bus: "virtio",
-				Dev: fmt.Sprintf("vd%s", DiskLetterForIndex(i)),
-			},
-			Driver: &libvirtxml.DomainDiskDriver{
-				Name: "qemu",
-				Type: "qcow2",
-			},
-		}
+		disk := newDefDisk()
 
 		diskKey := fmt.Sprintf("disk.%d", i)
 		diskMap := d.Get(diskKey).(map[string]interface{})

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -368,7 +368,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	var disks []libvirtxml.DomainDisk
 	var scsiDisk = false
 	for i := 0; i < disksCount; i++ {
-		disk := newDefDisk()
+		disk := newDefDisk(i)
 
 		diskKey := fmt.Sprintf("disk.%d", i)
 		diskMap := d.Get(diskKey).(map[string]interface{})

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -203,14 +203,14 @@ func TestAccLibvirtDomain_ScsiDisk(t *testing.T) {
 
 }
 
-func TestAccLibvirtDomainUrlDisk(t *testing.T) {
+func TestAccLibvirtDomainURLDisk(t *testing.T) {
 	var domain libvirt.Domain
 	u, err := url.Parse("http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso")
 	if err != nil {
 		t.Error(err)
 	}
 
-	var configUrl = fmt.Sprintf(`
+	var configURL = fmt.Sprintf(`
             resource "libvirt_domain" "acceptance-test-domain" {
                     name = "terraform-test-domain"
                     disk {
@@ -224,10 +224,10 @@ func TestAccLibvirtDomainUrlDisk(t *testing.T) {
 		CheckDestroy: testAccCheckLibvirtDomainDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: configUrl,
+				Config: configURL,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain", &domain),
-					testAccCheckLibvirtUrlDisk(u, &domain),
+					testAccCheckLibvirtURLDisk(u, &domain),
 				),
 			},
 		},
@@ -623,7 +623,7 @@ func testAccCheckLibvirtScsiDisk(n string, domain *libvirt.Domain) resource.Test
 	}
 }
 
-func testAccCheckLibvirtUrlDisk(u *url.URL, domain *libvirt.Domain) resource.TestCheckFunc {
+func testAccCheckLibvirtURLDisk(u *url.URL, domain *libvirt.Domain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		xmlDesc, err := domain.GetXMLDesc(0)
 		if err != nil {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -143,7 +143,12 @@ resource "libvirt_domain" "my_machine" {
 
 The `disk` block supports:
 
-* `volume_id` - (Required) The volume id to use for this disk.
+* `volume_id` - (Optional) The volume id to use for this disk.
+* `url` - (Optional) The http url to use as the block device for this disk (read-only)
+
+While both `volume_id` and `url` are optional, it is intended that you use either a volume or a
+url.
+
 * `scsi` - (Optional) Use a scsi controller for this disk.  The controller
 model is set to `virtio-scsi`
 * `wwn` - (Optional) Specify a WWN to use for the disk if the disk is using
@@ -166,6 +171,10 @@ resource "libvirt_domain" "domain1" {
   disk {
     volume_id = "${libvirt_volume.mydisk.id}"
     scsi = "yes"
+  }
+
+  disk {
+    url = "http://foo.com/install.iso"
   }
 }
 ```


### PR DESCRIPTION
QEMU supports a [http url for a block device](https://git.qemu.org/?p=qemu.git;a=blob;f=block/curl.c).

This can be used from the command line:

```console
qemu-kvm -m 1G -drive media=cdrom,driver=raw,node-name=cdrom,file.driver=http,file.url=http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso
```

and from libvirt

```xml
<disk type='network' device='cdrom'>
    <driver name='qemu' type='raw'/>
    <source protocol="http" name="url_path">
      <host name="hostname" port="80"/>
    </source>
    <target dev='hde' bus='ide' tray='open'/>
    <readonly/>
  </disk>
```
This PR allows to add a disk to a domain like this:

```hcl
disk {
  url = "http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso"
}
```

Which, combined with boot order:

```hcl
  boot_device {
      dev = [ "cdrom", "hd", "network"]
  }
```

Allows you to boot directly from a remote ISO, without the need to load it into the libvirt pool.
