### PR TITLE
Fix broken tests due to incorrect usage of t.Skip()

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -871,7 +871,7 @@ func TestAccLibvirtDomainFirmware(t *testing.T) {
 	if _, err := os.Stat(firmware); os.IsNotExist(err) {
 		firmware = "/usr/share/ovmf/OVMF.fd"
 		if _, err := os.Stat(firmware); os.IsNotExist(err) {
-			t.Skip("Can't test domain custom firmware: OVMF firmware not found: %s")
+			t.Skipf("Can't test domain custom firmware: OVMF firmware not found: %s", err)
 		}
 	}
 
@@ -879,7 +879,7 @@ func TestAccLibvirtDomainFirmware(t *testing.T) {
 	if _, err := os.Stat(template); os.IsNotExist(err) {
 		template = "/usr/share/qemu/OVMF.fd"
 		if _, err := os.Stat(template); os.IsNotExist(err) {
-			t.Skip("Can't test domain custom firmware template: OVMF template not found: %s")
+			t.Skipf("Can't test domain custom firmware template: OVMF template not found: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Current tests were broken with the following error:

    # github.com/dmacvicar/terraform-provider-libvirt/libvirt
    libvirt/resource_libvirt_domain_test.go:874: Skip call has possible formatting directive %s
    libvirt/resource_libvirt_domain_test.go:882: Skip call has possible formatting directive %s
    FAIL	github.com/dmacvicar/terraform-provider-libvirt/libvirt [build failed]

t.Skip with formatting should be t.Skipf()