### PR TITLE
Fix broken acceptance tests from #460

### DIFF
--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -58,8 +58,8 @@ func TestAccLibvirtNetworkDataSource_DNSSRVTemplate(t *testing.T) {
 			{
 				Config: `data "libvirt_network_dns_srv_template" "etcd_cluster" {
   count = 2
-  service = etcd-server-ssl
-  protocol = tcp
+  service = "etcd-server-ssl"
+  protocol = "tcp"
   target = "my-etcd-${count.index}.tt.testing"
 }`,
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Missing quotes in HCL template makes acceptance tests fail.

(https://github.com/dmacvicar/terraform-provider-libvirt/pull/460)