### PR TITLE
enable dhcp as optional parameter (typelist)

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -229,8 +229,10 @@ func getDomainInterfacesFromNetworks(domain libvirtxml.Domain,
 		networkDef, err := newDefNetworkfromLibvirt(network)
 		macAddresses := make(map[string][]string)
 		for _, ips := range networkDef.IPs {
-			for _, dhcpHost := range ips.DHCP.Hosts {
-				macAddresses[dhcpHost.MAC] = append(macAddresses[dhcpHost.MAC], dhcpHost.IP)
+			if ips.DHCP != nil {
+				for _, dhcpHost := range ips.DHCP.Hosts {
+					macAddresses[dhcpHost.MAC] = append(macAddresses[dhcpHost.MAC], dhcpHost.IP)
+				}
 			}
 		}
 		networkMacAddresses[networkName] = macAddresses

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -165,6 +165,7 @@ func TestNetworkFromLibvirt(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
+
 	if dn.Forward.Mode != "nat" {
 		t.Errorf("Wrong forward mode: %s", dn.Forward.Mode)
 	}

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -165,7 +165,6 @@ func TestNetworkFromLibvirt(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-
 	if dn.Forward.Mode != "nat" {
 		t.Errorf("Wrong forward mode: %s", dn.Forward.Mode)
 	}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -222,11 +222,13 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 					return err
 				}
 				if d.Get("dhcp.0.enabled").(bool) {
+					log.Printf("[DEBUG]: dhcp.0.enabled.")
 					dni.DHCP = dhcp
+					log.Printf("[DEBUG]: dhcp values: %#v", dni.DHCP)
 				}
-
 				ipsPtrsLst = append(ipsPtrsLst, *dni)
 			}
+
 			networkDef.IPs = ipsPtrsLst
 		}
 

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -147,7 +147,7 @@ func resourceLibvirtNetworkUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	network, err := virConn.LookupNetworkByUUIDString(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error by retrieving network ID during update: %s", err)
+		return fmt.Errorf("Can't retrieve network with ID '%s' during update: %s", d.Id(), err)
 	}
 	defer network.Free()
 

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -42,7 +42,7 @@ func networkExists(n string, network *libvirt.Network) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network, DhcpStatus string) resource.TestCheckFunc {
+func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network, expectedDhcpStatus string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -64,7 +64,7 @@ func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network,
 		if err != nil {
 			return fmt.Errorf("Error reading libvirt network XML description: %s", err)
 		}
-		if DhcpStatus == "disabled" {
+		if expectedDhcpStatus == "disabled" {
 			for _, ips := range networkDef.IPs {
 				// &libvirtxml.NetworkDHCP{..} should be nil when dhcp is disabled
 				if ips.DHCP != nil {
@@ -73,7 +73,7 @@ func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network,
 				}
 			}
 		}
-		if DhcpStatus == "enabled" {
+		if expectedDhcpStatus == "enabled" {
 			for _, ips := range networkDef.IPs {
 				if ips.DHCP == nil {
 					return fmt.Errorf("the network should have DHCP enabled")
@@ -134,7 +134,7 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 	})
 }
 
-func TestAccLibvirtNetwork_EnableDhcpAndDisableItAfter(t *testing.T) {
+func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
 	var network1 libvirt.Network
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -162,7 +162,7 @@ func TestAccLibvirtNetwork_EnableDhcpAndDisableItAfter(t *testing.T) {
 	})
 }
 
-func TestAccLibvirtNetwork_dhcpDisabled(t *testing.T) {
+func TestAccLibvirtNetwork_DhcpDisabled(t *testing.T) {
 	var network1 libvirt.Network
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -66,18 +66,17 @@ func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network,
 		}
 		if DhcpStatus == "disabled" {
 			for _, ips := range networkDef.IPs {
-				fmt.Printf("%#v", ips.DHCP)
 				// &libvirtxml.NetworkDHCP{..} should be nil when dhcp is disabled
 				if ips.DHCP != nil {
+					fmt.Printf("%#v", ips.DHCP)
 					return fmt.Errorf("the network should have DHCP disabled")
 				}
 			}
 		}
 		if DhcpStatus == "enabled" {
 			for _, ips := range networkDef.IPs {
-				fmt.Printf("%#v", ips.DHCP)
 				if ips.DHCP == nil {
-					return fmt.Errorf("the network should have DHCP disabled")
+					return fmt.Errorf("the network should have DHCP enabled")
 				}
 			}
 		}
@@ -135,7 +134,7 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 	})
 }
 
