### PR TITLE
Add Website Docs to front page and provide a nice ubuntu example in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ servers on a [libvirt](https://libvirt.org/) host via [Terraform](https://terraf
 - [CloudInit](website/docs/r/cloudinit.html.markdown)
 - [CoreOS Ignition](website/docs/r/coreos_ignition.html.markdown)
 - [Domains](website/docs/r/domain.html.markdown)
-- [Networks](website/docs/r/network.html.markdown)
+- [Networks](website/docs/r/network.markdown)
 - [Volumes](website/docs/r/volume.html.markdown)
 
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ servers on a [libvirt](https://libvirt.org/) host via [Terraform](https://terraf
 - [How to contribute](doc/CONTRIBUTING.md)
 
 ## Webiste Docs
-- [Libvirt Provider](website/docs/index.html.mardown)
-- [CloudInit](website/docs/r/cloudinit.html.mardown)
-- [CoreOS Ignition](website/docs/r/coreos_ignition.html.mardown)
-- [Domains](website/docs/r/domain.html.mardown)
-- [Networks](website/docs/r/network.html.mardown)
-- [Volumes](website/docs/r/volume.html.mardown)
+- [Libvirt Provider](website/docs/index.html.markdown)
+- [CloudInit](website/docs/r/cloudinit.html.markdown)
+- [CoreOS Ignition](website/docs/r/coreos_ignition.html.markdown)
+- [Domains](website/docs/r/domain.html.markdown)
+- [Networks](website/docs/r/network.html.markdown)
+- [Volumes](website/docs/r/volume.html.markdown)
 
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ servers on a [libvirt](https://libvirt.org/) host via [Terraform](https://terraf
 - [Building from source](#building-from-source)
 - [How to contribute](doc/CONTRIBUTING.md)
 
-## Webiste Docs
+## Website Docs
 - [Libvirt Provider](website/docs/index.html.markdown)
 - [CloudInit](website/docs/r/cloudinit.html.markdown)
 - [CoreOS Ignition](website/docs/r/coreos_ignition.html.markdown)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ servers on a [libvirt](https://libvirt.org/) host via [Terraform](https://terraf
 - [Building from source](#building-from-source)
 - [How to contribute](doc/CONTRIBUTING.md)
 
+## Webiste Docs
+- [Libvirt Provider](website/docs/index.html.mardown)
+- [CloudInit](website/docs/r/cloudinit.html.mardown)
+- [CoreOS Ignition](website/docs/r/coreos_ignition.html.mardown)
+- [Domains](website/docs/r/domain.html.mardown)
+- [Networks](website/docs/r/network.html.mardown)
+- [Volumes](website/docs/r/volume.html.mardown)
 
 
 ## Installing

--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -1,0 +1,68 @@
+# instance the provider
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+# We fetch the latest ubuntu release image from their mirrors
+resource "libvirt_volume" "ubuntu-qcow2" {
+  name = "ubuntu-qcow2"
+  pool = "default"
+  source = "https://cloud-images.ubuntu.com/releases/xenial/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img"
+  format = "qcow2"
+}
+
+# Create a network for our VMs
+resource "libvirt_network" "vm_network" {
+   name = "vm_network"
+   addresses = ["10.0.1.0/24"]
+}
+
+# Use CloudInit to add our ssh-key to the instance
+resource "libvirt_cloudinit" "commoninit" {
+          name           = "commoninit.iso"
+          ssh_authorized_key = "<ssh-key-here>"
+        }
+
+
+# Create the machine
+resource "libvirt_domain" "domain-ubuntu" {
+  name = "ubuntu-terraform"
+  memory = "512"
+  vcpu = 1
+
+  cloudinit = "${libvirt_cloudinit.commoninit.id}"
+
+  network_interface {
+    network_name = "vm_network"
+  }
+
+  # IMPORTANT
+  # Ubuntu can hang is a isa-serial is not present at boot time.
+  # If you find your CPU 100% and never is available this is why
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  console {
+      type        = "pty"
+      target_type = "virtio"
+      target_port = "1"
+  }
+
+  disk {
+       volume_id = "${libvirt_volume.ubuntu-qcow2.id}"
+  }
+  graphics {
+    type = "spice"
+    listen_type = "address"
+    autoport = "yes"
+  }
+}
+
+# Print the Boxes IP
+# Note: you can use `virsh domifaddr <vm_name> <interface>` to get the ip later
+output "ip" {
+  value = "${libvirt_domain.domain-ubuntu.network_interface.0.addresses.0}"
+}


### PR DESCRIPTION
Really love this provider. I spent a bit too long looking for the docs (in website). The docs are not on the terraform site yet (not sure if this has been submitted as a community provider?). 

I add links to website docs to the README and I also added an example for ubuntu, it has a section for the isa-serial bug with ubuntu cloud images and shows how to use cloudinit resource which was missing too.