### PR TITLE
Static routes for networks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ For example the `domain` resource, and others are organized like follow:
 make testacc
 ```
 
+You can also run some particular test with:
+
+```
+make testacc TEST_ARGS="-run TestAccLibvirtDomain_Cpu"
+```
+
+Or run a group of test with a verbose loglevel:
+
+```bash
+TF_LOG=DEBUG make testacc TEST_ARGS="-run TestAccLibvirtNet*"
+```
+
 ### Code coverage:
 
 Run first the testacc suite.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 LDFLAGS += -X main.version=$$(git describe --always --abbrev=40 --dirty)
 
+# default  args for tests
+TEST_ARGS_DEF := -covermode=count -coverprofile=profile.cov
+
 default: build
 
 build: gofmtcheck golint vet
@@ -8,12 +11,29 @@ build: gofmtcheck golint vet
 install:
 	go install -ldflags "${LDFLAGS}"
 
+# unit tests
+# usage:
+# - run all the unit tests: make test
+# - run some particular test: make test TEST_ARGS="-run TestAccLibvirtDomain_Cpu"
 test:
-	go test -v -covermode=count -coverprofile=profile.cov ./libvirt
+	go test -v $(TEST_ARGS_DEF) $(TEST_ARGS) ./libvirt
 	go test -v .
+
+# acceptance tests
+# usage:
+#
+# - run all the acceptance tests:
+#   make testacc
+#
+# - run some particular test:
+#   make testacc TEST_ARGS="-run TestAccLibvirtDomain_Cpu"
+#
+# - run all the network test with a verbose loglevel:
+#   TF_LOG=DEBUG make testacc TEST_ARGS="-run TestAccLibvirtNet*"
+#
 testacc:
 	go test -v .
-	./travis/run-tests-acceptance
+	./travis/run-tests-acceptance $(TEST_ARGS)
 
 vet:
 	@echo "go vet ."
@@ -29,7 +49,6 @@ golint:
 
 gofmtcheck:
 	bash travis/run-gofmt
-
 
 clean:
 	./travis/cleanup.sh

--- a/libvirt/network_routes.go
+++ b/libvirt/network_routes.go
@@ -1,0 +1,58 @@
+package libvirt
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/libvirt/libvirt-go-xml"
+)
+
+// getRoutesFromResource gets the libvirt network routes from a network definition
+func getRoutesFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkRoute, error) {
+	routesCount, ok := d.GetOk("routes.#")
+	if !ok {
+		log.Printf("[INFO] No routes defined")
+		return []libvirtxml.NetworkRoute{}, nil
+	}
+
+	routes := []libvirtxml.NetworkRoute{}
+	log.Printf("[INFO] %d routes defined", routesCount)
+	for i := 0; i < routesCount.(int); i++ {
+		route := libvirtxml.NetworkRoute{}
+		routePrefix := fmt.Sprintf("routes.%d", i)
+
+		if cidr, ok := d.GetOk(routePrefix + ".cidr"); ok {
+			addr, net, err := net.ParseCIDR(cidr.(string))
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing static route in network: %s", err)
+			}
+
+			if addr.To4() == nil {
+				route.Family = "ipv6"
+			}
+
+			route.Address = addr.String()
+
+			ones, _ := net.Mask.Size()
+			route.Prefix = (uint)(ones)
+		} else {
+			return nil, fmt.Errorf("no address defined for static route")
+		}
+
+		if gw, ok := d.GetOk(routePrefix + ".gateway"); ok {
+			ip := net.ParseIP(gw.(string))
+			if ip == nil {
+				return nil, fmt.Errorf("Error parsing IP '%s' in static route in network", gw)
+			}
+			route.Gateway = ip.String()
+		} else {
+			return nil, fmt.Errorf("no gateway defined for static route")
+		}
+
+		routes = append(routes, route)
+	}
+
+	return routes, nil
+}

--- a/travis/run-tests-acceptance
+++ b/travis/run-tests-acceptance
@@ -1,9 +1,20 @@
 #!/bin/bash
-set -x
+#
+# Run acceptance tests.
+#
+# Usage:
+#
+# * List all the acceptance tests: run-tests-acceptance -list 'TestAccLibvirt*'
+# * Run some particular test:      run-tests-acceptance -run TestAccLibvirtDomain_Cpu
+#
+
+TEST_ARGS=$@
+TEST_ARGS_DEF="-covermode=count -coverprofile=profile.cov -timeout=1200s"
 
 unset http_proxy
 export TERRAFORM_LIBVIRT_TEST_DOMAIN_TYPE=qemu
 export LIBVIRT_DEFAULT_URI="qemu:///system"
 export TF_ACC=true
 
-go test -v -covermode=count -coverprofile=profile.cov -timeout=1200s ./libvirt
+set -x
+go test -v $TEST_ARGS_DEF $TEST_ARGS ./libvirt

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -65,6 +65,15 @@ resource "libvirt_network" "kube_network" {
     #     ip = "my.ip.address.2"
     #   },
     # ]
+
+    # (Optional) one or more static routes.
+    # "cidr" and "gateway" must be specified. The format is:
+    # routes = [
+    #   {
+    #     cidr = "10.17.0.0/16"
+    #     gateway = "10.18.0.2"
+    #   },
+    # ]
   }
 }
 ```
@@ -104,6 +113,8 @@ The following arguments are supported:
    it will be automatically obtained by libvirt in `none`, `nat` and `route` modes).
 * `autostart` - (Optional) Set to `true` to start the network on host boot up.
   If not specified `false` is assumed.
+* `routes` - (Optional) a list of static routes. A `cidr` and a `gateway` must
+  be provided. The `gateway` must be reachable via the bridge interface.
 * `dns` - (Optional) configuration of DNS specific settings for the network
 
 Inside of `dns` section the following argument are supported:


### PR DESCRIPTION
Static routes for networks. Users could now specify static routes in a network like this:

```hcl
    ...
    # (Optional) one or more static routes.
    # "cidr" and "gateway" must be specified. The format is:
    routes = [
    {
        cidr = "10.17.0.0/16"
        gateway = "10.18.0.2"
    },
    ...
```