### PR TITLE
supporting virtio-scsi image disk

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -407,6 +407,18 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 
+		if _, ok := diskMap["driver_type"].(string); ok {
+			disk.Driver.Type = diskMap["driver_type"].(string)
+		}
+
+		// support scsi drive for virtio-scsi
+		if scsiDisk {
+			disk.Target = &libvirtxml.DomainDiskTarget{
+				Bus: "scsi",
+				Dev: fmt.Sprintf("sd%s", DiskLetterForIndex(i)),
+			}
+		}
+
 		if _, ok := diskMap["volume_id"].(string); ok {
 			volumeKey := diskMap["volume_id"].(string)
 


### PR DESCRIPTION
in some cause, people want to use sd? as dev name
```
<devices>
 <disk type='file' device='disk'>
  <target dev='sda' bus='scsi'/>
  <address type='drive' controller='0' bus='0' target='0' unit='0'/>
 </disk>
 <controller type='scsi' index='0' model='virtio-scsi'/>
</devices>
```

and
say if you create a raw image, and want to use it on domain, it will failure due to default domain xml only support qcow2, 
```
1 error(s) occurred:

* libvirt_domain.fopd-tst1088-lab1: 1 error(s) occurred:

* libvirt_domain.fopd-tst1088-lab1: Error creating libvirt domain: virError(Code=1, Domain=10, Message='internal error: qemu unexpectedly closed the monitor: 2018-03-09T17:35:26.716475Z qemu-kvm: -drive file=/data/raid/sda/images/tst00.lab1-0,format=qcow2,if=none,id=drive-scsi0-0-0-0: Image is not in qcow2 format')
```
with config support like this
```
  disk {
       volume_id = "${libvirt_volume.fopd-tst0023-lab1-0.id}",
       driver_type = "raw",
       scsi = true
  }
```
