### PR TITLE
Fix small issues due latest change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ install:
 	go install
 
 test:
-	go test -v -covermode=count -coverprofile=profile.cov . ./libvirt
-
+	go test -v -covermode=count -coverprofile=profile.cov ./libvirt
+	go test -v .
 testacc:
+	go test -v .
 	./travis/run-tests-acceptance
 
 vet:


### PR DESCRIPTION
`make test` doesn't work anymore.

The go  covermode need seperate module at once.. 

I am checking if the `terraform version` has other things