### PR TITLE
refactor and generalize more codebase of testacc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,3 @@ script:
   - make gofmtcheck
   - make vet
   - golint -set_exit_status libvirt/
-  - make test
-  - goveralls -coverprofile=profile.cov -service=travis-ci

--- a/libvirt/acceptance_tests_functions_helpers.go
+++ b/libvirt/acceptance_tests_functions_helpers.go
@@ -2,6 +2,7 @@ package libvirt
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/terraform"
 	libvirt "github.com/libvirt/libvirt-go"
@@ -23,6 +24,21 @@ func getResourceFromTerraformState(resourceName string, state *terraform.State) 
 		return nil, fmt.Errorf("No libvirt resource key ID is set")
 	}
 	return rs, nil
+}
+
+// getVolumeFromTerraformState lookup volume by name and return the libvirt volume from a terraform state
+func getVolumeFromTerraformState(name string, state *terraform.State, virConn libvirt.Connect) (*libvirt.StorageVol, error) {
+	rs, err := getResourceFromTerraformState(name, state)
+	if err != nil {
+		return nil, err
+	}
+
+	vol, err := virConn.LookupStorageVolByKey(rs.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("[DEBUG]:The ID is %s", rs.Primary.ID)
+	return vol, nil
 }
 
 // helper used in network tests for retrieve xml network definition.

--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -10,9 +10,8 @@ import (
 
 func TestAccLibvirtNetworkDataSource_DNSHostTemplate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 
 			{

--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -33,13 +33,11 @@ func TestAccLibvirtNetworkDataSource_DNSHostTemplate(t *testing.T) {
 }
 
 func checkDNSHostTemplate(id, name, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[id]
-		if !ok {
-			return fmt.Errorf("Not found: %s", id)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+	return func(state *terraform.State) error {
+
+		rs, err := getResourceFromTerraformState(id, state)
+		if err != nil {
+			return err
 		}
 
 		v := rs.Primary.Attributes[name]

--- a/libvirt/resource_libvirt_cloud_init_test.go
+++ b/libvirt/resource_libvirt_cloud_init_test.go
@@ -19,11 +19,9 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 	expectedContentsEmpty := Expected{UserData: "#cloud-config2", NetworkConfig: "", MetaData: ""}
 	randomIsoName := acctest.RandString(10) + ".iso"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return nil
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_cloudinit_disk", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -107,8 +105,9 @@ func TestAccLibvirtCloudInit_ManuallyDestroyed(t *testing.T) {
 		}`, randomResourceName, randomResourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_cloudinit_disk", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckLibvirtCloudInitConfigBasic,

--- a/libvirt/resource_libvirt_coreos_ignition_test.go
+++ b/libvirt/resource_libvirt_coreos_ignition_test.go
@@ -51,17 +51,13 @@ func TestAccLibvirtIgnition_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIgnitionVolumeExists(n string, volume *libvirt.StorageVol) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+func testAccCheckIgnitionVolumeExists(name string, volume *libvirt.StorageVol) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
 
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt ignition key ID is set")
+		rs, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		ignKey, err := getIgnitionVolumeKeyFromTerraformID(rs.Primary.ID)

--- a/libvirt/resource_libvirt_coreos_ignition_test.go
+++ b/libvirt/resource_libvirt_coreos_ignition_test.go
@@ -35,7 +35,7 @@ func TestAccLibvirtIgnition_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtIgnitionDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_ignition", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -83,30 +83,4 @@ func testAccCheckIgnitionVolumeExists(name string, volume *libvirt.StorageVol) r
 		*volume = *retrievedVol
 		return nil
 	}
-}
-
-func testAccCheckLibvirtIgnitionDestroy(s *terraform.State) error {
-	virtConn := testAccProvider.Meta().(*Client).libvirt
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "libvirt_ignition" {
-			continue
-		}
-
-		// Try to find the Ignition Volume
-
-		ignKey, errKey := getIgnitionVolumeKeyFromTerraformID(rs.Primary.ID)
-		if errKey != nil {
-			return errKey
-		}
-
-		_, err := virtConn.LookupStorageVolByKey(ignKey)
-		if err == nil {
-			return fmt.Errorf(
-				"Error waiting for IgnitionVolume (%s) to be destroyed: %s",
-				ignKey, err)
-		}
-	}
-
-	return nil
 }

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -863,21 +863,11 @@ func testAccCheckLibvirtURLDisk(u *url.URL, domain *libvirt.Domain) resource.Tes
 func testAccCheckLibvirtDestroyLeavesIPs(name string, ip string, network *libvirt.Network) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
-		rs, err := getResourceFromTerraformState(name, state)
-		if err != nil {
-			return err
-		}
-
 		virConn := testAccProvider.Meta().(*Client).libvirt
-
-		retrieveNetwork, err := virConn.LookupNetworkByUUIDString(rs.Primary.ID)
-
+		networkDef, err := getNetworkDef(state, name, *virConn)
 		if err != nil {
 			return err
 		}
-
-		networkDef, err := getXMLNetworkDefFromLibvirt(retrieveNetwork)
-
 		for _, ips := range networkDef.IPs {
 			for _, dhcpHost := range ips.DHCP.Hosts {
 				if dhcpHost.IP == ip {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -748,15 +748,12 @@ func testAccCheckLibvirtDomainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckLibvirtDomainExists(n string, domain *libvirt.Domain) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+func testAccCheckLibvirtDomainExists(name string, domain *libvirt.Domain) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt domain ID is set")
+		rs, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		virConn := testAccProvider.Meta().(*Client).libvirt
@@ -863,15 +860,12 @@ func testAccCheckLibvirtURLDisk(u *url.URL, domain *libvirt.Domain) resource.Tes
 	}
 }
 
-func testAccCheckLibvirtDestroyLeavesIPs(n string, ip string, network *libvirt.Network) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+func testAccCheckLibvirtDestroyLeavesIPs(name string, ip string, network *libvirt.Network) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt network ID is set")
+		rs, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		virConn := testAccProvider.Meta().(*Client).libvirt
@@ -1098,15 +1092,12 @@ func TestAccLibvirtDomain_ArchType(t *testing.T) {
 	})
 }
 
-func testAccCheckLibvirtNetworkExists(n string, network *libvirt.Network) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+func testAccCheckLibvirtNetworkExists(name string, network *libvirt.Network) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt network ID is set")
+		rs, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		virConn := testAccProvider.Meta().(*Client).libvirt
@@ -1195,16 +1186,12 @@ func TestAccLibvirtDomain_ShutoffMultiDomainsRunning(t *testing.T) {
 	})
 }
 
-func testAccCheckLibvirtDomainStateEqual(n string, domain *libvirt.Domain, exptectedState string) resource.TestCheckFunc {
+func testAccCheckLibvirtDomainStateEqual(name string, domain *libvirt.Domain, exptectedState string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt domain ID is set")
+		rs, err := getResourceFromTerraformState(name, s)
+		if err != nil {
+			return err
 		}
 
 		virConn := testAccProvider.Meta().(*Client).libvirt

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -23,7 +23,7 @@ func TestAccLibvirtDomain_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -51,7 +51,7 @@ func TestAccLibvirtDomain_Detailed(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -99,7 +99,7 @@ func TestAccLibvirtDomain_Volume(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: configVolAttached,
@@ -154,7 +154,7 @@ func TestAccLibvirtDomain_VolumeTwoDisks(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: configVolAttached,
@@ -210,7 +210,7 @@ func TestAccLibvirtDomain_VolumeDriver(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -254,7 +254,7 @@ func TestAccLibvirtDomain_ScsiDisk(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: configScsi,
@@ -303,7 +303,7 @@ func TestAccLibvirtDomain_URLDisk(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: configURL,
@@ -354,7 +354,7 @@ func TestAccLibvirtDomain_KernelInitrdCmdline(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -404,7 +404,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -454,7 +454,7 @@ func TestAccLibvirtDomain_CheckDHCPEntries(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config:             configWithDomain,
@@ -504,7 +504,7 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -553,7 +553,7 @@ func TestAccLibvirtDomain_IgnitionObject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -582,7 +582,7 @@ func TestAccLibvirtDomain_Cpu(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -614,7 +614,7 @@ func TestAccLibvirtDomain_Autostart(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: autostartTrue,
@@ -656,7 +656,7 @@ func TestAccLibvirtDomain_Filesystems(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -702,7 +702,7 @@ func TestAccLibvirtDomain_Consoles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -726,26 +726,6 @@ func TestAccLibvirtDomain_Consoles(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckLibvirtDomainDestroy(s *terraform.State) error {
-	virtConn := testAccProvider.Meta().(*Client).libvirt
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "libvirt_domain" {
-			continue
-		}
-
-		// Try to find the server
-		_, err := virtConn.LookupDomainByUUIDString(rs.Primary.ID)
-		if err == nil {
-			return fmt.Errorf(
-				"Error waiting for domain (%s) to be destroyed: %s",
-				rs.Primary.ID, err)
-		}
-	}
-
-	return nil
 }
 
 func testAccCheckLibvirtDomainExists(name string, domain *libvirt.Domain) resource.TestCheckFunc {
@@ -972,7 +952,7 @@ func subtestAccLibvirtDomainFirmwareNoTemplate(t *testing.T, NVRAMPath string, f
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -1010,7 +990,7 @@ func subtestAccLibvirtDomainFirmwareTemplate(t *testing.T, NVRAMPath string, fir
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -1043,7 +1023,7 @@ func TestAccLibvirtDomain_MachineType(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -1069,7 +1049,7 @@ func TestAccLibvirtDomain_ArchType(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -1124,7 +1104,7 @@ func TestAccLibvirtDomain_ShutoffDomain(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -1153,7 +1133,7 @@ func TestAccLibvirtDomain_ShutoffMultiDomainsRunning(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -1222,7 +1202,7 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_domain", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(`

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -18,7 +18,7 @@ func TestAccCheckLibvirtNetwork_LocalOnly(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -67,7 +67,7 @@ func TestAccCheckLibvirtNetwork_DNSForwarders(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -152,7 +152,7 @@ func TestAccLibvirtNetwork_DNSHosts(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -293,24 +293,6 @@ func testAccCheckLibvirtNetworkDhcpStatus(name string, expectedDhcpStatus string
 	}
 }
 
-func testAccCheckLibvirtNetworkDestroy(s *terraform.State) error {
-	virtConn := testAccProvider.Meta().(*Client).libvirt
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "libvirt_network" {
-			continue
-		}
-		_, err := virtConn.LookupNetworkByUUIDString(rs.Primary.ID)
-		if err == nil {
-			return fmt.Errorf(
-				"Error waiting for network (%s) to be destroyed: %s",
-				rs.Primary.ID, err)
-		}
-	}
-
-	return nil
-}
-
 func TestAccLibvirtNetwork_Import(t *testing.T) {
 	var network libvirt.Network
 	randomNetworkResource := acctest.RandString(10)
@@ -320,7 +302,7 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(`
@@ -348,7 +330,7 @@ func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -376,7 +358,7 @@ func TestAccLibvirtNetwork_DhcpDisabled(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -425,7 +407,7 @@ func TestAccLibvirtNetwork_BridgedMode(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -450,7 +432,7 @@ func TestAccLibvirtNetwork_Autostart(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_network", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -13,25 +13,6 @@ import (
 	libvirt "github.com/libvirt/libvirt-go"
 )
 
-func testAccCheckLibvirtVolumeDestroy(state *terraform.State) error {
-	virConn := testAccProvider.Meta().(*Client).libvirt
-
-	for _, rs := range state.RootModule().Resources {
-		if rs.Type != "libvirt_volume" {
-			continue
-		}
-
-		_, err := virConn.LookupStorageVolByKey(rs.Primary.ID)
-		if err == nil {
-			return fmt.Errorf(
-				"Error waiting for volume (%s) to be destroyed: %s",
-				rs.Primary.ID, err)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckLibvirtVolumeExists(name string, volume *libvirt.StorageVol) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
@@ -118,7 +99,7 @@ func TestAccLibvirtVolume_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -146,7 +127,7 @@ func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -176,7 +157,7 @@ func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -214,7 +195,7 @@ func TestAccLibvirtVolume_ManuallyDestroyed(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckLibvirtVolumeConfigBasic,
@@ -257,7 +238,7 @@ func TestAccLibvirtVolume_UniqueName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
@@ -293,7 +274,7 @@ func TestAccLibvirtVolume_DownloadFromSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -336,7 +317,7 @@ func TestAccLibvirtVolume_DownloadFromSourceFormat(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -365,7 +346,7 @@ func TestAccLibvirtVolume_Format(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -395,7 +376,7 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_volume", *testAccProvider.Meta().(*Client).libvirt),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: fmt.Sprintf(`

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -41,11 +41,10 @@ func testAccCheckLibvirtVolumeExists(name string, volume *libvirt.StorageVol) re
 			return err
 		}
 
-		retrievedVol, err := virConn.LookupStorageVolByKey(rs.Primary.ID)
+		retrievedVol, err := getVolumeFromTerraformState(name, state, *virConn)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("The ID is %s", rs.Primary.ID)
 
 		realID, err := retrievedVol.GetKey()
 		if err != nil {
@@ -85,12 +84,7 @@ func testAccCheckLibvirtVolumeIsBackingStore(name string, volume *libvirt.Storag
 	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
 
-		resource, err := getResourceFromTerraformState(name, state)
-		if err != nil {
-			return err
-		}
-
-		vol, err := virConn.LookupStorageVolByKey(resource.Primary.ID)
+		vol, err := getVolumeFromTerraformState(name, state, *virConn)
 		if err != nil {
 			return err
 		}

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -33,16 +33,12 @@ func testAccCheckLibvirtVolumeDestroy(state *terraform.State) error {
 }
 
 func testAccCheckLibvirtVolumeExists(name string, volume *libvirt.StorageVol) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
 
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No libvirt volume key ID is set")
+		rs, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		retrievedVol, err := virConn.LookupStorageVolByKey(rs.Primary.ID)
@@ -86,16 +82,12 @@ func testAccCheckLibvirtVolumeDoesNotExists(n string, volume *libvirt.StorageVol
 }
 
 func testAccCheckLibvirtVolumeIsBackingStore(name string, volume *libvirt.StorageVol) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(state *terraform.State) error {
 		virConn := testAccProvider.Meta().(*Client).libvirt
 
-		resource, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		if resource.Primary.ID == "" {
-			return fmt.Errorf("No libvirt volume key ID is set")
+		resource, err := getResourceFromTerraformState(name, state)
+		if err != nil {
+			return err
 		}
 
 		vol, err := virConn.LookupStorageVolByKey(resource.Primary.ID)


### PR DESCRIPTION
## Major highlights for this PR:

0) `80` Lines of code removed. :tada:  Would be contraproductive the contrary for a refactor :smile: 

1) CheckDestroy
Instead of having each Resource test redefine the `destroyCheck` have it generic only in 1 place.
like: 
`CheckDestroy: testaccCheckLibvirtDestroyResource("libvirt_cloudinit_disk", *testAccProvider.Meta().(*Client).libvirt),`

https://github.com/dmacvicar/terraform-provider-libvirt/pull/430/commits/f97b4800b5d974fe1c3837ef5fbbdc3c5f2f0058

___ 
#### 2) getVolumeFromTerraformState
creating  generic helper for `getVolumeFromTerraformState`  https://github.com/dmacvicar/terraform-provider-libvirt/pull/430/commits/4fb6e3e539782842b58a6eb6127f4c8768ac28a8

___
#### 3) getNetworkDef
  move  getNetworkDef from Network.go test to global place for helper libvirt/acceptance_tests_functions_helpers.go` and use it in the domain testacc 
https://github.com/dmacvicar/terraform-provider-libvirt/pull/430/commits/adbdbefb58c7cfd4a5272c8b9b36769fe4c2b2f6

___
#### 4) getResourceFromTerraformState
 use `getResourceFromTerraformState` for  all testacc  https://github.com/dmacvicar/terraform-provider-libvirt/pull/430/commits/e52bb64963f4363fe390e9b7167f7ebe3ed1662d