### PR TITLE
fix function name changed.

### DIFF
--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -25,7 +25,7 @@ func getNetworkDef(s *terraform.State, name string) (*libvirtxml.Network, error)
 	if err != nil {
 		return nil, err
 	}
-	networkDef, err := newDefNetworkfromLibvirt(network)
+	networkDef, err := getXMLNetworkDefFromLibvirt(network)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading libvirt network XML description: %s", err)
 	}


### PR DESCRIPTION
PR #393 has introduced a new function name. ( merged).
PR #376 was using the old name, which we merged after pr #393 and the
review was done before merging #393.

This commit just fix the name of function