### PR TITLE
examples: Fix 'autoport' value from string to boolean

### DIFF
--- a/examples/format/libvirt.tf
+++ b/examples/format/libvirt.tf
@@ -66,6 +66,6 @@ resource "libvirt_domain" "domain-debian8-qcow2" {
   graphics {
     type = "spice"
     listen_type = "address"
-    autoport = "yes"
+    autoport = true
   }
 }

--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -57,7 +57,7 @@ resource "libvirt_domain" "domain-ubuntu" {
   graphics {
     type = "spice"
     listen_type = "address"
-    autoport = "yes"
+    autoport = true
   }
 }
 

--- a/examples/uefi/libvirt.tf
+++ b/examples/uefi/libvirt.tf
@@ -33,6 +33,6 @@ resource "libvirt_domain" "domain" {
   graphics {
     type = "spice"
     listen_type = "address"
-    autoport = "yes"
+    autoport = true
   }
 


### PR DESCRIPTION
The schema was changed to require a boolean value for the 'autoport'
argument. Fixes the following error:

Error: libvirt_domain.domain-ubuntu: graphics.0.autoport: cannot parse '' as bool: strconv.ParseBool: parsing "yes": invalid syntax