### PR TITLE
Add cloud-init support for the network-config file.

### DIFF
--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -34,6 +34,11 @@ func resourceCloudInit() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"network_config": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"ssh_authorized_key": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -53,6 +58,7 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 	cloudInit := newCloudInitDef()
 	cloudInit.MetaData.LocalHostname = d.Get("local_hostname").(string)
 	cloudInit.UserDataRaw = d.Get("user_data").(string)
+	cloudInit.NetworkConfigRaw = d.Get("network_config").(string)
 
 	if _, ok := d.GetOk("ssh_authorized_key"); ok {
 		sshKey := d.Get("ssh_authorized_key").(string)
@@ -96,6 +102,7 @@ func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", ci.Name)
 	d.Set("local_hostname", ci.MetaData.LocalHostname)
 	d.Set("user_data", ci.UserDataRaw)
+	d.Set("network_config", ci.NetworkConfigRaw)
 
 	if len(ci.UserData.SSHAuthorizedKeys) == 1 {
 		d.Set("ssh_authorized_key", ci.UserData.SSHAuthorizedKeys[0])

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -36,5 +36,11 @@ The following arguments are supported:
   be merged automatically with the values specified in other arguments
   (like `local_hostname`, `ssh_authorized_key`, etc). The contents of
   `user_data` will take precedence over the ones defined by the other keys.
+* `network_config` - (Optional) Raw NoCloud network-config data.
+  The content of this will be placed into the network-config file directly
+  in the root of the iso. This allows you to specify static networking
+  configurations (such as static IPs and DNS) that are applied from early
+  boot.  See:
+  http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html#datasource-nocloud
 
 Any change of the above fields will cause a new resource to be created.


### PR DESCRIPTION
This allows creating static and custom networking configurations.

Re-opening #270 with documentation added.