### PR TITLE
Revert "Do not use qemu-agent by default to gather network information"

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,20 +120,6 @@ Look at more advanced examples [here](examples/)
 
 You can target different libvirt hosts instantiating the [provider multiple times](https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances). [Example](examples/multiple).
 
-### Using qemu-agent
-
-From its documentation, [qemu-agent](https://wiki.libvirt.org/page/Qemu_guest_agent):
-
->It is a daemon program running inside the domain which is supposed to help management applications with executing functions which need assistance of the guest OS.
-
-Until terraform-provider-libvirt 0.4.2, qemu-agent was used by default to get network configuration. However, if qemu-agent is not running, this creates a delay until connecting to it times-out.
-
-In current versions, we default to not to attempt connecting to it, and attempting to retrieve network interface information from the agent needs to be enabled explicitly with `TF_USE_QEMU_AGENT`. Note that you still need to make sure the agent is running in the OS, and that is unrelated to this option.
-
-`TF_SKIP_QEMU_AGENT` is deprecated and has no effect (except for a warning).
-
-Be aware that this variables may be subject to change again in future versions.
-
 ## Troubleshooting (aka you have a problem)
 
 Have a look at [TROUBLESHOOTING](doc/TROUBLESHOOTING.md), and feel free to add a PR if you find out something is missing.

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -14,11 +14,7 @@ import (
 	"github.com/libvirt/libvirt-go-xml"
 )
 
-// deprecated, now defaults to not use it, but we warn the user
-const skipQemuAgentEnvVar = "TF_SKIP_QEMU_AGENT"
-
-// if explicitly enabled
-const useQemuAgentEnvVar = "TF_USE_QEMU_AGENT"
+const skipQemuEnvVar = "TF_SKIP_QEMU_AGENT"
 
 const domWaitLeaseStillWaiting = "waiting-addresses"
 const domWaitLeaseDone = "all-addresses-obtained"
@@ -150,8 +146,10 @@ func domainIsRunning(domain libvirt.Domain) (bool, error) {
 func domainGetIfacesInfo(domain libvirt.Domain, domainDef libvirtxml.Domain,
 	virConn *libvirt.Connect) ([]libvirt.DomainInterface, error) {
 
-	_, found := os.LookupEnv(useQemuAgentEnvVar)
+	_, found := os.LookupEnv(skipQemuEnvVar)
 	if found {
+		log.Printf("[DEBUG] %s defined in environment: skipping qemu-agent", skipQemuEnvVar)
+	} else {
 		// get all the interfaces using the qemu-agent, this includes also
 		// interfaces that are not attached to networks managed by libvirt
 		// (eg. bridges, macvtap,...)
@@ -163,13 +161,6 @@ func domainGetIfacesInfo(domain libvirt.Domain, domainDef libvirtxml.Domain,
 			// or macvtap. Hence it has the highest priority
 			return interfaces, nil
 		}
-	} else {
-		_, found = os.LookupEnv(skipQemuAgentEnvVar)
-		if found {
-			log.Printf("[DEBUG] %s is deprecated and qemu-agent is not used by default.", skipQemuAgentEnvVar)
-		}
-		log.Printf("[INFO] Set %s if you want to get network information from qemu-agent", useQemuAgentEnvVar)
-
 	}
 
 	log.Print("[DEBUG] getting domain addresses from networks")


### PR DESCRIPTION
Reverts dmacvicar/terraform-provider-libvirt#354

# problem

Since this merge the bridge mode doesn't work anymore 

as i discussed with @inercia  in gitter, we have  a problem with this when using `bridge` mode.

I just test it before migrating sumaform to tf11. ( we use bridge in prod)

# what we can do for fixing pb:
- we could implement a function that enable qemu-agent when bridge is active.

To me this could be ok, but as we hit already the pb with bridge, the question is:

` how many networking configurations could require the enabling of qemu-agent`?

What i fear is that we have to much corner cases that would require the enablement in that particolar networking modes.
To me seems really difficult to maintain and that is why i would enable by default the qemu-agent and disable it if not needed.