### PR TITLE
.travis: Update golint URI to use x/lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go_import_path: github.com/dmacvicar/terraform-provider-libvirt
 install:        true
 before_script:
   - go get github.com/mattn/goveralls
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 addons:
   apt:
     packages:


### PR DESCRIPTION
Catching up with golang/lint@ead987a6 (haruyama/golintx#20) and [avoiding][1]:

```console
$ go get github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```

[1]: https://travis-ci.org/dmacvicar/terraform-provider-libvirt/builds/440782401#L517