### PR TITLE
Tests: dhcp_test should be expected true..

### DIFF
--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -154,7 +154,7 @@ func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
 					}
 				}`),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("libvirt_network.test_net", "dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr("libvirt_network.test_net", "dhcp.0.enabled", "true"),
 					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network.test_net", &network1, "enabled"),
 				),
 			},


### PR DESCRIPTION
when enabled

this is just nitpick. I overlooked it when i was testing the update ( testing 2 steps in same tests)  function which we canot tests because we have some other issues.

