### PR TITLE
additional minor fixes on string formats

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -833,7 +833,7 @@ func testAccCheckLibvirtDomainKernelInitrdCmdline(domain *libvirt.Domain, kernel
 			return fmt.Errorf("Can't get initrd volume id")
 		}
 		if domainDef.OS.Initrd != key {
-			return fmt.Errorf("Initrd is not set correctly: '%s' vs '%s'", domainDef.OS, key)
+			return fmt.Errorf("Initrd is not set correctly: '%s' vs '%s'", domainDef.OS.Initrd, key)
 		}
 		if domainDef.OS.Cmdline != "bar=bye foo=1 foo=2" {
 			return fmt.Errorf("Kernel args not set correctly: '%s'", domainDef.OS.Cmdline)

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -373,7 +373,7 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 		// so we need some transformations...
 		addr := net.ParseIP(address.Address)
 		if addr == nil {
-			return fmt.Errorf("Error parsing IP '%s': %s", address, err)
+			return fmt.Errorf("Error parsing IP '%s': %s", address.Address, err)
 		}
 		bits := net.IPv6len * 8
 		if addr.To4() != nil {
@@ -382,7 +382,7 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 
 		mask := net.CIDRMask(int(address.Prefix), bits)
 		network := addr.Mask(mask)
-		addresses = append(addresses, fmt.Sprintf("%s/%s", network, address.Prefix))
+		addresses = append(addresses, fmt.Sprintf("%s/%d", network, address.Prefix))
 	}
 	if len(addresses) > 0 {
 		d.Set("addresses", addresses)

--- a/travis/run-tests-acceptance
+++ b/travis/run-tests-acceptance
@@ -4,6 +4,7 @@ set -x
 unset http_proxy
 export TERRAFORM_LIBVIRT_TEST_DOMAIN_TYPE=qemu
 export LIBVIRT_DEFAULT_URI="qemu:///system"
+export TF_SKIP_QEMU_AGENT="true"
 export TF_ACC=true
 
 go test -v -covermode=count -coverprofile=profile.cov -timeout=1200s ./libvirt


### PR DESCRIPTION
fix following errors
```golang
go vet .
libvirt/resource_libvirt_network.go:376: arg address for printf verb %s of wrong type: github.com/dmacvicar/terraform-provider-libvirt/vendor/github.com/libvirt/libvirt-go-xml.NetworkIP
libvirt/resource_libvirt_network.go:385: arg address.Prefix for printf verb %s of wrong type: uint
libvirt/resource_libvirt_domain_test.go:836: arg domainDef.OS for printf verb %s of wrong type: *github.com/dmacvicar/terraform-provider-libvirt/vendor/github.com/libvirt/libvirt-go-xml.DomainOS
exit status 1
```