### PR TITLE
add Makefile cleanup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,8 @@ golint:
 gofmtcheck:
 	bash travis/run-gofmt
 
+
+clean:
+	./travis/cleanup.sh
+
 .PHONY: build install test vet fmt golint

--- a/travis/cleanup.sh
+++ b/travis/cleanup.sh
@@ -4,7 +4,7 @@ echo "--> Cleanup Domains"
 sudo virsh list --all | (grep -E "terraform-test|acceptance-test" || :) | awk '{print $2}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh destroy {}; sudo virsh undefine {}'
 
 echo "--> Cleanup Networks"
-sudo virsh net-list --all | (grep "acceptance-test-network|test_net" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh net-destroy {}; sudo virsh net-undefine {}'
+sudo virsh net-list --all | (grep -E "acceptance-test-network|test-net" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh net-destroy {}; sudo virsh net-undefine {}'
 
 echo "--> Cleanup Volumes"
-sudo virsh vol-list --pool default | (grep -E "terraform-acceptance-test*" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh vol-delete --pool default {}'
+sudo virsh vol-list --pool default | (grep -E "terraform-acceptance-test|ignition" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh vol-delete --pool default {}'

--- a/travis/cleanup.sh
+++ b/travis/cleanup.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+echo "--> Cleanup Domains"
+sudo virsh list --all | (grep -E "terraform-test|acceptance-test" || :) | awk '{print $2}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh destroy {}; sudo virsh undefine {}'
+
+echo "--> Cleanup Networks"
+sudo virsh net-list --all | (grep "acceptance-test-network|test_net" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh net-destroy {}; sudo virsh net-undefine {}'
+
+echo "--> Cleanup Volumes"
+sudo virsh vol-list --pool default | (grep -E "terraform-acceptance-test*" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh vol-delete --pool default {}'


### PR DESCRIPTION
This is usefull when tests fails and you need to remove the unclean resources that hangs on your systems

I dunno if i covered all possibly resources that we create during tests, i would propose that if make cleanup doesn't clean up, the name can be added  later