### PR TITLE
Fix support for raw volumes

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -422,6 +422,10 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 				return fmt.Errorf("Error retrieving volume file: %s", err)
 			}
 
+			if !strings.HasSuffix(diskVolumeFile, ".qcow2") {
+				disk.Driver.Type = "raw"
+			}
+
 			disk.Source = &libvirtxml.DomainDiskSource{
 				File: diskVolumeFile,
 			}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -120,6 +120,10 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	volumeDef.Target.Format.Type = volumeFormat
 
+	if volumeFormat == "qcow2" {
+		volumeDef.Name = fmt.Sprintf("%s.qcow2", volumeDef.Name)
+	}
+
 	var (
 		img    image
 		volume *libvirt.StorageVol


### PR DESCRIPTION
Hey,

thanks for this nice project. I use it currently very heavily. I found a bug when I try to use `raw` volumes then I got the following message:

```console
* libvirt_domain.template: Error creating libvirt domain: virError(Code=1, Domain=10, Message='internal error: process exited while connecting to monitor: 2017-12-11T19:57:09.278580Z qemu-system-x86_64: -drive file=/var/lib/libvirt/images/template_docker,format=qcow2,if=none,id=drive-virtio-disk1: Image is not in qcow2 format')
```

The problem is that the image is correctly converted as raw image, but the libvirt definition is not correct and assumes that it's an qcow2 image.

My solution is to check the file extension like you do when using a volume from url. Futhermore I added the file exentsion to qcow2 volumes so that anything except qcow2 will be defined as raw.