-func TestAccLibvirtNetwork_dhcpEnabled(t *testing.T) {
+func TestAccLibvirtNetwork_EnableDhcpAndDisableItAfter(t *testing.T) {
 	var network1 libvirt.Network
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -155,6 +154,7 @@ func TestAccLibvirtNetwork_dhcpEnabled(t *testing.T) {
 					}
 				}`),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_network.test_net", "dhcp.0.enabled", "false"),
 					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network.test_net", &network1, "enabled"),
 				),
 			},

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -47,9 +47,10 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
-* `domain` - The domain used by the DNS server.
-* `addresses` - A list of (0 or 1) ipv4 and (0 or 1) ipv6 subnets in CIDR notation
+* `domain` - (Optional) The domain used by the DNS server.
+* `addresses` - (Optional) A list of (0 or 1) ipv4 and (0 or 1) ipv6 subnets in CIDR notation
   format for being served by the DHCP server. Address of subnet should be used.
+   No DHCP server will be started if this attributed is omitted.
 * `mode` -  One of:
     - `none`: the guests can talk to each other and the host OS, but cannot reach
     any other machines on the LAN.
@@ -105,6 +106,19 @@ resource "libvirt_network" "my_network" {
 }
 ```
 
+* `dhcp` - (Optional) DHCP configuration. 
+   You need to use it in conjuction with the adresses variable.
+  * `enabled` - (Optional) when false, disable the DHCP server
+```hcl
+				resource "libvirt_network" "test_net" {
+					name      = "networktest"
+					mode      = "nat"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					dhcp {
+						enabled = true
+					}
+```
 ## Attributes Reference
 
 * `id` - a unique identifier for the resource

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -24,7 +24,9 @@ resource "libvirt_network" "kube_network" {
   #  the domain used by the DNS server in this network
   domain = "k8s.local"
 
-  # the addresses allowed for domains connected and served by the DHCP server
+  #  list of subnets the addresses allowed for domains connected
+  # also derived to define the host addresses
+  # also derived to define the addresses served by the DHCP server
   addresses = ["10.17.3.0/24", "2001:db8:ca2:2::1/64"]
 
   # (optional) the bridge device defines the name of a bridge device
@@ -48,9 +50,12 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
 * `domain` - (Optional) The domain used by the DNS server.
-* `addresses` - (Optional) A list of (0 or 1) ipv4 and (0 or 1) ipv6 subnets in CIDR notation
-  format for being served by the DHCP server. Address of subnet should be used.
-   No DHCP server will be started if this attributed is omitted.
+* `addresses` - (Optional) A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in
+  CIDR notation.  This defines the subnets associated to that network.
+  This argument is also used to define the address on the real host.
+  If `dhcp {  enabled = true }` addresses is also used to define the address range served by
+  the DHCP server.
+  No DHCP server will be started if `addresses` is omitted.
 * `mode` -  One of:
     - `none`: the guests can talk to each other and the host OS, but cannot reach
     any other machines on the LAN.


### PR DESCRIPTION
This pr contain: 

- dhcp backport from #288.
- documentation.

Additionaly to the #288 we have:
-  real testing for real the dhcp parameter via xml property of network
    -  we are testing that the xml networkDefinition have dhcp set or not (depending on dhcp nabl/disable) 
