### PR TITLE
fix difference detection when using an existing bridge network

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -1069,6 +1069,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		case "bridge":
 			netIface["bridge"] = networkInterfaceDef.Source.Bridge
+			netIface["network_name"] = networkInterfaceDef.Source.Network
 		case "direct":
 			{
 				switch networkInterfaceDef.Source.Mode {


### PR DESCRIPTION
given the terraform:

```json
resource "libvirt_domain" "myvm" {
  network_interface {
    bridge = "some-bridge"
    network_name = "existing-bridge-network"
  }
}
```

`terraform plan` would always think it needs to re-apply the domain