### PR TITLE
redesign cloud_init resource to cloud_init_disk, extend fields etc.

### DIFF
--- a/examples/ubuntu/cloud_init.cfg
+++ b/examples/ubuntu/cloud_init.cfg
@@ -9,29 +9,11 @@
 # This is the configuration syntax that the write_files module
 # will know how to understand. encoding can be given b64 or gzip or (gz+b64).
 # The content will be decoded accordingly and then written to the path that is
-# provided. 
+# provided.
 #
 # Note: Content strings here are truncated for example purposes.
-write_files:
--   encoding: b64
-    content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4...
-    owner: root:root
-    path: /etc/sysconfig/selinux
-    permissions: '0644'
--   content: |
-        # My new /etc/sysconfig/samba file
-
-        SMBDOPTIONS="-D"
-    path: /etc/sysconfig/samba
--   content: !!binary |
-        f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAwARAAAAAAABAAAAAAAAAAJAVAAAAAAAAAAAAAEAAOAAI
-        AEAAHgAdAAYAAAAFAAAAQAAAAAAAAABAAEAAAAAAAEAAQAAAAAAAwAEAAAAAAADAAQAAAAAAAAgA
-        AAAAAAAAAwAAAAQAAAAAAgAAAAAAAAACQAAAAAAAAAJAAAAAAAAcAAAAAAAAABwAAAAAAAAAAQAA
-        ....
-    path: /bin/arch
-    permissions: '0555'
--   encoding: gzip
-    content: !!binary |
-        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
-    path: /usr/bin/hello
-    permissions: '0755'
+ssh_pwauth: True
+chpasswd:
+  list: |
+     root:terraform-libvirt-linux
+  expire: False

--- a/examples/ubuntu/cloud_init.cfg
+++ b/examples/ubuntu/cloud_init.cfg
@@ -1,0 +1,37 @@
+#cloud-config
+# vim: syntax=yaml
+#
+# ***********************
+# 	---- for more examples look at: ------
+# ---> https://cloudinit.readthedocs.io/en/latest/topics/examples.html
+# ******************************
+#
+# This is the configuration syntax that the write_files module
+# will know how to understand. encoding can be given b64 or gzip or (gz+b64).
+# The content will be decoded accordingly and then written to the path that is
+# provided. 
+#
+# Note: Content strings here are truncated for example purposes.
+write_files:
+-   encoding: b64
+    content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4...
+    owner: root:root
+    path: /etc/sysconfig/selinux
+    permissions: '0644'
+-   content: |
+        # My new /etc/sysconfig/samba file
+
+        SMBDOPTIONS="-D"
+    path: /etc/sysconfig/samba
+-   content: !!binary |
+        f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAwARAAAAAAABAAAAAAAAAAJAVAAAAAAAAAAAAAEAAOAAI
+        AEAAHgAdAAYAAAAFAAAAQAAAAAAAAABAAEAAAAAAAEAAQAAAAAAAwAEAAAAAAADAAQAAAAAAAAgA
+        AAAAAAAAAwAAAAQAAAAAAgAAAAAAAAACQAAAAAAAAAJAAAAAAAAcAAAAAAAAABwAAAAAAAAAAQAA
+        ....
+    path: /bin/arch
+    permissions: '0555'
+-   encoding: gzip
+    content: !!binary |
+        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+    path: /usr/bin/hello
+    permissions: '0755'

--- a/examples/ubuntu/network_config.cfg
+++ b/examples/ubuntu/network_config.cfg
@@ -1,0 +1,5 @@
+network:
+version: 2
+        ethernets:
+         eno1:
+         dhcp4: true

--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -21,10 +21,19 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/cloud_init.cfg")}"
 }
 
+
+data "template_file" "network_config" {
+  template = "${file("${path.module}/network_config.cfg")}"
+}
+
+# for more info about paramater check this out
+# https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
+# you can add also meta_data field
 resource "libvirt_cloudinit" "commoninit" {
           name           = "commoninit.iso"
           user_data          = "${data.template_file.user_data.rendered}"
+          network_config = "${data.template_file.network_config.rendered}"
 }
 
 # Create the machine

--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -17,12 +17,15 @@ resource "libvirt_network" "vm_network" {
    addresses = ["10.0.1.0/24"]
 }
 
