### PR TITLE
Added support for importing domain, network, and volume

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -42,6 +42,9 @@ func resourceLibvirtDomain() *schema.Resource {
 		Delete: resourceLibvirtDomainDelete,
 		Update: resourceLibvirtDomainUpdate,
 		Exists: resourceLibvirtDomainExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -916,3 +916,39 @@ func TestAccLibvirtDomain_ArchType(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLibvirtDomain_Import(t *testing.T) {
+	var domain libvirt.Domain
+	var config = fmt.Sprintf(`
+	resource "libvirt_domain" "acceptance-test-domain-2" {
+		name   = "terraform-test"
+		memory = 384
+		vcpu   = 2
+	}`)
+
+	resourceName := "libvirt_domain.acceptance-test-domain-2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+			resource.TestStep{
+				ResourceName: resourceName,
+				ImportState:  true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain-2", &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain-2", "name", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain-2", "memory", "384"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain.acceptance-test-domain-2", "vcpu", "2"),
+				),
+			},
+		},
+	})
+}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -42,6 +42,9 @@ func resourceLibvirtNetwork() *schema.Resource {
 		Delete: resourceLibvirtNetworkDelete,
 		Exists: resourceLibvirtNetworkExists,
 		Update: resourceLibvirtNetworkUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -102,7 +102,7 @@ func testAccCheckLibvirtNetworkDestroy(s *terraform.State) error {
 func TestAccLibvirtNetwork_Import(t *testing.T) {
 	var network libvirt.Network
 
-	const config = fmt.Sprintf(`
+	const config = `
 	resource "libvirt_network" "test_net" {
 		name      = "networktest"
 		mode      = "nat"

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -98,3 +98,35 @@ func testAccCheckLibvirtNetworkDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+func TestAccLibvirtNetwork_Import(t *testing.T) {
+	var network libvirt.Network
+
+	const config = fmt.Sprintf(`
+	resource "libvirt_network" "test_net" {
+		name      = "networktest"
+		mode      = "nat"
+		domain    = "k8s.local"
+		addresses = ["10.17.3.0/24"]
+	}`
+
+	resourceName := "libvirt_network.test_net"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+			resource.TestStep{
+				ResourceName: resourceName,
+				ImportState:  true,
+				Check: resource.ComposeTestCheckFunc(
+					networkExists("libvirt_network.test_net", &network),
+				),
+			},
+		},
+	})
+}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -64,6 +64,9 @@ func resourceLibvirtVolume() *schema.Resource {
 		Read:   resourceLibvirtVolumeRead,
 		Delete: resourceLibvirtVolumeDelete,
 		Schema: volumeCommonSchema(),
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -196,11 +196,15 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckLibvirtVolumeConfigImport,
+			},
+			resource.TestStep{
 				ResourceName: resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			}
+			resource.TestStep{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-3", &volume),
 					resource.TestCheckResourceAttr(
@@ -210,7 +214,7 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_volume.terraform-acceptance-test-3", "format", "raw"),
 				),
-			},
+			}
 		},
 	})
 }

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -184,9 +184,9 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 
 	const testAccCheckLibvirtVolumeConfigImport = `
 	resource "libvirt_volume" "terraform-acceptance-test-4" {
-		name   = "terraform-test"
-		format = "raw"
-		size   =  1073741824
+			name   = "terraform-test"
+			format = "raw"
+			size   =  1073741824
 	}`
 
 	resourceName := "libvirt_volume.terraform-acceptance-test-4"
@@ -201,20 +201,15 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 			},
 			resource.TestStep{
 				ResourceName: resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			}
-			resource.TestStep{
+				ImportState:  true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-3", &volume),
+					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-4", &volume),
 					resource.TestCheckResourceAttr(
-						"libvirt_volume.terraform-acceptance-test-3", "name", "terraform-test"),
+						"libvirt_volume.terraform-acceptance-test-4", "name", "terraform-test"),
 					resource.TestCheckResourceAttr(
-						"libvirt_volume.terraform-acceptance-test-3", "size", "1073741824"),
-					resource.TestCheckResourceAttr(
-						"libvirt_volume.terraform-acceptance-test-3", "format", "raw"),
+						"libvirt_volume.terraform-acceptance-test-4", "size", "1073741824"),
 				),
-			}
+			},
 		},
 	})
 }

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -178,3 +178,39 @@ func TestAccLibvirtVolume_Format(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLibvirtVolume_Import(t *testing.T) {
+	var volume libvirt.StorageVol
+
+	const testAccCheckLibvirtVolumeConfigImport = `
+	resource "libvirt_volume" "terraform-acceptance-test-4" {
+		name   = "terraform-test"
+		format = "raw"
+		size   =  1073741824
+	}`
+
+	resourceName := "libvirt_volume.terraform-acceptance-test-4"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLibvirtVolumeConfigImport,
+				ResourceName: resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume.terraform-acceptance-test-3", &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "name", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "size", "1073741824"),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume.terraform-acceptance-test-3", "format", "raw"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Added Terraform import functionality
Usage:
```
# terraform import libvirt_domain.<name>   <UUID>
# terraform import libvirt_volume.<name>   <path to volume>
# terraform import libvirt_network.<name>   <UUID>
```