### PR TITLE
check uniqueness of storage volume name

### DIFF
--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -2,6 +2,7 @@ package libvirt
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -104,6 +105,32 @@ func TestAccLibvirtVolume_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_volume.terraform-acceptance-test-1", "size", "1073741824"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtVolume_UniqueName(t *testing.T) {
+	const config = `
+	resource "libvirt_volume" "terraform-acceptance-test-1" {
+		name = "terraform-test"
+		size =  1073741824
+	}
+
+	resource "libvirt_volume" "terraform-acceptance-test-2" {
+		name = "terraform-test"
+		size =  1073741824
+	}
+	`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`storage volume 'terraform-test' already exists`),
 			},
 		},
 	})


### PR DESCRIPTION
The storage volume name needs to be unique. If this is not the case, the
storage volume will be overwritten which is not problematic itself.
However, `terraform destroy` will fail since it will try and delete the
same storage volume twice.

Consider the following example:
```hcl
provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_volume" "disk_1" {
  name   = "vol_1"
  source = "http://example.org/image.qcow2"
}

resource "libvirt_volume" "disk_2" {
  name   = "vol_1"
  source = "http://example.org/image.qcow2"
}
```

Running `terraform apply` works perfectly. However, running `terraform destroy`
would fail with the below message if the uniqueness were to be ignored.
```
Storage volume not found: no storage vol with matching name 'vol_1'
```

Signed-off-by: Thomas Hipp <thipp@suse.de>