### PR TITLE
WIP: remove corrupted downladed volumes in case of unexpected error

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -261,8 +261,12 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 			// If we don't throw away the id, we will keep instead a broken volume.
 			//  see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
 			d.Set("id", "")
+			// remove the corrupted volume
+			if err := volume.Wipe(0); err != nil {
+				return fmt.Errorf("[ERROR] while uploading source Volume %s. Volume couldn't be deleted. Delete it manually", img.String())
+			}
 			if volErr := volume.Delete(libvirt.STORAGE_VOL_DELETE_WITH_SNAPSHOTS); volErr != nil {
-				log.Printf("[ERROR] Volume %s could not be deleted. Delete it manually", img.String())
+				return fmt.Errorf("[ERROR] while uploading source Volume %s. Volume couldn't be deleted. Delete it manually", img.String())
 			}
 			return fmt.Errorf("Error while uploading source %s: %s", img.String(), err)
 		}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -257,6 +257,10 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	if _, ok := d.GetOk("source"); ok {
 		err = img.Import(newCopier(client.libvirt, volume, volumeDef.Capacity.Value), volumeDef)
 		if err != nil {
+			// If an unexpected error occurs don't save volume ID so we will taint the volume after.
+			// If we don't throw away the id, we will keep instead a broken volume.
+			//  see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
+			d.Set("id", "")
 			return fmt.Errorf("Error while uploading source %s: %s", img.String(), err)
 		}
 	}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -261,6 +261,9 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 			// If we don't throw away the id, we will keep instead a broken volume.
 			//  see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
 			d.Set("id", "")
+			if volErr := volume.Delete(libvirt.STORAGE_VOL_DELETE_WITH_SNAPSHOTS); volErr != nil {
+				log.Printf("[ERROR] Volume %s could not be deleted. Delete it manually", img.String())
+			}
 			return fmt.Errorf("Error while uploading source %s: %s", img.String(), err)
 		}
 	}


### PR DESCRIPTION
fix #494 ( i think the nil id is the best solution). 

Also we do the same in the `ignition` or `cloudinit`,  returning a nil key.


@Bischoff @juliogonzalez could you try this out?


From my side i will experiment a little with this, to see if we don't have any unexpected things around :) ( so no hurry to merge it)