### PR TITLE
Handle keyword-less kernel params

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -992,7 +992,14 @@ func setCmdlineArgs(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 	var cmdlineArgs []string
 	for i := 0; i < d.Get("cmdline.#").(int); i++ {
 		for k, v := range d.Get(fmt.Sprintf("cmdline.%d", i)).(map[string]interface{}) {
-			cmdlineArgs = append(cmdlineArgs, fmt.Sprintf("%s=%v", k, v))
+			var cmd string
+			if k == "_" {
+				// keyless cmd (eg: nosplash)
+				cmd = fmt.Sprintf("%v", v)
+			} else {
+				cmd = fmt.Sprintf("%s=%v", k, v)
+			}
+			cmdlineArgs = append(cmdlineArgs, cmd)
 		}
 	}
 	sort.Strings(cmdlineArgs)

--- a/libvirt/utils_domain_def.go
+++ b/libvirt/utils_domain_def.go
@@ -60,8 +60,16 @@ func splitKernelCmdLine(cmdLine string) ([]map[string]string, error) {
 	}
 
 	currCmdLine := make(map[string]string)
+	keylessCmdLineArgs := []string{}
+
 	argVals := strings.Split(cmdLine, " ")
 	for _, argVal := range argVals {
+		if !strings.Contains(argVal, "=") {
+			// keyless cmd line (eg: nosplash)
+			keylessCmdLineArgs = append(keylessCmdLineArgs, argVal)
+			continue
+		}
+
 		kv := strings.Split(argVal, "=")
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("Can't parse kernel command line: '%s'", cmdLine)
@@ -76,6 +84,11 @@ func splitKernelCmdLine(cmdLine string) ([]map[string]string, error) {
 	}
 	if len(currCmdLine) > 0 {
 		cmdLines = append(cmdLines, currCmdLine)
+	}
+	if len(keylessCmdLineArgs) > 0 {
+		cl := make(map[string]string)
+		cl["_"] = strings.Join(keylessCmdLineArgs, " ")
+		cmdLines = append(cmdLines, cl)
 	}
 	return cmdLines, nil
 }

--- a/libvirt/utils_domain_def_test.go
+++ b/libvirt/utils_domain_def_test.go
@@ -12,8 +12,8 @@ func init() {
 }
 
 func TestSplitKernelCmdLine(t *testing.T) {
-	e := []map[string]string{{"foo": "bar"}, {"foo": "bar", "key": "val"}}
-	r, err := splitKernelCmdLine("foo=bar foo=bar key=val")
+	e := []map[string]string{{"foo": "bar"}, {"foo": "bar", "key": "val"}, {"_": "nosplash rw"}}
+	r, err := splitKernelCmdLine("foo=bar foo=bar key=val nosplash rw")
 	if !reflect.DeepEqual(r, e) {
 		t.Fatalf("got='%s' expected='%s'", spew.Sdump(r), spew.Sdump(e))
 	}

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -85,7 +85,7 @@ resource "libvirt_domain" "domain-suse" {
 }
 ```
 
-* `kernel` - (Optional) The path of the initrd to boot.
+* `initrd` - (Optional) The path of the initrd to boot.
 
 You can use it in the same way as the kernel.
 
@@ -102,9 +102,14 @@ resource "libvirt_domain" "domain-suse" {
   cmdline {
     arg1 = "value1"
     arg2 = "value2"
+    "_" = "rw nosplash"
   }
 }
 ```
+
+Kernel params that don't have a keyword identifier can be specified using the
+special `"_"` keyword. Multiple keyword-less params have to be specified using
+the same `"_"` keyword, like in the example above.
 
 Also note that the `cmd` block is actually a list of maps, so it is possible to
 declare several of them by using either the literal list and map syntax as in
@@ -150,6 +155,10 @@ resource "libvirt_domain" "my_machine" {
   }
 }
 ```
+
+~> **Note well:** `kernel` and `initrd` have to be specified at the same time; `cmdline`
+   arguments can be specified only when `kernel` and `initrd` have been defined.
+   Otherwise libvirt will refuse to start the domain.
 
 ### UEFI images
 


### PR DESCRIPTION
Allow kernel params that don't have a key/value structure to be handled.
