### PR TITLE
domain: honor arch, machine, and emulator settings

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -1,9 +1,11 @@
 package libvirt
 
 import (
+	"os"
+
+	"github.com/hashicorp/terraform/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
-	"os"
 )
 
 func newFilesystemDef() libvirtxml.DomainFilesystem {
@@ -20,9 +22,7 @@ func newDomainDef() libvirtxml.Domain {
 	domainDef := libvirtxml.Domain{
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
-				Type:    "hvm",
-				Arch:    "x86_64",
-				Machine: "pc",
+				Type: "hvm",
 			},
 		},
 		Memory: &libvirtxml.DomainMemory{
@@ -75,8 +75,19 @@ func newDomainDef() libvirtxml.Domain {
 	return domainDef
 }
 
-func newDomainDefForConnection(virConn *libvirt.Connect) (libvirtxml.Domain, error) {
+func newDomainDefForConnection(virConn *libvirt.Connect, rd *schema.ResourceData) (libvirtxml.Domain, error) {
 	d := newDomainDef()
+
+	if arch, ok := rd.GetOk("arch"); ok {
+		d.OS.Type.Arch = arch.(string)
+	} else {
+		arch, err := getHostArchitecture(virConn)
+		if err != nil {
+			return d, err
+		}
+		d.OS.Type.Arch = arch
+	}
+
 	caps, err := getHostCapabilities(virConn)
 	if err != nil {
 		return d, err
@@ -86,7 +97,17 @@ func newDomainDefForConnection(virConn *libvirt.Connect) (libvirtxml.Domain, err
 		return d, err
 	}
 
-	d.Devices.Emulator = guest.Arch.Emulator
+	if emulator, ok := rd.GetOk("emulator"); ok {
+		d.Devices.Emulator = emulator.(string)
+	} else {
+		d.Devices.Emulator = guest.Arch.Emulator
+	}
+
+	if machine, ok := rd.GetOk("machine"); ok {
+		d.OS.Type.Machine = machine.(string)
+	} else if len(guest.Arch.Machines) > 0 {
+		d.OS.Type.Machine = guest.Arch.Machines[0].Name
+	}
 
 	canonicalmachine, err := getCanonicalMachineName(caps, d.OS.Type.Arch, d.OS.Type.Type, d.OS.Type.Machine)
 	if err != nil {


### PR DESCRIPTION
The settings 'arch', 'machine', and 'emulator' should be honored. The
default values have been removed. Instead, if not provided, the values
are determined by consulting libvirt directly.

This fixes #262.

Signed-off-by: Thomas Hipp <thipp@suse.de>