### PR TITLE
 remove unused/deprecated function remoteImageSize

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -4,8 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"net/http"
-	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -67,18 +67,6 @@ func resourceLibvirtVolume() *schema.Resource {
 	}
 }
 
-func remoteImageSize(url string) (int, error) {
-	response, err := http.Head(url)
-	if err != nil {
-		return 0, err
-	}
-	length, err := strconv.Atoi(response.Header.Get("Content-Length"))
-	if err != nil {
-		return 0, err
-	}
-	return length, nil
-}
-
 func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
 	if client.libvirt == nil {


### PR DESCRIPTION
this function was merged in utils.go during refactoring.
The old function was merged here:
https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/libvirt/utils_volume.go#L76