### PR TITLE
Fix spurious reading network_name when using bridge as the source

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -206,6 +206,10 @@ func getDomainInterfacesFromNetworks(domain libvirtxml.Domain,
 	var macAddresses []string
 
 	for _, networkInterface := range domain.Devices.Interfaces {
+		// only for devices with a network associated to it
+		if networkInterface.Source.Network == nil {
+			continue
+		}
 		networkNames = append(networkNames, networkInterface.Source.Network.Network)
 		macAddresses = append(macAddresses, strings.ToUpper(networkInterface.MAC.Address))
 	}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -834,7 +834,6 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		} else if networkInterfaceDef.Source.Bridge != nil {
 			netIface["bridge"] = networkInterfaceDef.Source.Bridge
-			netIface["network_name"] = networkInterfaceDef.Source.Network.Network
 		} else if networkInterfaceDef.Source.Direct != nil {
 			switch networkInterfaceDef.Source.Direct.Mode {
 			case "vepa":


### PR DESCRIPTION
In the past, Source contained Network and Bridge as a string. Now because the Source is exclusive, it is an union of both.

There is no apparent reason why one would have a Network name as a source when
using Bridge as the source.
