### PR TITLE
Allow DHCP configuration of static ip addresses for network resource

### DIFF
--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -28,8 +28,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"libvirt_network_dns_host_template": datasourceLibvirtNetworkDNSHostTemplate(),
-			"libvirt_network_dns_srv_template":  datasourceLibvirtNetworkDNSSRVTemplate(),
+			"libvirt_network_dns_host_template":  datasourceLibvirtNetworkDNSHostTemplate(),
+			"libvirt_network_dns_srv_template":   datasourceLibvirtNetworkDNSSRVTemplate(),
+			"libvirt_network_dhcp_host_template": datasourceLibvirtNetworkDHCPHostTemplate(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -205,6 +205,30 @@ func resourceLibvirtNetwork() *schema.Resource {
 							Optional: true,
 							Required: false,
 						},
+						"hosts": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"mac": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Libvirt DHCP can configure static ip address assignements. This
commit adds support to read resource config with extended dhcp
settings with dhcp host-ip-mac assignements.

Example:

    ```
    resource "libvirt_network" "my_network" {
      name = "my_network"
      mode = "nat"
      domain = "example.org"
      addresses = [ "192.168.1.0/24" ]
      dhcp = {
          enabled = true
          hosts = [
            {
              host = "host1"
              ip = "192.168.1.2"
              mac = "00:11:22:33:44:55"
            },
            {
              host = "host2"
              ip = "192.168.1.3"
              mac = "00:11:22:33:44:56"
            },
            {
              host = "host3"
              ip = "192.168.1.4"
              mac = "00:11:22:33:44:57"
            }
          ]
      }
    }
    ```