### PR TITLE
Revert "Remove mutex before poolRefresh"

### DIFF
--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -60,6 +60,9 @@ func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 	}
 	defer pool.Free()
 
+	client.poolMutexKV.Lock(ci.PoolName)
+	defer client.poolMutexKV.Unlock(ci.PoolName)
+
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
 	waitForSuccess("Error refreshing pool for volume", func() error {

--- a/libvirt/config.go
+++ b/libvirt/config.go
@@ -1,9 +1,9 @@
 package libvirt
 
 import (
-	"log"
-
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	libvirt "github.com/libvirt/libvirt-go"
+	"log"
 )
 
 // Config struct for the libvirt-provider
@@ -13,7 +13,8 @@ type Config struct {
 
 // Client libvirt
 type Client struct {
-	libvirt *libvirt.Connect
+	libvirt     *libvirt.Connect
+	poolMutexKV *mutexkv.MutexKV
 }
 
 // Client libvirt, generate libvirt client given URI
@@ -25,7 +26,8 @@ func (c *Config) Client() (*Client, error) {
 	log.Println("[INFO] Created libvirt client")
 
 	client := &Client{
-		libvirt: libvirtClient,
+		libvirt:     libvirtClient,
+		poolMutexKV: mutexkv.NewMutexKV(),
 	}
 
 	return client, nil

--- a/libvirt/coreos_ignition_def.go
+++ b/libvirt/coreos_ignition_def.go
@@ -38,6 +38,9 @@ func (ign *defIgnition) CreateAndUpload(client *Client) (string, error) {
 	}
 	defer pool.Free()
 
+	client.poolMutexKV.Lock(ign.PoolName)
+	defer client.poolMutexKV.Unlock(ign.PoolName)
+
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
 	waitForSuccess("Error refreshing pool for volume", func() error {

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -91,6 +91,9 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 		poolName = d.Get("pool").(string)
 	}
 
+	client.poolMutexKV.Lock(poolName)
+	defer client.poolMutexKV.Unlock(poolName)
+
 	pool, err := client.libvirt.LookupStoragePoolByName(poolName)
 	if err != nil {
 		return fmt.Errorf("can't find storage pool '%s'", poolName)

--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -301,6 +301,14 @@ func removeVolume(client *Client, key string) error {
 	}
 	defer volPool.Free()
 
+	poolName, err := volPool.GetName()
+	if err != nil {
+		return fmt.Errorf("Error retrieving name of volume: %s", err)
+	}
+
+	client.poolMutexKV.Lock(poolName)
+	defer client.poolMutexKV.Unlock(poolName)
+
 	waitForSuccess("Error refreshing pool for volume", func() error {
 		return volPool.Refresh(0)
 	})


### PR DESCRIPTION
Reverts dmacvicar/terraform-provider-libvirt#495

fix #https://github.com/dmacvicar/terraform-provider-libvirt/issues/504
I think if we don't find a  solution the wise solution is to revert this.
@wking cc