### PR TITLE
network: fix the error message typo for clearing

### DIFF
--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -350,7 +350,7 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	err = network.Create()
 	if err != nil {
-		return fmt.Errorf("Error crearing libvirt network: %s", err)
+		return fmt.Errorf("Error clearing libvirt network: %s", err)
 	}
 	defer network.Free()
 


### PR DESCRIPTION
Browsing logs and saw this typo.