### PR TITLE
allow setting of network card model

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -581,7 +581,7 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 
 		netIface := libvirtxml.DomainInterface{
 			Model: &libvirtxml.DomainInterfaceModel{
-				Type: "virtio",
+				Type: d.Get(prefix + ".model").(string),
 			},
 		}
 

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -188,6 +188,11 @@ func resourceLibvirtDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"model": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "virtio",
+						},
 						"passthrough": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -827,6 +832,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 			"bridge":         "",
 			"vepa":           "",
 			"macvtap":        "",
+			"model":          "",
 			"passthrough":    "",
 			"mac":            mac,
 			"hostname":       "",
@@ -855,6 +861,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			netIface["network_name"] = networkInterfaceDef.Source.Network.Network
+			netIface["model"] = networkInterfaceDef.Model
 
 			// try to look for this MAC in the DHCP configuration for this VM
 			if HasDHCP(networkDef) {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -396,6 +396,9 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 			mac            = "52:54:00:A9:F5:17"
 			wait_for_lease = true
 		}
+		network_interface = {
+			model = "e1000"
+		}
 		disk {
 			file = "%s/testdata/tcl.iso"
 		}
@@ -414,6 +417,8 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 						"libvirt_domain."+randomDomainName, "network_interface.0.network_name", "default"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "network_interface.1.mac", "52:54:00:A9:F5:17"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "network_interface.2.model", "e1000"),
 				),
 			},
 		},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -353,6 +353,7 @@ When using a virtual network, users can specify:
   [network resource](/website/docs/r/network.markdown) managed by the
   Terraform libvirt provider.
 * `mac` - (Optional) The specific MAC address to use for this interface.
+* `model` - Set the model of emulated network interface card, defaults to `virtio`.
 * `addresses` - (Optional) An IP address for this domain in this network.
 * `hostname` - (Optional) A hostname that will be assigned to this domain
   resource in this network.


### PR DESCRIPTION
see #521 
this time the testacc shall work as resourceLibvirtDomainRead has been updated accordingly too.