### PR TITLE
 Fix incompatible change from 77982e

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -840,7 +840,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 		} else if networkInterfaceDef.Source.Bridge != nil {
-			netIface["bridge"] = networkInterfaceDef.Source.Bridge
+			netIface["bridge"] = networkInterfaceDef.Source.Bridge.Bridge
 		} else if networkInterfaceDef.Source.Direct != nil {
 			switch networkInterfaceDef.Source.Direct.Mode {
 			case "vepa":


### PR DESCRIPTION
These prevent the IP addresses read by Terraform to be correctly exported to the Terraform state.

Although I'm not exactly sure how that fail, I believe the Terraform state is filled with libvirt own objects which (silently) fail to be serialized correctly into the state.

This is the debug log of Terraform for one of the machine:
```
2018-08-28T18:09:12.753+0200 [DEBUG] plugin.terraform-provider-libvirt: 2018/08/28 18:09:12 [DEBUG] Interfaces obtained via qemu-agent: [{Name:ens3 Hwaddr:ac:de:48:f4:cf:b1 Addrs:[{Type:0 Addr:10.20.3.120 Prefix:16} {Type:1 Addr:fe80::aede:48ff:fef4:cfb1 Prefix:64}]}]
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 2018/08/28 18:09:12 [DEBUG] read: addresses for 'AC:DE:48:F4:CF:B1': [10.20.3.120 fe80::aede:48ff:fef4:cfb1]
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 2018/08/28 18:09:12 [DEBUG] read: ifaces for 'xxx':
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: ([]map[string]interface {}) (len=1 cap=1) {
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 	(map[string]interface {}) (len=10) {
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=11) "passthrough": (string) "",
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=3) "mac": (string) (len=17) "AC:DE:48:F4:CF:B1",
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=14) "wait_for_lease": (bool) true,
2018-08-28T18:09:12.754+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=10) "network_id": (string) "",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=12) "network_name": (string) "",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=6) "bridge": (*libvirtxml.DomainInterfaceSourceBridge)(0xc420465be0)({
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 			Bridge: (string) (len=3) "br0"
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		}),
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=4) "vepa": (string) "",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=7) "macvtap": (string) "",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=8) "hostname": (string) "",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=9) "addresses": ([]string) (len=2 cap=2) {
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 			(string) (len=11) "10.20.3.120",
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 			(string) (len=25) "fe80::aede:48ff:fef4:cfb1"
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 		}
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: 	}
2018-08-28T18:09:12.755+0200 [DEBUG] plugin.terraform-provider-libvirt: }
```

The `bridge` value is not right here and prevents the whole `network_interface` value to be saved correctly.