### PR TITLE
Network: add mtu setting

### DIFF
--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -166,3 +166,11 @@ func getDomainFromResource(d *schema.ResourceData) *libvirtxml.NetworkDomain {
 
 	return domain
 }
+
+func getMTUFromResource(d *schema.ResourceData) *libvirtxml.NetworkMTU {
+	if mtu, ok := d.GetOk("mtu"); ok {
+		return &libvirtxml.NetworkMTU{Size: uint(mtu.(int))}
+	}
+
+	return nil
+}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -68,6 +68,11 @@ func resourceLibvirtNetwork() *schema.Resource {
 				Computed: true,
 				ForceNew: false,
 			},
+			"mtu": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Required: false,
+			},
 			"addresses": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -366,6 +371,8 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	// use a bridge provided by the user, or create one otherwise (libvirt will assign on automatically when empty)
 	networkDef.Bridge = getBridgeFromResource(d)
 
+	networkDef.MTU = getMTUFromResource(d)
+
 	// check the network mode
 	networkDef.Forward = &libvirtxml.NetworkForward{
 		Mode: getNetModeFromResource(d),
@@ -517,6 +524,10 @@ func resourceLibvirtNetworkRead(d *schema.ResourceData, meta interface{}) error 
 
 	d.Set("name", networkDef.Name)
 	d.Set("bridge", networkDef.Bridge.Name)
+
+	if networkDef.MTU != nil {
+		d.Set("mtu", networkDef.MTU.Size)
+	}
 
 	if networkDef.Forward != nil {
 		d.Set("mode", networkDef.Forward.Mode)

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -474,3 +474,31 @@ func TestAccLibvirtNetwork_Autostart(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLibvirtNetwork_MTU(t *testing.T) {
+	var network libvirt.Network
+	randomNetworkResource := acctest.RandString(10)
+	randomNetworkName := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_network" "%s" {
+					name      = "%s"
+					mode      = "nat"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					autostart = true
+					mtu = 9999
+				}`, randomNetworkResource, randomNetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkExists("libvirt_network."+randomNetworkResource, &network),
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "mtu", "9999"),
+				),
+			},
+		},
+	})
+}

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -34,6 +34,10 @@ resource "libvirt_network" "kube_network" {
   # (only necessary in "bridge" mode)
   # bridge = "br7"
 
+  # (optional) the MTU for the network. If not supplied, the underlying device's
+  # default is used (usually 1500)
+  # mtu = 9000
+
   # (Optional) DNS configuration
   dns {
     # (Optional, default false)
@@ -111,6 +115,9 @@ The following arguments are supported:
 * `bridge` - (Optional) The bridge device defines the name of a bridge
    device which will be used to construct the virtual network (when not provided,
    it will be automatically obtained by libvirt in `none`, `nat` and `route` modes).
+* `mtu` - (Optional) The MTU to set for the underlying network interfaces. When
+   not supplied, libvirt will use the default for the interface, usually 1500.
+   Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
 * `autostart` - (Optional) Set to `true` to start the network on host boot up.
   If not specified `false` is assumed.
 * `routes` - (Optional) a list of static routes. A `cidr` and a `gateway` must


### PR DESCRIPTION
This plumbs through the "mtu" top-level variable in the network XML.

It's not amazingly useful, as libvirt doesn't pass it through to the DHCP server, but... baby steps!