### PR TITLE
Decouple definition of subnet addresses from definition of DHCP range

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -229,8 +229,10 @@ func getDomainInterfacesFromNetworks(domain libvirtxml.Domain,
 		networkDef, err := newDefNetworkfromLibvirt(network)
 		macAddresses := make(map[string][]string)
 		for _, ips := range networkDef.IPs {
-			for _, dhcpHost := range ips.DHCP.Hosts {
-				macAddresses[dhcpHost.MAC] = append(macAddresses[dhcpHost.MAC], dhcpHost.IP)
+			if ips.DHCP != nil {
+				for _, dhcpHost := range ips.DHCP.Hosts {
+					macAddresses[dhcpHost.MAC] = append(macAddresses[dhcpHost.MAC], dhcpHost.IP)
+				}
 			}
 		}
 		networkMacAddresses[networkName] = macAddresses

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -24,8 +24,14 @@ resource "libvirt_network" "kube_network" {
   #  the domain used by the DNS server in this network
   domain = "k8s.local"
 
-  # the addresses allowed for domains connected and served by the DHCP server
+  # the addresses allowed for domains connected
+  # also derived to define the host addresses
+  # also derived to define the addresses served by the DHCP server
   addresses = ["10.17.3.0/24", "2001:db8:ca2:2::1/64"]
+
+  # (optional) start a DHCP server or not
+  # defaults to true
+  # enable_dhcp = false
 
   # (optional) the bridge device defines the name of a bridge device
   # which will be used to construct the virtual network.
@@ -48,8 +54,16 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
 * `domain` - The domain used by the DNS server.
-* `addresses` - A list of (0 or 1) ipv4 and (0 or 1) ipv6 subnets in CIDR notation
-  format for being served by the DHCP server. Address of subnet should be used.
+* `addresses` - A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in
+  CIDR notation.  This defines the subnets associated to that network.
+  This argument is also used to define the address on the real host,
+  by appending `.1` at the end.  Finally, if `enable_dhcp` is true,
+  this argument is also used to define the address range served by
+  the DHCP server, between `.2` and the last but one address
+  in the subnet (`.254` for a `/24`).
+* `enable_dhcp` - A boolean (`true` or `false`). If true, a DHCP server will
+  be put in place to serve addresses on that network. If not specified,
+  `true` is assumed.  For it to have an effect, `addresses` must be used.
 * `mode` -  One of:
     - `none`: the guests can talk to each other and the host OS, but cannot reach
     any other machines on the LAN.


### PR DESCRIPTION
### What does this PR do? ###
If no addresses are declared for a network, then the bridge to the network does not get an IP address on the real host, making the network (and the VMs using it) unreacheable from the real host.

If addresses are declared, then a DHCP server is started on the network, but this is not always wished.

This PR adds a new `dhcp` boolean flag, that lets someone, in conjunction with existing `addresses` list, set up an address for the bridge while not starting a DHCP server. This flag defaults to `true`, thus keeping compatibility with existing `main.tf` files.

### Example ###
This setup:
```
(...)
resource "libvirt_network" "private_network" {
  name = "mynetwork"
  mode = "none"
  addresses = [ "192.168.75.0/24" ]
  dhcp = false
}
(...)
```
results in:
```
# virsh net-dumpxml mynetwork
<network connections='1'>
  <name>mynetwork</name>
  <uuid>10de3502-198d-482e-8034-5cc1950905d3</uuid>
  <bridge name='virbr2' stp='on' delay='0'/>
  <mac address='52:54:00:86:59:bd'/>
  <ip family='ipv4' address='192.168.75.1' prefix='24'>
  </ip>
</network>
```

Please notice the absence of unwanted:
```
    <dhcp>
      <range start='192.168.75.2' end='192.168.75.254'/>
    </dhcp>
```

The bridge gets an IP address as expected:
```
# ip address show
64: virbr2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:86:59:bd brd ff:ff:ff:ff:ff:ff
    inet 192.168.75.1/24 brd 192.168.75.255 scope global virbr2
       valid_lft forever preferred_lft forever
```
