### PR TITLE
add support for setting SRVs for network

### DIFF
--- a/libvirt/data_source_libvirt_network.go
+++ b/libvirt/data_source_libvirt_network.go
@@ -67,3 +67,92 @@ func resourceLibvirtNetworkDNSHostRead(d *schema.ResourceData, meta interface{})
 
 	return nil
 }
+
+// a libvirt network DNS SRV template datasource
+//
+// Datasource example:
+//
+// data "libvirt_network_dns_srv_template" "etcd_cluster" {
+//   count = "${var.etcd_count}"
+//   service = "etcd-server"
+//   protocol = "tcp"
+//   domain = "${discovery_domain}"
+//   target = "${var.cluster_name}-etcd-${count.index}.${discovery_domain}"
+// }
+//
+// resource "libvirt_network" "k8snet" {
+//   ...
+//   dns = [{
+//     srvs = [ "${flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered)}" ]
+//   }]
+//   ...
+// }
+//
+func datasourceLibvirtNetworkDNSSRVTemplate() *schema.Resource {
+	return &schema.Resource{
+		Read: resourceLibvirtNetworkDNSSRVRead,
+		Schema: map[string]*schema.Schema{
+			"service": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"port": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"weight": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"priority": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rendered": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLibvirtNetworkDNSSRVRead(d *schema.ResourceData, meta interface{}) error {
+	dnsSRV := map[string]interface{}{}
+	if service, ok := d.GetOk("service"); ok {
+		dnsSRV["service"] = service.(string)
+	}
+	if protocol, ok := d.GetOk("protocol"); ok {
+		dnsSRV["protocol"] = protocol.(string)
+	}
+	if domain, ok := d.GetOk("domain"); ok {
+		dnsSRV["domain"] = domain.(string)
+	}
+	if target, ok := d.GetOk("target"); ok {
+		dnsSRV["target"] = target.(string)
+	}
+	if port, ok := d.GetOk("port"); ok {
+		dnsSRV["port"] = port.(string)
+	}
+	if weight, ok := d.GetOk("weight"); ok {
+		dnsSRV["weight"] = weight.(string)
+	}
+	if priority, ok := d.GetOk("priority"); ok {
+		dnsSRV["priority"] = priority.(string)
+	}
+	d.Set("rendered", dnsSRV)
+	d.SetId(strconv.Itoa(hashcode.String(fmt.Sprintf("%v", dnsSRV))))
+
+	return nil
+}

--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -21,17 +21,17 @@ func TestAccLibvirtNetworkDataSource_DNSHostTemplate(t *testing.T) {
   hostname = "myhost${count.index}"
 }`,
 				Check: resource.ComposeTestCheckFunc(
-					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "ip", "1.1.1.0"),
-					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "hostname", "myhost0"),
-					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "ip", "1.1.1.1"),
-					checkDNSHostTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "hostname", "myhost1"),
+					checkTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "ip", "1.1.1.0"),
+					checkTemplate("data.libvirt_network_dns_host_template.bootstrap.0", "hostname", "myhost0"),
+					checkTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "ip", "1.1.1.1"),
+					checkTemplate("data.libvirt_network_dns_host_template.bootstrap.1", "hostname", "myhost1"),
 				),
 			},
 		},
 	})
 }
 
-func checkDNSHostTemplate(id, name, value string) resource.TestCheckFunc {
+func checkTemplate(id, name, value string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
 		rs, err := getResourceFromTerraformState(id, state)
@@ -47,4 +47,30 @@ func checkDNSHostTemplate(id, name, value string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func TestAccLibvirtNetworkDataSource_DNSSRVTemplate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+
+			{
+				Config: `data "libvirt_network_dns_srv_template" "etcd_cluster" {
+  count = 2
+  service = etcd-server-ssl
+  protocol = tcp
+  target = "my-etcd-${count.index}.tt.testing"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.0", "target", "my-etcd-0.tt.testing"),
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.0", "service", "etcd-server-ssl"),
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.0", "protocol", "tcp"),
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.1", "target", "my-etcd-1.tt.testing"),
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.1", "service", "etcd-server-ssl"),
+					checkTemplate("data.libvirt_network_dns_srv_template.etcd_cluster.1", "protocol", "tcp"),
+				),
+			},
+		},
+	})
 }

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -29,6 +29,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"libvirt_network_dns_host_template": datasourceLibvirtNetworkDNSHostTemplate(),
+			"libvirt_network_dns_srv_template":  datasourceLibvirtNetworkDNSSRVTemplate(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
This commit adds a new template for generating dns srv records similar to dns hosts
and then adds `srvs` key to `dns` section for libvirt_network.

```hcl
a libvirt network DNS SRV template datasource

Datasource example:

data "libvirt_network_dns_srv_template" "etcd_cluster" {
  count = "${var.etcd_count}"
  service = "etcd-server"
  protocol = "tcp"
  domain = "${discovery_domain}"
  target = "${var.cluster_name}-etcd-${count.index}.${discovery_domain}"
}

resource "libvirt_network" "k8snet" {
  ...
  dns = [{
    srvs = [ "${flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered)}" ]
  }]
  ...
}
```