+data "template_file" "user_data" {
+  template = "${file("${path.module}/cloud_init.cfg")}"
+}
+
 # Use CloudInit to add our ssh-key to the instance
 resource "libvirt_cloudinit" "commoninit" {
           name           = "commoninit.iso"
-          ssh_authorized_key = "<ssh-key-here>"
-        }
-
+          user_data          = "${data.template_file.user_data.rendered}"
+}
 
 # Create the machine
 resource "libvirt_domain" "domain-ubuntu" {

--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -30,7 +30,7 @@ data "template_file" "network_config" {
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field
-resource "libvirt_cloudinit" "commoninit" {
+resource "libvirt_cloudinit_disk" "commoninit" {
           name           = "commoninit.iso"
           user_data          = "${data.template_file.user_data.rendered}"
           network_config = "${data.template_file.network_config.rendered}"
@@ -42,7 +42,7 @@ resource "libvirt_domain" "domain-ubuntu" {
   memory = "512"
   vcpu = 1
 
-  cloudinit = "${libvirt_cloudinit.commoninit.id}"
+  cloudinit = "${libvirt_cloudinit_disk.commoninit.id}"
 
   network_interface {
     network_name = "vm_network"

--- a/libvirt/acceptance_tests_functions_helpers.go
+++ b/libvirt/acceptance_tests_functions_helpers.go
@@ -6,10 +6,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// This file contain function helper used for testsuite/testacc
+// This file contain function helpers used for testsuite/testacc
 
-// getResourceFromTerraformState is helper function for getting a resource by name
+// getResourceFromTerraformState get aresource by name
 // from terraform states produced during testacc
+// and return the resource
 func getResourceFromTerraformState(resourceName string, state *terraform.State) (*terraform.ResourceState, error) {
 	rs, ok := state.RootModule().Resources[resourceName]
 	if !ok {

--- a/libvirt/acceptance_tests_functions_helpers.go
+++ b/libvirt/acceptance_tests_functions_helpers.go
@@ -1,0 +1,24 @@
+package libvirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// This file contain function helper used for testsuite/testacc
+
+// getResourceFromTerraformState is helper function for getting a resource by name
+// from terraform states produced during testacc
+func getResourceFromTerraformState(resourceName string, state *terraform.State) (*terraform.ResourceState, error) {
+	rs, ok := state.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s", resourceName)
+	}
+
+	if rs.Primary.ID == "" {
+		return nil, fmt.Errorf("No libvirt resource key ID is set")
+	}
+	return rs, nil
+
+}

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -28,7 +28,6 @@ type defCloudInit struct {
 	NetworkConfig string `yaml:"network_config"`
 }
 
-// TODO: check better this one maybe do in otherplaces
 func newCloudInitDef() defCloudInit {
 	return defCloudInit{}
 }

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -35,11 +35,14 @@ func newCloudInitDef() defCloudInit {
 // Create a ISO file based on the contents of the CloudInit instance and
 // uploads it to the libVirt pool
 // Returns a string holding terraform's internal ID of this resource
-func (ci *defCloudInit) CreateAndUpload(client *Client) (string, error) {
+func (ci *defCloudInit) CreateIso() (string, error) {
 	iso, err := ci.createISO()
 	if err != nil {
 		return "", err
 	}
+	return iso, err
+}
+func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 
 	pool, err := client.libvirt.LookupStoragePoolByName(ci.PoolName)
 	if err != nil {

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -42,6 +42,7 @@ func (ci *defCloudInit) CreateIso() (string, error) {
 	}
 	return iso, err
 }
+
 func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 
 	pool, err := client.libvirt.LookupStoragePoolByName(ci.PoolName)
@@ -67,12 +68,8 @@ func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		// Remove the tmp directory holding the ISO
-		if err = os.RemoveAll(filepath.Dir(iso)); err != nil {
-			log.Printf("Error while removing tmp directory holding the ISO file: %s", err)
-		}
-	}()
+
+	defer removeTmpIsoDirectory(iso)
 
 	size, err := img.Size()
 	if err != nil {
@@ -107,6 +104,15 @@ func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 	}
 
 	return ci.buildTerraformKey(key), nil
+}
+
+func removeTmpIsoDirectory(iso string) {
+	// Remove the tmp directory holding the ISO
+	err := os.RemoveAll(filepath.Dir(iso))
+	if err != nil {
+		log.Printf("Error while removing tmp directory holding the ISO file: %s", err)
+	}
+
 }
 
 // create a unique ID for terraform use

--- a/libvirt/cloudinit_def_test.go
+++ b/libvirt/cloudinit_def_test.go
@@ -38,7 +38,7 @@ func TestCloudInitCreateFiles(t *testing.T) {
 	}
 }
 
-func TestCloudInitCreateISONoExteralTool(t *testing.T) {
+func TestCloudInitCreateISONoExternalTool(t *testing.T) {
 	path := os.Getenv("PATH")
 	defer os.Setenv("PATH", path)
 

--- a/libvirt/cloudinit_def_test.go
+++ b/libvirt/cloudinit_def_test.go
@@ -3,19 +3,8 @@ package libvirt
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"gopkg.in/yaml.v2"
 )
-
-func TestNewCloudInitDef(t *testing.T) {
-	ci := newCloudInitDef()
-
-	if ci.MetaData.InstanceID == "" {
-		t.Error("Expected metadata InstanceID not to be empty")
-	}
-}
 
 func TestCloudInitTerraformKeyOps(t *testing.T) {
 	ci := newCloudInitDef()
@@ -41,8 +30,7 @@ func TestCloudInitCreateFiles(t *testing.T) {
 		t.Errorf("Unexpected error %v", err)
 	}
 	defer os.RemoveAll(dir)
-
-	for _, file := range []string{userData, metaData} {
+	for _, file := range []string{"user-data", "meta-data", "network-config"} {
 		check, err := exists(filepath.Join(dir, file))
 		if !check {
 			t.Errorf("%s not found: %v", file, err)
@@ -65,99 +53,6 @@ func TestCloudInitCreateISONoExteralTool(t *testing.T) {
 
 	if iso != "" {
 		t.Errorf("Expected iso to be empty")
-	}
-}
-
-func TestCloudInitConvertUserDataToMapPreservesCloudInitNames(t *testing.T) {
-	ud := defCloudInitUserData{
-		SSHAuthorizedKeys: []string{"key1"},
-	}
-
-	actual, err := convertUserDataToMap(ud)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	_, ok := actual["ssh_authorized_keys"]
-	if !ok {
-		t.Error("Could not found ssh_authorized_keys key")
-	}
-}
-
-func TestCloudInitMergeEmptyUserDataIntoUserDataRaw(t *testing.T) {
-	ud := defCloudInitUserData{}
-
-	var userDataRaw = `
-new-key: new-value-set-by-extra
-ssh_authorized_keys:
-  - key2-from-extra-data
-`
-
-	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	actual := make(map[string]interface{})
-	err = yaml.Unmarshal([]byte(res), &actual)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	if _, ok := actual["ssh_authorized_keys"]; !ok {
-		t.Error("ssh_authorized_keys missing")
-	}
-
-	if _, ok := actual["new-key"]; !ok {
-		t.Error("new-key missing")
-	}
-}
-
-func TestCloudInitMergeUserDataIntoEmptyUserDataRaw(t *testing.T) {
-	ud := defCloudInitUserData{
-		SSHAuthorizedKeys: []string{"key1"},
-	}
-	var userDataRaw string
-
-	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	actual := make(map[string]interface{})
-	err = yaml.Unmarshal([]byte(res), &actual)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	if _, ok := actual["ssh_authorized_keys"]; !ok {
-		t.Error("ssh_authorized_keys missing")
-	}
-}
-
-func TestCloudInitMergeUserDataIntoUserDataRawGivesPrecedenceToRawData(t *testing.T) {
-	udKey := "user-data-key"
-	ud := defCloudInitUserData{
-		SSHAuthorizedKeys: []string{udKey},
-	}
-
-	var userDataRaw = `
-new-key: new-value-set-by-extra
-ssh_authorized_keys:
-  - key2-from-extra-data
-`
-
-	res, err := mergeUserDataIntoUserDataRaw(ud, userDataRaw)
-	if err != nil {
-		t.Errorf("Unexpectd error %v", err)
-	}
-
-	if strings.Contains(res, udKey) {
-		t.Error("Should not have found string defined by user data")
-	}
-
-	if !strings.Contains(res, "key2-from-extra-data") {
-		t.Error("Should have found string defined by raw data")
 	}
 }
 

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -20,11 +20,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"libvirt_domain":    resourceLibvirtDomain(),
-			"libvirt_volume":    resourceLibvirtVolume(),
-			"libvirt_network":   resourceLibvirtNetwork(),
-			"libvirt_cloudinit": resourceCloudInit(),
-			"libvirt_ignition":  resourceIgnition(),
+			"libvirt_domain":         resourceLibvirtDomain(),
+			"libvirt_volume":         resourceLibvirtVolume(),
+			"libvirt_network":        resourceLibvirtNetwork(),
+			"libvirt_cloudinit_disk": resourceCloudInitDisk(),
+			"libvirt_ignition":       resourceIgnition(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/libvirt/resource_libvirt_cloud_init.go
+++ b/libvirt/resource_libvirt_cloud_init.go
@@ -7,12 +7,12 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceCloudInit() *schema.Resource {
+func resourceCloudInitDisk() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudInitCreate,
-		Read:   resourceCloudInitRead,
-		Delete: resourceCloudInitDelete,
-		Exists: resourceCloudInitExists,
+		Create: resourceCloudInitDiskCreate,
+		Read:   resourceCloudInitDiskRead,
+		Delete: resourceCloudInitDiskDelete,
+		Exists: resourceCloudInitDiskExists,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -44,7 +44,7 @@ func resourceCloudInit() *schema.Resource {
 	}
 }
 
-func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] creating cloudinit")
 	client := meta.(*Client)
 	virConn := client.libvirt
@@ -77,10 +77,10 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.Partial(false)
 
-	return resourceCloudInitRead(d, meta)
+	return resourceCloudInitDiskRead(d, meta)
 }
 
-func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitDiskRead(d *schema.ResourceData, meta interface{}) error {
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
@@ -98,7 +98,7 @@ func resourceCloudInitRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudInitDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
@@ -112,8 +112,8 @@ func resourceCloudInitDelete(d *schema.ResourceData, meta interface{}) error {
 	return removeVolume(client, key)
 }
 
-func resourceCloudInitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	log.Printf("[DEBUG] Check if resource libvirt_cloudinit exists")
+func resourceCloudInitDiskExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	log.Printf("[DEBUG] Check if resource libvirt_cloudinit_disk exists")
 	client := meta.(*Client)
 	if client.libvirt == nil {
 		return false, fmt.Errorf(LibVirtConIsNil)

--- a/libvirt/resource_libvirt_cloud_init.go
+++ b/libvirt/resource_libvirt_cloud_init.go
@@ -61,7 +61,11 @@ func resourceCloudInitCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] cloudInit: %+v", cloudInit)
 
-	key, err := cloudInit.CreateAndUpload(client)
+	iso, err := cloudInit.CreateIso()
+	if err != nil {
+		return err
+	}
+	key, err := cloudInit.UploadIso(client, iso)
 	if err != nil {
 		return err
 	}

--- a/libvirt/resource_libvirt_cloud_init_test.go
+++ b/libvirt/resource_libvirt_cloud_init_test.go
@@ -126,20 +126,18 @@ func TestAccLibvirtCloudInit_ManuallyDestroyed(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudInitVolumeExists(n string, volume *libvirt.StorageVol) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+func testAccCheckCloudInitVolumeExists(volumeName string, volume *libvirt.StorageVol) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
 
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+		rs, err := getResourceFromTerraformState(volumeName, state)
+		if err != nil {
+			return err
 		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt volume key ID is set")
-		}
-
 		cikey, err := getCloudInitVolumeKeyFromTerraformID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 		retrievedVol, err := virConn.LookupStorageVolByKey(cikey)
 		if err != nil {
 			return err

--- a/libvirt/resource_libvirt_cloud_init_test.go
+++ b/libvirt/resource_libvirt_cloud_init_test.go
@@ -16,6 +16,7 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 	// this structs are contents values we expect.
 	expectedContents := Expected{UserData: "#cloud-config", NetworkConfig: "network:", MetaData: "instance-id: bamboo"}
 	expectedContents2 := Expected{UserData: "#cloud-config2", NetworkConfig: "network2:", MetaData: "instance-id: bamboo2"}
+	expectedContentsEmpty := Expected{UserData: "#cloud-config2", NetworkConfig: "", MetaData: ""}
 	randomIsoName := acctest.RandString(10) + ".iso"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -54,6 +55,20 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
 					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
 					expectedContents2.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "libvirt_cloudinit" "%s" {
+								name           = "%s"
+								user_data      = "#cloud-config2"
+							}`, randomResourceName, randomIsoName),
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
+					expectedContentsEmpty.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
 				),
 			},
 		},

--- a/libvirt/resource_libvirt_cloud_init_test.go
+++ b/libvirt/resource_libvirt_cloud_init_test.go
@@ -27,7 +27,7 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-					resource "libvirt_cloudinit" "%s" {
+					resource "libvirt_cloudinit_disk" "%s" {
 								name           = "%s"
 								user_data      = "#cloud-config"
 								meta_data = "instance-id: bamboo"
@@ -36,14 +36,14 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
-					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
-					expectedContents.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
+						"libvirt_cloudinit_disk."+randomResourceName, "name", randomIsoName),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit_disk."+randomResourceName, &volume),
+					expectedContents.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit_disk."+randomResourceName, &volume),
 				),
 			},
 			{
 				Config: fmt.Sprintf(`
-					resource "libvirt_cloudinit" "%s" {
+					resource "libvirt_cloudinit_disk" "%s" {
 								name           = "%s"
 								user_data      = "#cloud-config2"
 								meta_data = "instance-id: bamboo2"
@@ -52,29 +52,29 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
-					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
-					expectedContents2.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
+						"libvirt_cloudinit_disk."+randomResourceName, "name", randomIsoName),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit_disk."+randomResourceName, &volume),
+					expectedContents2.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit_disk."+randomResourceName, &volume),
 				),
 			},
 			{
 				Config: fmt.Sprintf(`
-					resource "libvirt_cloudinit" "%s" {
+					resource "libvirt_cloudinit_disk" "%s" {
 								name           = "%s"
 								user_data      = "#cloud-config2"
 							}`, randomResourceName, randomIsoName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
-					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
-					expectedContentsEmpty.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
+						"libvirt_cloudinit_disk."+randomResourceName, "name", randomIsoName),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit_disk."+randomResourceName, &volume),
+					expectedContentsEmpty.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit_disk."+randomResourceName, &volume),
 				),
 			},
 			// when we apply 2 times with same conf, we should not have a diff. See bug:
 			// https://github.com/dmacvicar/terraform-provider-libvirt/issues/313
 			{
 				Config: fmt.Sprintf(`
-						resource "libvirt_cloudinit" "%s" {
+						resource "libvirt_cloudinit_disk" "%s" {
 									name           = "%s"
 									user_data      = "#cloud-config4"
 								}`, randomResourceName, randomIsoName),
@@ -82,9 +82,9 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 				PlanOnly:           true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"libvirt_cloudinit."+randomResourceName, "name", randomIsoName),
-					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
-					expectedContentsEmpty.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit."+randomResourceName, &volume),
+						"libvirt_cloudinit_disk."+randomResourceName, "name", randomIsoName),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit_disk."+randomResourceName, &volume),
+					expectedContentsEmpty.testAccCheckCloudInitDiskFilesContent("libvirt_cloudinit_disk."+randomResourceName, &volume),
 				),
 			},
 		},
@@ -100,7 +100,7 @@ func TestAccLibvirtCloudInit_ManuallyDestroyed(t *testing.T) {
 	randomResourceName := acctest.RandString(10)
 
 	testAccCheckLibvirtCloudInitConfigBasic := fmt.Sprintf(`
-    	resource "libvirt_cloudinit" "%s" {
+    	resource "libvirt_cloudinit_disk" "%s" {
   	  name           = "%s"
 			pool           = "default"
 			user_data      = "#cloud-config\nssh_authorized_keys: []\n"
@@ -113,7 +113,7 @@ func TestAccLibvirtCloudInit_ManuallyDestroyed(t *testing.T) {
 			{
 				Config: testAccCheckLibvirtCloudInitConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudInitVolumeExists("libvirt_cloudinit."+randomResourceName, &volume),
+					testAccCheckCloudInitVolumeExists("libvirt_cloudinit_disk."+randomResourceName, &volume),
 				),
 			},
 			{

--- a/libvirt/utils_test.go
+++ b/libvirt/utils_test.go
@@ -3,12 +3,30 @@ package libvirt
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform/terraform"
 )
+
+// getResourceFromTerraformState is helper function for getting a resource by name
+// from terraform states produced during testacc
+func getResourceFromTerraformState(resourceName string, state *terraform.State) (*terraform.ResourceState, error) {
+	rs, ok := state.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s", resourceName)
+	}
+
+	if rs.Primary.ID == "" {
+		return nil, fmt.Errorf("No libvirt resource key ID is set")
+	}
+	return rs, nil
+
+}
 
 func TestDiskLetterForIndex(t *testing.T) {
 

--- a/libvirt/utils_test.go
+++ b/libvirt/utils_test.go
@@ -3,30 +3,12 @@ package libvirt
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/terraform/terraform"
 )
-
-// getResourceFromTerraformState is helper function for getting a resource by name
-// from terraform states produced during testacc
-func getResourceFromTerraformState(resourceName string, state *terraform.State) (*terraform.ResourceState, error) {
-	rs, ok := state.RootModule().Resources[resourceName]
-	if !ok {
-		return nil, fmt.Errorf("Not found: %s", resourceName)
-	}
-
-	if rs.Primary.ID == "" {
-		return nil, fmt.Errorf("No libvirt resource key ID is set")
-	}
-	return rs, nil
-
-}
 
 func TestDiskLetterForIndex(t *testing.T) {
 

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "libvirt"
-page_title: "Libvirt: libvirt_cloudinit"
+page_title: "Libvirt: libvirt_cloudinit_disk"
 sidebar_current: "docs-libvirt-cloudinit"
 description: |-
   Manages a cloud-init ISO to attach to a domain
@@ -14,7 +14,7 @@ used to customize a domain during first boot.
 ## Example Usage
 
 ```hcl
-resource "libvirt_cloudinit" "commoninit" {
+resource "libvirt_cloudinit_disk" "commoninit" {
   name = "commoninit.iso"
 }
 

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "libvirt"
 page_title: "Libvirt: libvirt_cloudinit_disk"
-sidebar_current: "docs-libvirt-cloudinit"
+sidebar_current: "docs-libvirt-cloudinit-disk"
 description: |-
-  Manages a cloud-init ISO to attach to a domain
+  Manages a cloud-init ISO disk to attach to a domain
 ---
 
-# libvirt\_cloudinit
+# libvirt\_cloudinit\_disk
 
 Manages a [cloud-init](http://cloudinit.readthedocs.io/) ISO disk that can be
 used to customize a domain during first boot.
@@ -16,9 +16,27 @@ used to customize a domain during first boot.
 ```hcl
 resource "libvirt_cloudinit_disk" "commoninit" {
   name = "commoninit.iso"
+  user_data          = "${data.template_file.user_data.rendered}"
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/cloud_init.cfg")}"
 }
 
 ```
+
+where `cloud_init_cfg` is a file on same dir level of the terraform tf.file
+```
+#cloud-config
+ssh_pwauth: True
+chpasswd:
+  list: |
+     root:linux
+  expire: False
+```
+
+In this example we change with help of cloud-init the root pwd.
+Take also insipiration from ubuntu.tf https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/examples/ubuntu/ubuntu-example.tf
 
 ## Argument Reference
 
@@ -32,4 +50,4 @@ The following arguments are supported:
 
 * `user_data` - (Optional)  cloud-init user data.
 * `meta_data` - (Optional)  cloud-init user data.
-# `network_config` - (Optional) cloud-init network-config data.
+* `network_config` - (Optional) cloud-init network-config data.

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -27,9 +27,9 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by libvirt.
 * `pool` - (Optional) The pool where the resource will be created.
   If not given, the `default` pool will be used.
+  For user_data, network_config and meta_data parameters have a look at upstream doc:
+   http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html#datasource-nocloud
+
 * `user_data` - (Optional)  cloud-init user data.
 * `meta_data` - (Optional)  cloud-init user data.
 # `network_config` - (Optional) cloud-init network-config data.
-
-For user_data, network_config and meta_data parameters have a look at:
- http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html#datasource-nocloud

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -16,7 +16,6 @@ used to customize a domain during first boot.
 ```hcl
 resource "libvirt_cloudinit" "commoninit" {
   name = "commoninit.iso"
-  local_hostname = "node"
 }
 
 ```
@@ -28,13 +27,9 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the resource, required by libvirt.
 * `pool` - (Optional) The pool where the resource will be created.
   If not given, the `default` pool will be used.
-* `local_hostname` - (Optional) If specified this is going to be the hostname of
-  the domain.
-* `ssh_authorized_key` - (Optional) A public ssh key that will be accepted by
-  the `root` user.
-* `user_data` - (Optional) Raw cloud-init user data. This content will
-  be merged automatically with the values specified in other arguments
-  (like `local_hostname`, `ssh_authorized_key`, etc). The contents of
-  `user_data` will take precedence over the ones defined by the other keys.
+* `user_data` - (Optional)  cloud-init user data.
+* `meta_data` - (Optional)  cloud-init user data.
+# `network_config` - (Optional) cloud-init network-config data.
 
-Any change of the above fields will cause a new resource to be created.
+For user_data, network_config and meta_data parameters have a look at:
+ http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html#datasource-nocloud

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `network_interface` - (Optional) An array of one or more network interfaces to
   attach to the domain. The `network_interface` object structure is documented
   [below](#handling-network-interfaces).
-* `cloudinit` - (Optional) The `libvirt_cloudinit` disk that has to be used by
+* `cloudinit` - (Optional) The `libvirt_cloudinit_disk` disk that has to be used by
   the domain. This is going to be attached as a CDROM ISO. Changing the
   cloud-init won't cause the domain to be recreated, however the change will
   have effect on the next reboot.

--- a/website/libvirt.erb
+++ b/website/libvirt.erb
@@ -14,7 +14,7 @@
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-libvirt-resource-cloudinit") %>>
-              <a href="/docs/providers/libvirt/r/cloudinit.html">libvirt_cloudinit</a>
+              <a href="/docs/providers/libvirt/r/cloudinit.html">libvirt_cloudinit_disk</a>
             </li>
             <li<%= sidebar_current("docs-libvirt-resource-coreos-ignition") %>>
               <a href="/docs/providers/libvirt/r/coreos_ignition.html">libvirt_ignition</a>


### PR DESCRIPTION
## TODOS:

- [x] Remove todos in codebase

- [x] add some negative tests

- [x] documentation
- [x] split in readable commits

- [x] rename cloud_init into `cloud_init_disk`



fix #313 #384 


example:

```hcl

# instance the provider
provider "libvirt" {
  uri = "qemu:///system"
}

# We fetch the latest ubuntu release image from their mirrors
resource "libvirt_volume" "ubuntu-qcow2" {
  name = "ubuntu-qcow2"
  pool = "default"
  source = "https://cloud-images.ubuntu.com/releases/xenial/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img"
  format = "qcow2"
}

# Use CloudInit to add our ssh-key to the instance
resource "libvirt_cloudinit" "test" {
          name           = "test.iso"
          user_data          = "${data.template_file.user_data.rendered}"
		network_config = <<EOF
		network:
		version: 2
		ethernets:
		eno1:
		dhcp4: true
		EOF
}


data "template_file" "user_data" {
  template = "${file("${path.module}/cloud_init.cfg")}"
}

# Create the machine
resource "libvirt_domain" "domain-ubuntu" {
  name = "ubuntu-terraform"
  memory = "512"
  vcpu = 1

  cloudinit = "${libvirt_cloudinit.test.id}"

  # IMPORTANT
  # Ubuntu can hang if an isa-serial is not present at boot time.
  # If you find your CPU 100% and never is available this is why
  console {
    type        = "pty"
    target_port = "0"
    target_type = "serial"
  }

  console {
      type        = "pty"
      target_type = "virtio"
      target_port = "1"
  }

  disk {
       volume_id = "${libvirt_volume.ubuntu-qcow2.id}"
  }
  graphics {
    type = "spice"
    listen_type = "address"
    autoport = true
  }
}
```
cloudinit file
```
#cloud-config
ssh_pwauth: True
chpasswd:
  list: |
     root:linux
     cloud-user:atomic
  expire: False
```