### PR TITLE
Modify cloudinit to use 'mkisofs' instead of 'genisoimage'.

### DIFF
--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -150,7 +150,7 @@ func (ci *defCloudInit) createISO() (string, error) {
 
 	isoDestination := filepath.Join(tmpDir, ci.Name)
 	cmd := exec.Command(
-		"genisoimage",
+		"mkisofs",
 		"-output",
 		isoDestination,
 		"-volid",


### PR DESCRIPTION
genisoimage was debian's fork of mkisofs so the two are compatible, but mkisofs is available on more OS (e.g. macOS via brew). The genisoimage Ubuntu package at least installs 'mkisofs' also.