### PR TITLE
Allow for specifying custom meta-data for the cloud-init image.

### DIFF
--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -34,6 +34,12 @@ func resourceCloudInit() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"meta_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"ssh_authorized_key": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -53,6 +59,7 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 	cloudInit := newCloudInitDef()
 	cloudInit.MetaData.LocalHostname = d.Get("local_hostname").(string)
 	cloudInit.UserDataRaw = d.Get("user_data").(string)
+	cloudInit.MetaDataRaw = d.Get("meta_data").(string)
 
 	if _, ok := d.GetOk("ssh_authorized_key"); ok {
 		sshKey := d.Get("ssh_authorized_key").(string)
@@ -96,6 +103,7 @@ func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", ci.Name)
 	d.Set("local_hostname", ci.MetaData.LocalHostname)
 	d.Set("user_data", ci.UserDataRaw)
+	d.Set("meta_data", ci.MetaDataRaw)
 
 	if len(ci.UserData.SSHAuthorizedKeys) == 1 {
 		d.Set("ssh_authorized_key", ci.UserData.SSHAuthorizedKeys[0])

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -36,5 +36,9 @@ The following arguments are supported:
   be merged automatically with the values specified in other arguments
   (like `local_hostname`, `ssh_authorized_key`, etc). The contents of
   `user_data` will take precedence over the ones defined by the other keys.
+* `meta_data` - (Optional) Raw cloud-init meta data. This content will
+  be merged automatically with the values specified in other arguments
+  (like `local_hostname`, `ssh_authorized_key`, etc). The contents of
+  `meta_data` will take precedence over the ones defined by the other keys.
 
 Any change of the above fields will cause a new resource to be created.


### PR DESCRIPTION
Works exactly the same way as specifying custom user-data does.