### PR TITLE
Allow setting of VLAN tags for network interface

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -585,6 +585,19 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 			},
 		}
 
+		if _, ok := d.GetOk(prefix + ".vlan"); ok {
+			log.Print("[DEBUG] vlan definition set")
+			netIface.VLan = &libvirtxml.DomainInterfaceVLan{}
+			for vlantag := 0; vlantag < d.Get(prefix+".vlan.0.tag.#").(int); vlantag++ {
+				tagPrefix := fmt.Sprintf(prefix+".vlan.0.tag.%d", vlantag)
+				netIface.VLan.Tags = append(
+					netIface.VLan.Tags,
+					libvirtxml.DomainInterfaceVLanTag{
+						ID: uint(d.Get(tagPrefix).(int)),
+					},
+				)
+			}
+		}
 		// calculate the MAC address
 		var mac string
 		if macI, ok := d.GetOk(prefix + ".mac"); ok {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -214,6 +214,25 @@ func resourceLibvirtDomain() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+
+						"vlan": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Required: false,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tag": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Required: false,
+										Elem: &schema.Schema{
+											Type: schema.TypeInt,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -381,6 +381,7 @@ When connecting to a LAN, users can specify a target device with:
   sent to the VF/IF of the configured network device. Depending on the
   capabilities of the device additional prerequisites or limitations may apply;
   for example, on Linux this requires kernel 2.6.38 or newer.
+* `vlan` - (Optional) A list of vlan tags (see example)
 
 Example of a `macvtap` interface:
 
@@ -393,6 +394,19 @@ resource "libvirt_domain" "my-domain" {
   }
 }
 ```
+
+For  LAN connections with vlan support (`bridge`) it is also possible to
+add vlan tag definition, example:
+
+```hcl
+  network_interface {
+      vlan {
+          tag = [12]
+      }
+  }
+```
+In case multiple tags are specified, libvirt will automatically set the vlan
+type to `trunk`. [Libvirt Vlan Doc](https://libvirt.org/formatdomain.html#elementVlanTag)
 
 **Warning:** the [Qemu guest agent](http://wiki.libvirt.org/page/Qemu_guest_agent)
 must be installed and running inside of the domain in order to discover the IP


### PR DESCRIPTION
Hi again,

sorry for hitting with another pull request, but these are things i will need in the near future,
so im just PR'ing my changes for internal stuff i run. 
This PR enables the definition of VLAN tags for the network interface of the domain. The
Network interface definition will be appended with:

```
      <vlan>
        <tag id='12'/>
      </vlan>
```
in case one    vlan tag is defined, or  mode trunk, if multiple:

```
    <vlan trunk='yes'>
        <tag id='12'/>
        <tag id='13'/>
      </vlan>
```
It however misses the feature to set a certain tag with the tagged or untagged flags as described for openvswitch here:

https://libvirt.org/formatdomain.html#elementVlanTag

have a nice weekend.

