### PR TITLE
support local cdroms

### DIFF
--- a/libvirt/disk_def.go
+++ b/libvirt/disk_def.go
@@ -24,21 +24,6 @@ func newDefDisk(i int) libvirtxml.DomainDisk {
 	}
 }
 
-func newCDROM() libvirtxml.DomainDisk {
-	return libvirtxml.DomainDisk{
-		Type:   "file",
-		Device: "cdrom",
-		Target: &libvirtxml.DomainDiskTarget{
-			Dev: "hda",
-			Bus: "ide",
-		},
-		Driver: &libvirtxml.DomainDiskDriver{
-			Name: "qemu",
-			Type: "raw",
-		},
-	}
-}
-
 func randomWWN(strlen int) string {
 	const chars = "abcdef0123456789"
 	result := make([]byte, strlen)

--- a/libvirt/disk_def_test.go
+++ b/libvirt/disk_def_test.go
@@ -21,13 +21,3 @@ func TestDefaultDiskMarshall(t *testing.T) {
 		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
 	}
 }
-
-func TestDefaultCDROMMarshall(t *testing.T) {
-	b := newCDROM()
-	buf := new(bytes.Buffer)
-	enc := xml.NewEncoder(buf)
-	enc.Indent("  ", "    ")
-	if err := enc.Encode(b); err != nil {
-		t.Fatalf("could not marshall this:\n%s", spew.Sdump(b))
-	}
-}

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -290,9 +290,15 @@ func TestAccLibvirtDomainKernelInitrdCmdline(t *testing.T) {
 func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 	var domain libvirt.Domain
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+
 	var config = fmt.Sprintf(`
-	resource "libvirt_volume" "acceptance-test-volume" {
-		name = "terraform-test"
+	resource "libvirt_network" "acceptance-test-network" {
+		name      = "terraform-test"
+		addresses = ["10.17.3.0/24"]
 	}
 
 	resource "libvirt_domain" "acceptance-test-domain" {
@@ -303,11 +309,12 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 		network_interface = {
 			network_name = "default"
 			mac          = "52:54:00:A9:F5:17"
+			wait_for_lease = 1
 		}
 		disk {
-			volume_id = "${libvirt_volume.acceptance-test-volume.id}"
+			file = "%s/testdata/tcl.iso"
 		}
-	}`)
+	}`, currentDir)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/travis/setup-guest
+++ b/travis/setup-guest
@@ -20,3 +20,6 @@ mkdir /pool-default
 chmod a+rwx /pool-default
 virsh pool-define pool.xml
 virsh pool-start default
+echo -e 'user = "root"\ngroup = "root"' >> /etc/libvirt/qemu.conf
+systemctl restart libvirtd
+

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -237,9 +237,9 @@ The `disk` block supports:
 
 * `volume_id` - (Optional) The volume id to use for this disk.
 * `url` - (Optional) The http url to use as the block device for this disk (read-only)
+* `file` - (Optional) The filename to use as the block device for this disk (read-only)
 
-While both `volume_id` and `url` are optional, it is intended that you use either a volume or a
-url.
+While `volume_id`, `url` and `file` are optional, it is intended that you use one of them.
 
 * `scsi` - (Optional) Use a scsi controller for this disk.  The controller
 model is set to `virtio-scsi`
@@ -267,6 +267,10 @@ resource "libvirt_domain" "domain1" {
 
   disk {
     url = "http://foo.com/install.iso"
+  }
+
+  disk {
+    file = "/absolute/path/to/disk.iso"
   }
 }
 ```


### PR DESCRIPTION
Local cdroms can now be added directly to the domain. See the
following example:

```hcl
resource "libvirt_domain" "test-domain" {
    name = "test"

    disk {
	file = "path/to/file.iso"
    }
}
```

Furthermore, a small Tiny Core Linux (TCL) ISO image has been added to
the testdata. This can be used for testing purposes.

Signed-off-by: Thomas Hipp <thipp@suse.de>