### PR TITLE
WIP: Retry HTTP downloads for 5xx errors

### DIFF
--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -186,10 +186,15 @@ func (i *httpImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageV
 	}
 
 	defer response.Body.Close()
+	log.Printf("[DEBUG]: url resp status code %s\n", response.Status)
 	if response.StatusCode == http.StatusNotModified {
 		return nil
 	}
-	log.Printf("[DEBUG]: url resp status code %s\n", response.Status)
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("Error while downloading %s: %d", i.url.String(), response.StatusCode)
+
+	}
 	return copier(response.Body)
 }
 

--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -167,11 +167,12 @@ func isQCOW2Header(buf []byte) (bool, error) {
 	return false, nil
 }
 
-// number of download retries on non client errors (eg. 5xx)
-const maxHTTPRetries int = 3
-const retryWaitSec = 2
-
 func (i *httpImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageVolume) error {
+	// number of download retries on non client errors (eg. 5xx)
+	const maxHTTPRetries int = 3
+	// wait time between retries
+	const retryWait time.Duration = 2 * time.Second
+
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", i.url.String(), nil)
 
@@ -202,7 +203,7 @@ func (i *httpImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageV
 		} else {
 			// retry
 			if retryCount < maxHTTPRetries {
-				time.Sleep(retryWaitSec * time.Second)
+				time.Sleep(retryWait)
 			}
 		}
 	}

--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -201,7 +201,8 @@ func (i *httpImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageV
 		} else if response.StatusCode < 500 {
 			break
 		} else {
-			// retry
+			// The problem is not client but server side
+			// retry a few times after a small wait
 			if retryCount < maxHTTPRetries {
 				time.Sleep(retryWait)
 			}

--- a/libvirt/utils_volume_test.go
+++ b/libvirt/utils_volume_test.go
@@ -116,10 +116,11 @@ func TestRemoteImageDownloadRetry(t *testing.T) {
 			http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
 					if errorCount < len(errorList) {
-						t.Logf("Retry %d", errorCount)
+						t.Logf("Server serving retry %d", errorCount)
 						http.Error(w, fmt.Sprintf("Error %d", errorCount), errorList[errorCount])
 						errorCount = errorCount + 1
 					} else {
+						t.Logf("Server: success (after %d errors)", errorCount)
 						http.ServeContent(w, r, "content", time.Now(), bytes.NewReader(content))
 					}
 				}))

--- a/libvirt/utils_volume_test.go
+++ b/libvirt/utils_volume_test.go
@@ -138,13 +138,18 @@ func TestRemoteImageDownloadRetry(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not create image object: %v", err)
 	}
+	start := time.Now()
 	if err = image.Import(copier, vol); err != nil {
 		t.Fatalf("Expected to retry: %v", err)
+	}
+	if time.Since(start).Seconds() < 4 {
+		t.Fatalf("Expected to retry at least 2 times x 2 seconds")
 	}
 
 	server = newErrorServer([]int{503, 404})
 	defer server.Close()
 	vol = newDefVolume()
+	start = time.Now()
 	image, err = newImage(server.URL)
 	if err != nil {
 		t.Errorf("Could not create image object: %v", err)
@@ -152,6 +157,10 @@ func TestRemoteImageDownloadRetry(t *testing.T) {
 	if err = image.Import(copier, vol); err == nil {
 		t.Fatalf("Expected %s to fail with status 4xx", server.URL)
 	}
+	if time.Since(start).Seconds() < 2 {
+		t.Fatalf("Expected to retry at least 1 times x 2 seconds")
+	}
+
 }
 
 func TestRemoteImageDownload(t *testing.T) {


### PR DESCRIPTION
This PR implements what is suggested on https://github.com/dmacvicar/terraform-provider-libvirt/issues/455

Most of the work was to do the proper testcase.

I also discovered a bug: we where not erroring at all for non-200 codes. We ignored [this part of the documentation](https://golang.org/pkg/net/http/#Client.Do):

>An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem). A non-2xx status code doesn't cause an error. 

So _Import_ did not error, and the error we spit to the user was probably some garbage when trying to read an empty response. This is now fixed in 5fa3124f87600e6b5a87b692660fbe03566bc23d

### TODO

- [ ] wait/backoff between retries
