### PR TITLE
add autostart false testcase

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -508,21 +508,35 @@ func TestAccLibvirtDomain_Cpu(t *testing.T) {
 func TestAccLibvirtDomain_Autostart(t *testing.T) {
 	var domain libvirt.Domain
 
-	var config = fmt.Sprintf(`
+	var autostartTrue = fmt.Sprintf(`
 	resource "libvirt_domain" "acceptance-test-domain" {
 		name      = "terraform-test"
 		autostart = true
 	}`)
+
+	var autostartFalse = fmt.Sprintf(`
+	resource "libvirt_domain" "acceptance-test-domain" {
+		name      = "terraform-test"
+		autostart = false
+	}`)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: autostartTrue,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain", &domain),
 					resource.TestCheckResourceAttr("libvirt_domain.acceptance-test-domain", "autostart", "true"),
+				),
+			},
+			{
+				Config: autostartFalse,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain.acceptance-test-domain", &domain),
+					resource.TestCheckResourceAttr("libvirt_domain.acceptance-test-domain", "autostart", "false"),
 				),
 			},
 		},


### PR DESCRIPTION
add autostart false testcase 
improve testcoverage `from: 69.5% of statements -->  coverage: 70.8% of statements`
I found this out when i was doing other stuff on the provider :fish:  :fishing_pole_and_fish: 