### PR TITLE
#349 Allow Configure VNC listen address #519

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -271,7 +271,10 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 		if listenType, ok := d.GetOk(prefix + ".listen_type"); ok {
 			switch listenType {
 			case "address":
-				listener.Address = &libvirtxml.DomainGraphicListenerAddress{}
+				listenAddress := d.Get(prefix + ".listen_address")
+				listener.Address = &libvirtxml.DomainGraphicListenerAddress{
+					listenAddress.(string),
+				}
 			case "network":
 				listener.Network = &libvirtxml.DomainGraphicListenerNetwork{}
 			case "socket":

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -238,6 +238,11 @@ func resourceLibvirtDomain() *schema.Resource {
 							Optional: true,
 							Default:  "none",
 						},
+						"listen_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "127.0.0.1",
+						},
 					},
 				},
 			},

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -501,6 +501,21 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 		}
 	}`, randomVolumeName, randomVolumeName, randomDomainName, randomDomainName)
 
+	var configListenAddress = fmt.Sprintf(`
+	resource "libvirt_volume" "%s" {
+		name = "%s"
+	}
+
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		graphics {
+			type        = "spice"
+			autoport    = "true"
+			listen_type = "address"
+			listen_address = "127.0.1.1"
+		}
+	}`, randomVolumeName, randomVolumeName, randomDomainName, randomDomainName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -516,6 +531,28 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 						"libvirt_domain."+randomDomainName, "graphics.0.autoport", "true"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "graphics.0.listen_type", "none"),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configListenAddress,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.type", "spice"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.autoport", "true"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.listen_type", "address"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.listen_address", "127.0.1.1"),
 				),
 			},
 		},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -408,9 +408,14 @@ The block supports:
 * `type` - the type of graphics emulation (default is "spice")
 * `autoport` - defaults to "yes"
 * `listen_type` - "listen type", defaults to "none"
+* `listen_address` - (Optional) IP Address where the VNC listener should be started if
+`listen_type` is set to `address`. Defaults to 127.0.0.1
 
 On occasion we have found it necessary to set a `type` of `vnc` and a
 `listen_type` of `address` with certain builds of QEMU.
+
+With `listen_address` it is possible to specify a listener address for the virtual
+machines VNC server. Usually this is an IP of the host system.
 
 The `graphics` block will look as follows:
 


### PR DESCRIPTION
as last PR, now with test ACC. Changing syntax  to


```
listen {
 address ..
}
```
will probably break already existing configurations, so i left the syntax in place.