### PR TITLE
Remove deprecated getDomainInterfacesFromNetworks

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -493,8 +493,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[INFO] Domain ID: %s", d.Id())
 
 	if len(waitForLeases) > 0 {
-		err = domainWaitForLeases(domain, waitForLeases, d.Timeout(schema.TimeoutCreate),
-			domainDef, virConn, d)
+		err = domainWaitForLeases(domain, waitForLeases, d.Timeout(schema.TimeoutCreate), d)
 		if err != nil {
 			return err
 		}
@@ -781,7 +780,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("filesystems", filesystems)
 
 	// lookup interfaces with addresses
-	ifacesWithAddr, err := domainGetIfacesInfo(*domain, domainDef, virConn, d)
+	ifacesWithAddr, err := domainGetIfacesInfo(*domain, d)
 	if err != nil {
 		return fmt.Errorf("Error retrieving interface addresses: %s", err)
 	}


### PR DESCRIPTION
# What does this PR?

So basically i found out that `getDomainInterfacesFromNetworks` function is never used. ( see testscode coverage) and i try it out manually. (see here https://github.com/dmacvicar/terraform-provider-libvirt/issues/425#issue-361766883, for more details)
This is since https://github.com/dmacvicar/terraform-provider-libvirt/commit/7b2adfc1f28d76399d63aaf50ff914268efbb87a

After analyzing a little, if you look at 
https://github.com/dmacvicar/terraform-provider-libvirt/blob/2150005da77ddc623992685a8a574c8c170c37e6/libvirt/domain.go#L244

```if mac == domMac {```
this is not correct instead should be

```if strings.ToUpper(mac) == domMac {```

Once you uppercase the mac the function will work.

## why i want still want  remove it:

I am still want to remove this function because since the merge it never worked.

Now even if we could fix it to make it working, i don't see any advantage for having it.

This function is also impacting considerable the performance of the plugin ( i noticed when doing the testacc tests were slow once i have fixed the function.)

Other then performance it add code complexity which in the network part we still have, so i would just remove it for simplifing the codebase.

For code complexity motivation i mean following:

when we do https://github.com/dmacvicar/terraform-provider-libvirt/blob/2150005da77ddc623992685a8a574c8c170c37e6/libvirt/domain.go#L150

we are basically trying in 3 ways to get the Interfaces. ( 1 is with the qemu-agent is ok)

Then we have the 2 which are doing the same thing,  so i get the impression that we are `trying` to  do things in order to work or getting the interface.

https://github.com/dmacvicar/terraform-provider-libvirt/blob/2150005da77ddc623992685a8a574c8c170c37e6/libvirt/domain.go#L170


Last argument for removal is that if until now we never experienced a bug without it, why we should keep  it ? :small_airplane: 


fix #425 