### PR TITLE
minorfix: format string correctly

### DIFF
--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -382,7 +382,7 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 
 		mask := net.CIDRMask(int(address.Prefix), bits)
 		network := addr.Mask(mask)
-		addresses = append(addresses, fmt.Sprintf("%s/%d", network, address.Prefix))
+		addresses = append(addresses, fmt.Sprintf("%s/%s", network, address.Prefix))
 	}
 	if len(addresses) > 0 {
 		d.Set("addresses", addresses)


### PR DESCRIPTION
```make build``` was failing because of
```golang
libvirt/resource_libvirt_network.go:385: arg address.Prefix for printf
verb %d of wrong type: string
```
