### PR TITLE
allow setting of disk cache mode

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -452,6 +452,11 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 				log.Printf("[WARN] Disk volume has no format specified: %s", volumeKey.(string))
 			}
 
+			if cache, ok := d.GetOk(prefix + ".cache"); ok {
+				log.Printf("[DEBUG] Setting disk cache mode to: %s", cache.(string))
+				disk.Driver.Cache = cache.(string)
+			}
+
 			disk.Source = &libvirtxml.DomainDiskSource{
 				Volume: &libvirtxml.DomainDiskSourceVolume{
 					Pool:   diskPoolName,

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -158,6 +158,10 @@ func resourceLibvirtDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"cache": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -142,7 +142,8 @@ func TestAccLibvirtDomain_VolumeTwoDisks(t *testing.T) {
 		}
 
 		disk {
-			volume_id = "${libvirt_volume.%s.id}"
+		    volume_id = "${libvirt_volume.%s.id}",
+		    cache = "none"
 		}
 	}`, randomVolumeName, randomVolumeName, randomVolumeName2, randomVolumeName2, randomDomainName, randomDomainName, randomVolumeName, randomVolumeName2)
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -256,6 +256,8 @@ While `volume_id`, `url` and `file` are optional, it is intended that you use on
 model is set to `virtio-scsi`
 * `wwn` - (Optional) Specify a WWN to use for the disk if the disk is using
 a scsi controller, if not specified then a random wwn is generated for the disk
+* `cache` - (Optional) The driver cache mode that shall be used. If not set libvirt
+default will be used [Disk Cache Modes](https://doc.opensuse.org/documentation/leap/virtualization/html/book.virt/cha.cachemodes.html).
 
 
 ```hcl


### PR DESCRIPTION
Small patch to allow setting of disk cache mode as described here: https://doc.opensuse.org/documentation/leap/virtualization/html/book.virt/cha.cachemodes.html