### PR TITLE
allow setting of video card type

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -251,6 +251,19 @@ func setCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) err
 	return nil
 }
 
+func setVideo(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
+	prefix := "video.0"
+	if _, ok := d.GetOk(prefix); ok {
+		domainDef.Devices.Videos = append(domainDef.Devices.Videos, libvirtxml.DomainVideo{
+			Model: libvirtxml.DomainVideoModel{
+				Type: d.Get(prefix + ".type").(string),
+			},
+		})
+	}
+
+	return nil
+}
+
 func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch string) error {
 	if arch == "s390x" || arch == "ppc64" {
 		domainDef.Devices.Graphics = nil

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -241,6 +241,20 @@ func resourceLibvirtDomain() *schema.Resource {
 					},
 				},
 			},
+			"video": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "cirrus",
+						},
+					},
+				},
+			},
 			"console": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -430,6 +444,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	setVideo(d, &domainDef)
 	setConsoles(d, &domainDef)
 	setCmdlineArgs(d, &domainDef)
 	setFirmware(d, &domainDef)

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -596,6 +596,35 @@ func TestAccLibvirtDomain_Cpu(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtDomain_Video(t *testing.T) {
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandString(10)
+
+	var config = fmt.Sprintf(`
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		video {
+			type = "vga"
+		}
+	}`, randomDomainName, randomDomainName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "video.0.type", "vga"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtDomain_Autostart(t *testing.T) {
 	var domain libvirt.Domain
 	randomDomainName := acctest.RandString(10)

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -398,7 +398,7 @@ resource "libvirt_domain" "my-domain" {
 must be installed and running inside of the domain in order to discover the IP
 addresses of all the network interfaces attached to a LAN.
 
-### Graphics devices
+### Graphics devices and Video Card
 
 The optional `graphics` block allows you to override the default graphics
 settings.
@@ -420,6 +420,18 @@ resource "libvirt_domain" "my_machine" {
   graphics {
     type = "vnc"
     listen_type = "address"
+  }
+}
+```
+
+The video card type can be changed from libvirt default `cirrus` to
+`vga` or others as described in [Video Card Elements](https://libvirt.org/formatdomain.html#elementsVideo)
+
+```hcl
+resource "libvirt_domain" "my_machine" {
+  ...
+  video {
+    type = "vga"
   }
 }
 ```


### PR DESCRIPTION
Usually this is something one might not think of, but there are certain systems that have trouble with the default video card set by libvirt (cirrus). For example ESXi will be stuck in a endless boot loop shortly after GRUB loading... It however works with video card type VGA.

Simple PR introduces posiblity to set video card type to VGA. There might be more options like ram/vram which are good with default values, so i ignored them. Maybe its good to add more options like 3d acceleration if needed. Comes with test case but does not re-read upon VM change, which is sufficient for my needs.