### PR TITLE
UEFI/OVMF booting: Don't check for existance of firmware/NVRAM

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -1016,9 +1015,6 @@ func setCmdlineArgs(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 func setFirmware(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 	if firmware, ok := d.GetOk("firmware"); ok {
 		firmwareFile := firmware.(string)
-		if _, err := os.Stat(firmwareFile); os.IsNotExist(err) {
-			return fmt.Errorf("could not find firmware file '%s'", firmwareFile)
-		}
 		domainDef.OS.Loader = &libvirtxml.DomainLoader{
 			Path:     firmwareFile,
 			Readonly: "yes",
@@ -1028,15 +1024,9 @@ func setFirmware(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 
 		if _, ok := d.GetOk("nvram.0"); ok {
 			nvramFile := d.Get("nvram.0.file").(string)
-			if _, err := os.Stat(nvramFile); os.IsNotExist(err) {
-				return fmt.Errorf("could not find nvram file '%s'", nvramFile)
-			}
 			nvramTemplateFile := ""
 			if nvramTemplate, ok := d.GetOk("nvram.0.template"); ok {
 				nvramTemplateFile = nvramTemplate.(string)
-				if _, err := os.Stat(nvramTemplateFile); os.IsNotExist(err) {
-					return fmt.Errorf("could not find nvram template file '%s'", nvramTemplateFile)
-				}
 			}
 			domainDef.OS.NVRam = &libvirtxml.DomainNVRam{
 				NVRam:    nvramFile,


### PR DESCRIPTION
This check fails if we're provisioning on a remote libvirt instance
as the files won't exist on the local machine anyway.
This is a rebase of #268.