### PR TITLE
libvirt/*_test: Remove redundant slice-literal entry types

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -456,7 +456,7 @@ func TestAccLibvirtDomain_CheckDHCPEntries(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:             configWithDomain,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
@@ -464,14 +464,14 @@ func TestAccLibvirtDomain_CheckDHCPEntries(t *testing.T) {
 					testAccCheckLibvirtNetworkExists("libvirt_network."+randomNetworkName, &network),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configWithoutDomain,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDestroyLeavesIPs("libvirt_network."+randomNetworkName,
 						"192.0.0.2", &network),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:             configWithDomain,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
@@ -1204,7 +1204,7 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(`
 				resource "libvirt_domain" "%s" {
 					name   = "%s"
@@ -1212,7 +1212,7 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 					vcpu   = 2
 				}`, randomDomainName, randomDomainName),
 			},
-			resource.TestStep{
+			{
 				ResourceName: "libvirt_domain." + randomDomainName,
 				ImportState:  true,
 				Check: resource.ComposeTestCheckFunc(

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -304,7 +304,7 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(`
 				resource "libvirt_network" "%s" {
 					name      = "%s"
@@ -313,7 +313,7 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 					addresses = ["10.17.3.0/24"]
 				}`, randomNetworkResource, randomNetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName: resourceName,
 				ImportState:  true,
 				Check: resource.ComposeTestCheckFunc(

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -378,7 +378,7 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(`
 					resource "libvirt_volume" "%s" {
 							name   = "%s"
@@ -386,7 +386,7 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 							size   =  1073741824
 					}`, randomVolumeResource, randomVolumeName),
 			},
-			resource.TestStep{
+			{
 				ResourceName: "libvirt_volume." + randomVolumeResource,
 				ImportState:  true,
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Generated with:

```console
$ gofmt -s -w libvirt/*.go
```

using:

```console
$ go version
go version go1.10.3 linux/amd64
```