### PR TITLE
close stream, check size, and fix backingstore  and other minor size assignement

### DIFF
--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -341,7 +341,7 @@ func downloadISO(virConn *libvirt.Connect, volume libvirt.StorageVol) (*os.File,
 
 	if uint64(bytesCopied) != info.Capacity {
 		stream.Abort()
-		return tmpFile, fmt.Errorf("Error while copying remote volume to local disk, bytesCopied %d !=  %d volume.size:", bytesCopied, info.Capacity)
+		return tmpFile, fmt.Errorf("Error while copying remote volume to local disk, bytesCopied %d !=  %d volume.size", bytesCopied, info.Capacity)
 	}
 
 	err = stream.Finish()

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -304,6 +304,8 @@ func readIso9660File(file os.FileInfo) ([]byte, error) {
 // pointer when you are done.
 func downloadISO(virConn *libvirt.Connect, volume libvirt.StorageVol) (*os.File, error) {
 	// get Volume info (required to get size later)
+	var bytesCopied int64
+
 	info, err := volume.GetInfo()
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving info for volume: %s", err)
@@ -320,18 +322,36 @@ func downloadISO(virConn *libvirt.Connect, volume libvirt.StorageVol) (*os.File,
 	if err != nil {
 		return tmpFile, err
 	}
-	defer stream.Finish()
 
-	volume.Download(stream, 0, info.Capacity, 0)
+	defer func() {
+		stream.Free()
+	}()
 
+	err = volume.Download(stream, 0, info.Capacity, 0)
+	if err != nil {
+		stream.Abort()
+		return tmpFile, fmt.Errorf("Error by downloading content to libvirt volume:%s", err)
+	}
 	sio := NewStreamIO(*stream)
 
-	n, err := io.Copy(tmpFile, sio)
+	bytesCopied, err = io.Copy(tmpFile, sio)
 	if err != nil {
 		return tmpFile, fmt.Errorf("Error while copying remote volume to local disk: %s", err)
 	}
+
+	if uint64(bytesCopied) != info.Capacity {
+		stream.Abort()
+		return tmpFile, fmt.Errorf("Error while copying remote volume to local disk, bytesCopied %d !=  %d volume.size:", bytesCopied, info.Capacity)
+	}
+
+	err = stream.Finish()
+	if err != nil {
+		stream.Abort()
+		return tmpFile, fmt.Errorf("Error by terminating libvirt stream %s", err)
+	}
+
 	tmpFile.Seek(0, 0)
-	log.Printf("%d bytes downloaded", n)
+	log.Printf("%d bytes downloaded", bytesCopied)
 
 	return tmpFile, nil
 }

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -193,16 +193,14 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 				return fmt.Errorf("Can't retrieve volume %s: %v", baseVolumeName.(string), err)
 			}
 		}
-
 		if baseVolume != nil {
 			backingStoreDef, err := newDefBackingStoreFromLibvirt(baseVolume)
 			if err != nil {
 				return fmt.Errorf("Could not retrieve backing store definition: %s", err.Error())
 			}
-
-			// does the backing store have some size information?, check at least that it is not smaller than the backing store
-			volumeDef.Capacity.Value = uint64(d.Get("size").(int))
 			if _, ok := d.GetOk("size"); ok {
+				// does the backing store have some size information?, check at least that it is not smaller than the backing store
+				volumeDef.Capacity.Value = uint64(d.Get("size").(int))
 				backingStoreVolumeDef, err := newDefVolumeFromLibvirt(baseVolume)
 				if err != nil {
 					return err
@@ -215,8 +213,9 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 			volumeDef.BackingStore = &backingStoreDef
 		}
 	}
-
-	volumeDef.Capacity.Value = uint64(d.Get("size").(int))
+	if _, ok := d.GetOk("size"); ok {
+		volumeDef.Capacity.Value = uint64(d.Get("size").(int))
+	}
 	data, err := xmlMarshallIndented(volumeDef)
 	if err != nil {
 		return fmt.Errorf("Error serializing libvirt volume: %s", err)

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -242,7 +242,7 @@ func TestAccLibvirtVolume_UniqueName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`storage volume '` + randomVolumeName + `' already exists`),
+				ExpectError: regexp.MustCompile(`storage volume '` + randomVolumeName + `' exists already`),
 			},
 		},
 	})

--- a/libvirt/stream.go
+++ b/libvirt/stream.go
@@ -19,8 +19,3 @@ func (sio *StreamIO) Read(p []byte) (int, error) {
 func (sio *StreamIO) Write(p []byte) (int, error) {
 	return sio.Stream.Send(p)
 }
-
-// Close closes the stream
-func (sio *StreamIO) Close() error {
-	return sio.Stream.Finish()
-}


### PR DESCRIPTION
this is a logical backport of what we are doing in `utils.volume.go` file already

The history behind this is a tentative to fix an issue we have currently when updating the `cloudinit.iso` and creating a vol on remote-kvm server.