### PR TITLE
refactor  with  help of new getXMLDomainDefFromLibvirt(domain)

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -226,7 +226,7 @@ func getDomainInterfacesFromNetworks(domain libvirtxml.Domain,
 		}
 		defer network.Free()
 
-		networkDef, err := newDefNetworkfromLibvirt(network)
+		networkDef, err := getXMLNetworkDefFromLibvirt(network)
 		macAddresses := make(map[string][]string)
 		for _, ips := range networkDef.IPs {
 			if ips.DHCP != nil {

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -1,12 +1,30 @@
 package libvirt
 
 import (
+	"encoding/xml"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
+
+// from existing domain return its  XMLdefintion
+func getXMLDomainDefFromLibvirt(domain *libvirt.Domain) (libvirtxml.Domain, error) {
+	domainXMLDesc, err := domain.GetXMLDesc(0)
+	if err != nil {
+		return libvirtxml.Domain{}, fmt.Errorf("Error retrieving libvirt domain XML description: %s", err)
+	}
+
+	domainDef := newDomainDef()
+	err = xml.Unmarshal([]byte(domainXMLDesc), &domainDef)
+	if err != nil {
+		return libvirtxml.Domain{}, fmt.Errorf("Error reading libvirt domain XML description: %s", err)
+	}
+
+	return domainDef, nil
+}
 
 // note source and target are not initialized
 func newFilesystemDef() libvirtxml.DomainFilesystem {

--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -27,7 +27,7 @@ func newDefNetworkFromXML(s string) (libvirtxml.Network, error) {
 	return networkDef, nil
 }
 
-func newDefNetworkfromLibvirt(network Network) (libvirtxml.Network, error) {
+func getXMLNetworkDefFromLibvirt(network Network) (libvirtxml.Network, error) {
 	networkXMLDesc, err := network.GetXMLDesc(0)
 	if err != nil {
 		return libvirtxml.Network{}, fmt.Errorf("Error retrieving libvirt domain XML description: %s", err)

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -131,7 +131,7 @@ func TestNetworkFromLibvirtError(t *testing.T) {
 		GetXMLDescError: errors.New("boom"),
 	}
 
-	_, err := newDefNetworkfromLibvirt(net)
+	_, err := getXMLNetworkDefFromLibvirt(net)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -142,7 +142,7 @@ func TestNetworkFromLibvirtWrongResponse(t *testing.T) {
 		GetXMLDescReply: "wrong xml",
 	}
 
-	_, err := newDefNetworkfromLibvirt(net)
+	_, err := getXMLNetworkDefFromLibvirt(net)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -161,7 +161,7 @@ func TestNetworkFromLibvirt(t *testing.T) {
 		</network>`,
 	}
 
-	dn, err := newDefNetworkfromLibvirt(net)
+	dn, err := getXMLNetworkDefFromLibvirt(net)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -841,7 +841,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Can't retrieve network ID for '%s'", networkInterfaceDef.Source.Network.Network)
 			}
 
-			networkDef, err := newDefNetworkfromLibvirt(network)
+			networkDef, err := getXMLNetworkDefFromLibvirt(network)
 			if err != nil {
 				return err
 			}
@@ -1376,7 +1376,7 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 			if err != nil {
 				return fmt.Errorf("Error retrieving network name: %s", err)
 			}
-			networkDef, err := newDefNetworkfromLibvirt(network)
+			networkDef, err := getXMLNetworkDefFromLibvirt(network)
 
 			// only for DHCP, we update the host table of the network
 			if HasDHCP(networkDef) {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -889,7 +889,7 @@ func testAccCheckLibvirtDestroyLeavesIPs(n string, ip string, network *libvirt.N
 			return err
 		}
 
-		networkDef, err := newDefNetworkfromLibvirt(retrieveNetwork)
+		networkDef, err := getXMLNetworkDefFromLibvirt(retrieveNetwork)
 
 		for _, ips := range networkDef.IPs {
 			for _, dhcpHost := range ips.DHCP.Hosts {

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -322,7 +322,7 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	defer network.Free()
 
-	networkDef, err := newDefNetworkfromLibvirt(network)
+	networkDef, err := getXMLNetworkDefFromLibvirt(network)
 	if err != nil {
 		return fmt.Errorf("Error reading libvirt network XML description: %s", err)
 	}

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -60,7 +60,7 @@ func testAccCheckLibvirtNetworkDhcpStatus(name string, network *libvirt.Network,
 			return err
 		}
 
-		networkDef, err := newDefNetworkfromLibvirt(network)
+		networkDef, err := getXMLNetworkDefFromLibvirt(network)
 		if err != nil {
 			return fmt.Errorf("Error reading libvirt network XML description: %s", err)
 		}


### PR DESCRIPTION
# what change this PR:

-  1change) change name of xmlgetter with more clear one (https://github.com/dmacvicar/terraform-provider-libvirt/commit/a6cc257ec1674f1283af757953517225899c75a4)
- 2 change) introduce new  function for retrieve XMLDefinitionDomain from existing domain (https://github.com/dmacvicar/terraform-provider-libvirt/commit/4eb51f5e3df0885ff9845435793dab84608e7dd8)


- 2refactoring)  use new function `getXMLDomainDefFromLibvirt https://github.com/dmacvicar/terraform-provider-libvirt/pull/393/commits/54372fd49ac4d73281fe2e5a5bf389b60d28f812