### PR TITLE
Initial prototype of a XML transformation hook based on XSLT

### DIFF
--- a/examples/xslt/main.tf
+++ b/examples/xslt/main.tf
@@ -1,0 +1,16 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+resource "libvirt_domain" "xslt-demo-domain" {
+  name = "xslt-demo-domain"
+  memory = "512"
+
+  network_interface {
+    network_name = "default"
+  }
+
+  xml {
+    xslt = "${file("nicmodel.xsl")}"
+  }
+}

--- a/examples/xslt/nicmodel.xsl
+++ b/examples/xslt/nicmodel.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:template match="node()|@*">
+     <xsl:copy>
+       <xsl:apply-templates select="node()|@*"/>
+     </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/domain/devices/interface[@type='network']/model/@type">
+    <xsl:attribute name="type">
+      <xsl:value-of select="'e1000'"/>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -348,6 +348,20 @@ func resourceLibvirtDomain() *schema.Resource {
 				Default:  false,
 				ForceNew: false,
 			},
+			"xml": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"xslt": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -456,8 +470,12 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return fmt.Errorf("Error serializing libvirt domain: %s", err)
 	}
+	log.Printf("[DEBUG] Generated XML for libvirt domain:\n%s", data)
 
-	log.Printf("[DEBUG] Creating libvirt domain with XML:\n%s", data)
+	data, err = transformResourceXML(data, d)
+	if err != nil {
+		return fmt.Errorf("Error applying XSLT stylesheet: %s", err)
+	}
 
 	domain, err := virConn.DomainDefineXML(data)
 	if err != nil {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -1229,6 +1229,121 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtDomain_XSLT_UnsupportedAttribute(t *testing.T) {
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandString(10)
+	randomNetworkName := acctest.RandString(10)
+
+	var config = fmt.Sprintf(`
+	resource "libvirt_network" "%s" {
+	  name      = "%s"
+  	  addresses = ["10.17.3.0/24"]
+    }
+
+	resource "libvirt_domain" "%s" {
+	  name = "%s"
+	  network_interface = {
+	    network_name = "default"
+	  }
+      xml {
+        xslt = <<EOF
+		<?xml version="1.0" ?>
+		<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+		  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+		  <xsl:template match="node()|@*">
+			 <xsl:copy>
+			   <xsl:apply-templates select="node()|@*"/>
+			 </xsl:copy>
+		  </xsl:template>
+
+		  <xsl:template match="/domain/devices/interface[@type='network']/model/@type">
+			<xsl:attribute name="type">
+			  <xsl:value-of select="'e1000'"/>
+			</xsl:attribute>
+		  </xsl:template>
+
+		</xsl:stylesheet>
+EOF
+      }
+	}`, randomNetworkName, randomNetworkName, randomDomainName, randomDomainName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					testAccCheckLibvirtDomainDescription(&domain, func(domainDef libvirtxml.Domain) error {
+						if domainDef.Devices.Interfaces[0].Model.Type != "e1000" {
+							return fmt.Errorf("Expecting XSLT to tranform network model to e1000")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtDomain_XSLT_SupportedAttribute(t *testing.T) {
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandString(10)
+	randomNetworkName := acctest.RandString(10)
+
+	var config = fmt.Sprintf(`
+	resource "libvirt_network" "%s" {
+	  name      = "%s"
+  	  addresses = ["10.17.3.0/24"]
+    }
+
+	resource "libvirt_domain" "%s" {
+	  name = "%s"
+	  network_interface = {
+	    network_name = "default"
+	  }
+      xml {
+        xslt = <<EOF
+        <?xml version="1.0" ?>
+          <xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:output omit-xml-declaration="yes" indent="yes"/>
+              <xsl:template match="node()|@*">
+              <xsl:copy>
+                <xsl:apply-templates select="node()|@*"/>
+              </xsl:copy>
+            </xsl:template>
+
+            <xsl:template match="/domain/devices/interface[@type='network']/source/@network">
+              <xsl:attribute name="network">
+                <xsl:value-of select="'%s'"/>
+              </xsl:attribute>
+            </xsl:template>
+          </xsl:stylesheet>
+EOF
+      }
+	}`, randomNetworkName, randomNetworkName, randomDomainName, randomDomainName, randomNetworkName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "network_interface.0.network_name", randomNetworkName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckLibvirtDomainDestroy(s *terraform.State) error {
 	virtConn := testAccProvider.Meta().(*Client).libvirt
 	for _, rs := range s.RootModule().Resources {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -1288,6 +1288,11 @@ EOF
 	})
 }
 
+// If using XSLT to transform a supported attribute by the terraform
+// provider schema, the provider will try to change it back to the
+// known state.
+// Therefore we explicitly advise against using it with existing
+// schema attributes
 func TestAccLibvirtDomain_XSLT_SupportedAttribute(t *testing.T) {
 	var domain libvirt.Domain
 	randomDomainName := acctest.RandString(10)

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -208,6 +208,21 @@ func resourceLibvirtNetwork() *schema.Resource {
 					},
 				},
 			},
+			"xml": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"xslt": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -439,6 +454,12 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	data, err := xmlMarshallIndented(networkDef)
 	if err != nil {
 		return fmt.Errorf("Error serializing libvirt network: %s", err)
+	}
+	log.Printf("[DEBUG] Generated XML for libvirt network:\n%s", data)
+
+	data, err = transformResourceXML(data, d)
+	if err != nil {
+		return fmt.Errorf("Error applying XSLT stylesheet: %s", err)
 	}
 
 	log.Printf("[DEBUG] Creating libvirt network at %s: %s", connectURI, data)

--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -1,0 +1,59 @@
+package libvirt
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// this function applies a XSLT transform to the xml data
+// and is to be reused in all resource types
+// your resource need to have a xml.xslt element in the schema
+func transformResourceXML(xml string, d *schema.ResourceData) (string, error) {
+	xslt, ok := d.GetOk("xml.0.xslt")
+	if !ok {
+		return xml, nil
+	}
+
+	xsltFile, err := ioutil.TempFile("", "terraform-provider-libvirt-xslt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(xsltFile.Name()) // clean up
+
+	// we trim the xslt as it may contain space before the xml declaration
+	// because of HCL heredoc
+	if _, err := xsltFile.Write([]byte(strings.TrimSpace(xslt.(string)))); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := xsltFile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	xmlFile, err := ioutil.TempFile("", "terraform-provider-libvirt-xml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(xmlFile.Name()) // clean up
+
+	if _, err := xmlFile.Write([]byte(xml)); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := xmlFile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	cmd := exec.Command("xsltproc", xsltFile.Name(), xmlFile.Name())
+	transformedXML, err := cmd.Output()
+	if err != nil {
+		return xml, err
+	}
+	log.Printf("[DEBUG] Transformed XML with user specified XSLT:\n%s", transformedXML)
+	return string(transformedXML), nil
+}

--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -11,14 +11,7 @@ import (
 )
 
 // this function applies a XSLT transform to the xml data
-// and is to be reused in all resource types
-// your resource need to have a xml.xslt element in the schema
-func transformResourceXML(xml string, d *schema.ResourceData) (string, error) {
-	xslt, ok := d.GetOk("xml.0.xslt")
-	if !ok {
-		return xml, nil
-	}
-
+func transformXML(xml string, xslt string) (string, error) {
 	xsltFile, err := ioutil.TempFile("", "terraform-provider-libvirt-xslt")
 	if err != nil {
 		log.Fatal(err)
@@ -27,7 +20,7 @@ func transformResourceXML(xml string, d *schema.ResourceData) (string, error) {
 
 	// we trim the xslt as it may contain space before the xml declaration
 	// because of HCL heredoc
-	if _, err := xsltFile.Write([]byte(strings.TrimSpace(xslt.(string)))); err != nil {
+	if _, err := xsltFile.Write([]byte(strings.TrimSpace(xslt))); err != nil {
 		log.Fatal(err)
 	}
 
@@ -56,4 +49,16 @@ func transformResourceXML(xml string, d *schema.ResourceData) (string, error) {
 	}
 	log.Printf("[DEBUG] Transformed XML with user specified XSLT:\n%s", transformedXML)
 	return string(transformedXML), nil
+}
+
+// this function applies a XSLT transform to the xml data
+// and is to be reused in all resource types
+// your resource need to have a xml.xslt element in the schema
+func transformResourceXML(xml string, d *schema.ResourceData) (string, error) {
+	xslt, ok := d.GetOk("xml.0.xslt")
+	if !ok {
+		return xml, nil
+	}
+
+	return transformXML(xml, xslt.(string))
 }

--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -76,7 +76,12 @@ func transformXML(xml string, xslt string) (string, error) {
 		log.Fatal(err)
 	}
 
-	cmd := exec.Command("xsltproc", xsltFile.Name(), xmlFile.Name())
+	cmd := exec.Command("xsltproc",
+		"--nomkdir",
+		"--nonet",
+		"--nowrite",
+		xsltFile.Name(),
+		xmlFile.Name())
 	transformedXML, err := cmd.Output()
 	if err != nil {
 		return xml, err

--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -46,6 +46,11 @@ func xsltDiffSupressFunc(k, old, new string, d *schema.ResourceData) bool {
 
 // this function applies a XSLT transform to the xml data
 func transformXML(xml string, xslt string) (string, error) {
+	// empty xslt is a no-op
+	if strings.TrimSpace(xslt) == "" {
+		return xml, nil
+	}
+
 	xsltFile, err := ioutil.TempFile("", "terraform-provider-libvirt-xslt")
 	if err != nil {
 		log.Fatal(err)

--- a/libvirt/utils_xslt_test.go
+++ b/libvirt/utils_xslt_test.go
@@ -1,0 +1,37 @@
+package libvirt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	identitySpaceStripXSLT = `
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:strip-space elements="*" />
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>
+`
+)
+
+func TestTransformXML(t *testing.T) {
+	const inXml string = `    <foo>
+
+      <la two="two" one="one">foo this is a test</la>
+
+  <be>bebe  </be>
+  </foo>
+`
+	const outXml string = `<?xml version="1.0"?>
+<foo><la two="two" one="one">foo this is a test</la><be>bebe  </be></foo>
+`
+
+	result, err := transformXML(inXml, identitySpaceStripXSLT)
+	assert.Nil(t, err)
+	assert.Equal(t, outXml, result)
+}

--- a/libvirt/utils_xslt_test.go
+++ b/libvirt/utils_xslt_test.go
@@ -3,23 +3,34 @@ package libvirt
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	identitySpaceStripXSLT = `
+func TestTransformXML(t *testing.T) {
+	const xslt = `
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:strip-space elements="*" />
   <xsl:template match="@*|node()">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
+  <xsl:template match="@format[parent::book]">
+    <xsl:attribute name="format">
+      <xsl:value-of select="'kindle'"/>
+    </xsl:attribute>
+  </xsl:template>
 </xsl:stylesheet>
 `
-)
+	const inXML string = "<books><book format=\"paper\"/></books>"
+	const outXML string = "<?xml version=\"1.0\"?>\n<books><book format=\"kindle\"/></books>\n"
 
-func TestTransformXML(t *testing.T) {
+	result, err := transformXML(inXML, xslt)
+	assert.Nil(t, err)
+	assert.Equal(t, outXML, result)
+}
+
+func TestXSLTDiffSupressFunc(t *testing.T) {
 	const inXML string = `    <foo>
 
       <la two="two" one="one">foo this is a test</la>
@@ -31,7 +42,5 @@ func TestTransformXML(t *testing.T) {
 <foo><la two="two" one="one">foo this is a test</la><be>bebe  </be></foo>
 `
 
-	result, err := transformXML(inXML, identitySpaceStripXSLT)
-	assert.Nil(t, err)
-	assert.Equal(t, outXML, result)
+	assert.True(t, xsltDiffSupressFunc("K", inXML, outXML, &schema.ResourceData{}))
 }

--- a/libvirt/utils_xslt_test.go
+++ b/libvirt/utils_xslt_test.go
@@ -20,18 +20,18 @@ const (
 )
 
 func TestTransformXML(t *testing.T) {
-	const inXml string = `    <foo>
+	const inXML string = `    <foo>
 
       <la two="two" one="one">foo this is a test</la>
 
   <be>bebe  </be>
   </foo>
 `
-	const outXml string = `<?xml version="1.0"?>
+	const outXML string = `<?xml version="1.0"?>
 <foo><la two="two" one="one">foo this is a test</la><be>bebe  </be></foo>
 `
 
-	result, err := transformXML(inXml, identitySpaceStripXSLT)
+	result, err := transformXML(inXML, identitySpaceStripXSLT)
 	assert.Nil(t, err)
-	assert.Equal(t, outXml, result)
+	assert.Equal(t, outXML, result)
 }

--- a/libvirt/utils_xslt_test.go
+++ b/libvirt/utils_xslt_test.go
@@ -30,6 +30,15 @@ func TestTransformXML(t *testing.T) {
 	assert.Equal(t, outXML, result)
 }
 
+func TestTransformXMLEmptyXSLTNoOp(t *testing.T) {
+	const xslt = ""
+	const inXML string = "<books><book format=\"paper\"/></books>"
+
+	result, err := transformXML(inXML, xslt)
+	assert.Nil(t, err)
+	assert.Equal(t, inXML, result)
+}
+
 func TestXSLTDiffSupressFunc(t *testing.T) {
 	const inXML string = `    <foo>
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -534,6 +534,18 @@ boot_device {
 }
 ```
 
+### Altering libvirt's generated domain XML definition
+
+The optional `xml` block relates to the generated domain XML.
+
+Currently the following attributes are supported:
+
+* `xslt`: specifies a XSLT stylesheet to transform the generated XML definition before creating the domain.
+  This is used to support features the provider does not allow to set from the schema.
+  It is not recommended to alter properties and settings that are exposed to the schema, as terraform will insist in changing them back to the known state.
+
+See https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/examples/xslt/main.tf and https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/examples/xslt/nicmodel.xsl for a working example that changes the NIC model.
+
 ## Attributes Reference
 
 * `id` - a unique identifier for the resource.

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -165,6 +165,19 @@ resource "libvirt_network" "k8snet" {
 						enabled = true
 					}
 ```
+
+### Altering libvirt's generated network XML definition
+
+The optional `xml` block relates to the generated network XML.
+
+Currently the following attributes are supported:
+
+* `xslt`: specifies a XSLT stylesheet to transform the generated XML definition before creating the network.
+  This is used to support features the provider does not allow to set from the schema.
+  It is not recommended to alter properties and settings that are exposed to the schema, as terraform will insist in changing them back to the known state.
+
+See the domain option with the same name for more information and examples.
+
 ## Attributes Reference
 
 * `id` - a unique identifier for the resource

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -65,6 +65,18 @@ The following arguments are supported:
 * `base_volume_pool` - (Optional) The name of the storage pool containing the
   volume defined by `base_volume_name`.
 
+### Altering libvirt's generated volume XML definition
+
+The optional `xml` block relates to the generated volume XML.
+
+Currently the following attributes are supported:
+
+* `xslt`: specifies a XSLT stylesheet to transform the generated XML definition before creating the volume.
+  This is used to support features the provider does not allow to set from the schema.
+  It is not recommended to alter properties and settings that are exposed to the schema, as terraform will insist in changing them back to the known state.
+
+See the domain option with the same name for more information and examples.
+
 ## Attributes Reference
 
 * `id` - a unique identifier for the resource


### PR DESCRIPTION
Sometimes the provider does not allow to set some libvirt attributes. Good examples are #350 (the provider does not allow to change the NIC model)  #419 (one needs to add a touch device).

This PR explores the idea of allowing for a transformation hook before creating the domain. The hook is in the form of a _XSLT_ stylesheet. This allow for almost unlimited capabilities when "editing" the generated XML.

```hcl
provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_domain" "xslt-demo-domain" {
  name = "xslt-demo-domain"
  memory = "512"

  network_interface {
    network_name = "default"
  }

  xml {
    xslt = "${file("nicmodel.xsl")}"
  }
}
```

_nicmodel.xsl_:

```xml
<?xml version="1.0" ?>
<xsl:stylesheet version="1.0"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
  <xsl:output omit-xml-declaration="yes" indent="yes"/>
  <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
  </xsl:template>

  <xsl:template match="/domain/devices/interface[@type='network']/model/@type">
    <xsl:attribute name="type">
      <xsl:value-of select="'e1000'"/>
    </xsl:attribute>
  </xsl:template>

</xsl:stylesheet>
```

Some notes about the implementation:

* The current implementation depends on _xsltproc_ to do the processing
* It works well for properties that are not supported by the provider. Otherwise the provider will insist in changing them back. I have an acceptance test for both cases: changing the nic model and changing the network name.
* I am not sure if it is worth to have the `xslt`property nested into an `xml` element.
* Only implemented for domain resources, but 95% of the code is generic. A few lines are needed in every resource creation and schema to add support for it.

The idea is of this PR is to gather some feedback and foresee problems I may not be seeing yet.

//cc @ncsurfus @unsubtleguy

## TODO

- [X]  Gather feedback
- [ ] Decide on the element name
- [X] Write some docs
- [X] Add missing resources
- [X] Hook the new diff function
- [X] Do a no-op if xslt is empty



