### PR TITLE
remove unused hash function

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -1,8 +1,6 @@
 package libvirt
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"log"
@@ -27,11 +25,6 @@ type pendingMapping struct {
 
 func init() {
 	spew.Config.Indent = "\t"
-}
-
-func hash(s string) string {
-	sha := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(sha[:])
 }
 
 func resourceLibvirtDomain() *schema.Resource {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -808,15 +808,6 @@ func testAccCheckIgnitionXML(domain *libvirt.Domain, volume *libvirt.StorageVol)
 	}
 }
 
-func TestHash(t *testing.T) {
-	actual := hash("this is a test")
-	expected := "2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c"
-
-	if actual != expected {
-		t.Errorf("Expected %s, got %s", expected, actual)
-	}
-}
-
 func testAccCheckLibvirtScsiDisk(n string, domain *libvirt.Domain) resource.TestCheckFunc {
 	return testAccCheckLibvirtDomainDescription(domain, func(domainDef libvirtxml.Domain) error {
 		disks := domainDef.Devices.Disks


### PR DESCRIPTION
this function was removed during a refactor but the commiter forgot to remove the function declaration and the related test

the concerned function was removed here:
https://github.com/dmacvicar/terraform-provider-libvirt/commit/f130f9848e61924bded600602a91822cf76e0959

anyway terraform have already an helper function for that so we don\t need it. 