### PR TITLE
Allow Setting for Host DNS Entries

### DIFF
--- a/libvirt/data_source_libvirt_network.go
+++ b/libvirt/data_source_libvirt_network.go
@@ -1,0 +1,69 @@
+package libvirt
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// a libvirt network DNS host template datasource
+//
+// Datasource example:
+//
+// data "libvirt_network_dns_host_template" "k8smasters" {
+//   count = "${var.master_count}"
+//   ip = "${var.master_ips[count.index]}"
+//   hostname = "master-${count.index}"
+// }
+//
+// resource "libvirt_network" "k8snet" {
+//   ...
+//   dns = [{
+//     hosts = [ "${flatten(data.libvirt_network_dns_host_template.k8smasters.*.rendered)}" ]
+//   }]
+//   ...
+// }
+//
+func datasourceLibvirtNetworkDNSHostTemplate() *schema.Resource {
+	return &schema.Resource{
+		Read: resourceLibvirtNetworkDNSHostRead,
+		Schema: map[string]*schema.Schema{
+			"ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rendered": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLibvirtNetworkDNSHostRead(d *schema.ResourceData, meta interface{}) error {
+	dnsHost := map[string]interface{}{}
+	if address, ok := d.GetOk("ip"); ok {
+		ip := net.ParseIP(address.(string))
+		if ip == nil {
+			return fmt.Errorf("Could not parse address '%s'", address)
+		}
+		dnsHost["ip"] = ip.String()
+	}
+	if hostname, ok := d.GetOk("hostname"); ok {
+		dnsHost["hostname"] = hostname.(string)
+	}
+	d.Set("rendered", dnsHost)
+	d.SetId(strconv.Itoa(hashcode.String(fmt.Sprintf("%v", dnsHost))))
+
+	return nil
+}

--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -1,0 +1,53 @@
+package libvirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccLibvirtNetworkDataSource_DNSHostTemplate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config: `data "libvirt_network_dns_host_template" "bootstrap" {
+  count = 2
+  ip = "1.1.1.${count.index}"
+  hostname = "myhost${count.index}"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "ip", "1.1.1.0"),
+					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "hostname", "myhost0"),
+					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "ip", "1.1.1.1"),
+					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "hostname", "myhost1"),
+				),
+			},
+		},
+	})
+}
+
+func checkDNSHostTemplate(id, name, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("Not found: %s", id)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		v := rs.Primary.Attributes[name]
+		if v != value {
+			return fmt.Errorf(
+				"Value for %s is %s, not %s", name, v, value)
+		}
+
+		return nil
+	}
+}

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -27,6 +27,10 @@ func Provider() terraform.ResourceProvider {
 			"libvirt_ignition":  resourceIgnition(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"libvirt_network_dns_host_template": datasourceLibvirtNetworkDNSHostTemplate(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -52,6 +52,19 @@ resource "libvirt_network" "kube_network" {
     #     domain = "my domain"
     #   }
     # ]
+
+    # (Optional) one or more DNS host entries.  Both of
+    # "ip" and "hostname" must be specified.  The format is:
+    # hosts = [
+    #   {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.1"
+    #   },
+    #   {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.2"
+    #   },
+    # ]
   }
 }
 ```
@@ -96,7 +109,26 @@ The following arguments are supported:
 Inside of `dns` section the following argument are supported:
 * `local_only` - (Optional) true/false: true means 'do not forward unresolved requests for this domain to the part DNS server
 * `forwarders` - (Optional) Either `address`, `domain`, or both must be set
+* `hosts` - (Optional) a DNS host entry block.  You can have one or more of these
+   blocks in your DNS definition. You must specify both `ip` and `hostname`.
 
+An advanced example of round-robin DNS (using DNS host templates) follows:
+
+```hcl
+resource "libvirt_network" "my_network" {
+  ...
+  dns = {
+    hosts = [ "${flatten(data.libvirt_network_dns_host_template.hosts.*.rendered)}" ]
+  }
+  ...
+}
+
+data "libvirt_network_dns_host_template" "hosts" {
+  count = "${var.host_count}"
+  ip = "${var.host_ips[count.index]}"
+  hostname = "my_host"
+}
+```
 
 * `dhcp` - (Optional) DHCP configuration. 
    You need to use it in conjuction with the adresses variable.


### PR DESCRIPTION
This will allow one to set host based DNS entries. So I can say
host=host1, ip=1.1.1.1
host=host1, ip=1.1.1.2
host=host2, ip=1.1.1.1
And It would work the way you expect...