### PR TITLE
Support multiple provider instances with different URIs (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ $ terraform destroy
 
 Look at more advanced examples [here](examples/)
 
+### Using multiple hypervisors / provider instances
+
+You can target different libvirt hosts instantiating the [provider multiple times](https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances). [Example](examples/multiple).
+
 ## Troubleshooting (aka you have a problem)
 
 Have a look at [TROUBLESHOOTING](doc/TROUBLESHOOTING.md), and feel free to add a PR if you find out something is missing.

--- a/examples/multiple/main.tf
+++ b/examples/multiple/main.tf
@@ -1,0 +1,42 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+provider "libvirt" {
+  alias = "remotehost"
+  uri = "qemu+ssh://root@remotehost-p1.qa.suse.de/system"
+}
+
+resource "libvirt_volume" "local-qcow2" {
+  name = "local-qcow2"
+  pool = "default"
+  format = "qcow2"
+  size = 100000
+}
+
+resource "libvirt_volume" "remotehost-qcow2" {
+  provider = "libvirt.remotehost"
+  name = "remotehost-qcow2"
+  pool = "default"
+  format = "qcow2"
+  size = 100000
+}
+
+resource "libvirt_domain" "local-domain" {
+  name = "local"
+  memory = "2048"
+  vcpu = 2
+  disk {
+    volume_id = "${libvirt_volume.local-qcow2.id}"
+  }
+}
+
+resource "libvirt_domain" "remotehost-domain" {
+  provider = "libvirt.remotehost"
+  name = "remotehost"
+  memory = "2048"
+  vcpu = 2
+  disk {
+    volume_id = "${libvirt_volume.remotehost-qcow2.id}"
+  }
+}

--- a/libvirt/config.go
+++ b/libvirt/config.go
@@ -1,9 +1,9 @@
 package libvirt
 
 import (
-	"log"
-
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	libvirt "github.com/libvirt/libvirt-go"
+	"log"
 )
 
 // Config struct for the libvirt-provider
@@ -13,25 +13,22 @@ type Config struct {
 
 // Client libvirt
 type Client struct {
-	libvirt *libvirt.Connect
+	libvirt     *libvirt.Connect
+	poolMutexKV *mutexkv.MutexKV
 }
 
 // Client libvirt, generate libvirt client given URI
 func (c *Config) Client() (*Client, error) {
-	var err error
-
-	if LibvirtClient == nil {
-		LibvirtClient, err = libvirt.NewConnect(c.URI)
-		if err != nil {
-			return nil, err
-		}
+	libvirtClient, err := libvirt.NewConnect(c.URI)
+	if err != nil {
+		return nil, err
 	}
+	log.Println("[INFO] Created libvirt client")
 
 	client := &Client{
-		libvirt: LibvirtClient,
+		libvirt:     libvirtClient,
+		poolMutexKV: mutexkv.NewMutexKV(),
 	}
-
-	log.Println("[INFO] Created libvirt client")
 
 	return client, nil
 }

--- a/libvirt/coreos_ignition_def.go
+++ b/libvirt/coreos_ignition_def.go
@@ -31,15 +31,15 @@ func newIgnitionDef() defIgnition {
 // Create a ISO file based on the contents of the CloudInit instance and
 // uploads it to the libVirt pool
 // Returns a string holding terraform's internal ID of this resource
-func (ign *defIgnition) CreateAndUpload(virConn *libvirt.Connect) (string, error) {
-	pool, err := virConn.LookupStoragePoolByName(ign.PoolName)
+func (ign *defIgnition) CreateAndUpload(client *Client) (string, error) {
+	pool, err := client.libvirt.LookupStoragePoolByName(ign.PoolName)
 	if err != nil {
 		return "", fmt.Errorf("can't find storage pool '%s'", ign.PoolName)
 	}
 	defer pool.Free()
 
-	poolMutexKV.Lock(ign.PoolName)
-	defer poolMutexKV.Unlock(ign.PoolName)
+	client.poolMutexKV.Lock(ign.PoolName)
+	defer client.poolMutexKV.Unlock(ign.PoolName)
 
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
@@ -88,7 +88,7 @@ func (ign *defIgnition) CreateAndUpload(virConn *libvirt.Connect) (string, error
 	defer volume.Free()
 
 	// upload ignition file
-	err = img.Import(newCopier(virConn, volume, volumeDef.Capacity.Value), volumeDef)
+	err = img.Import(newCopier(client.libvirt, volume, volumeDef.Capacity.Value), volumeDef)
 	if err != nil {
 		return "", fmt.Errorf("Error while uploading ignition file %s: %s", img.String(), err)
 	}

--- a/libvirt/resource_cloud_init.go
+++ b/libvirt/resource_cloud_init.go
@@ -45,7 +45,8 @@ func resourceCloudInit() *schema.Resource {
 
 func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] creating cloudinit")
-	virConn := meta.(*Client).libvirt
+	client := meta.(*Client)
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -66,7 +67,7 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] cloudInit: %+v", cloudInit)
 
-	key, err := cloudInit.CreateAndUpload(virConn)
+	key, err := cloudInit.CreateAndUpload(client)
 	if err != nil {
 		return err
 	}
@@ -105,8 +106,8 @@ func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
-	virConn := meta.(*Client).libvirt
-	if virConn == nil {
+	client := meta.(*Client)
+	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
 
@@ -115,5 +116,5 @@ func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return RemoveVolume(virConn, key)
+	return RemoveVolume(client, key)
 }

--- a/libvirt/resource_libvirt_coreos_ignition.go
+++ b/libvirt/resource_libvirt_coreos_ignition.go
@@ -35,8 +35,8 @@ func resourceIgnition() *schema.Resource {
 
 func resourceIgnitionCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] creating ignition file")
-	virConn := meta.(*Client).libvirt
-	if virConn == nil {
+	client := meta.(*Client)
+	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
 
@@ -48,7 +48,7 @@ func resourceIgnitionCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] ignition: %+v", ignition)
 
-	key, err := ignition.CreateAndUpload(virConn)
+	key, err := ignition.CreateAndUpload(client)
 	if err != nil {
 		return err
 	}
@@ -82,8 +82,8 @@ func resourceIgnitionRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIgnitionDelete(d *schema.ResourceData, meta interface{}) error {
-	virConn := meta.(*Client).libvirt
-	if virConn == nil {
+	client := meta.(*Client)
+	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
 
@@ -92,5 +92,5 @@ func resourceIgnitionDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return RemoveVolume(virConn, key)
+	return RemoveVolume(client, key)
 }

--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	libvirt "github.com/libvirt/libvirt-go"
 )
 
 var diskLetters = []rune("abcdefghijklmnopqrstuvwxyz")
@@ -65,8 +64,8 @@ func xmlMarshallIndented(b interface{}) (string, error) {
 }
 
 // RemoveVolume removes the volume identified by `key` from libvirt
-func RemoveVolume(virConn *libvirt.Connect, key string) error {
-	volume, err := virConn.LookupStorageVolByKey(key)
+func RemoveVolume(client *Client, key string) error {
+	volume, err := client.libvirt.LookupStorageVolByKey(key)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve volume %s", key)
 	}
@@ -85,8 +84,8 @@ func RemoveVolume(virConn *libvirt.Connect, key string) error {
 		return fmt.Errorf("Error retrieving name of volume: %s", err)
 	}
 
-	poolMutexKV.Lock(poolName)
-	defer poolMutexKV.Unlock(poolName)
+	client.poolMutexKV.Lock(poolName)
+	defer client.poolMutexKV.Unlock(poolName)
 
 	WaitForSuccess("Error refreshing pool for volume", func() error {
 		return volPool.Refresh(0)

--- a/main.go
+++ b/main.go
@@ -9,22 +9,7 @@ import (
 )
 
 func main() {
-	defer func() {
-		if libvirt.LibvirtClient != nil {
-			alive, err := libvirt.LibvirtClient.IsAlive()
-			if err != nil {
-				log.Printf("[ERROR] cannot determine libvirt connection status: %v", err)
-			}
-			if alive {
-				ret, err := libvirt.LibvirtClient.Close()
-				if err != nil {
-					log.Printf("[ERROR] cannot close libvirt connection %d - %v", ret, err)
-				} else {
-					libvirt.LibvirtClient = nil
-				}
-			}
-		}
-	}()
+	defer libvirt.CleanupLibvirtConnections()
 
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: libvirt.Provider,


### PR DESCRIPTION
Terraform supports this using
https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances

The current code had global connection and mutex instances that prevented this from
working correctly.

While the global objects and mutexes are gone with this PR, we still reuse the client per URI, in order to get the same mutex for the same hypervisor, and then close all opened connections at the end.

All global data is moved into the Client instance.

Fixes: https://github.com/dmacvicar/terraform-provider-libvirt/issues/290