### PR TITLE
Issue #391 Add dns enabled= no/yes option

### DIFF
--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -293,3 +293,27 @@ func testAccCheckLibvirtNetworkLocalOnly(name string, expectLocalOnly bool) reso
 		return nil
 	}
 }
+
+// testAccCheckLibvirtNetworkDNSEnable checks the dns-enable property of the Domain
+func testAccCheckLibvirtNetworkDNSEnableOrDisable(name string, expectDNS bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		virConn := testAccProvider.Meta().(*Client).libvirt
+
+		networkDef, err := getNetworkDef(s, name, *virConn)
+		if err != nil {
+			return err
+		}
+		if expectDNS {
+			if networkDef.DNS == nil || networkDef.DNS.Enable != "yes" {
+				return fmt.Errorf("networkDef.DNS.Enable is not true")
+			}
+		}
+		if !expectDNS {
+			if networkDef.DNS != nil && networkDef.DNS.Enable != "no" {
+				return fmt.Errorf("networkDef.DNS.Enable is true")
+			}
+		}
+		return nil
+	}
+}

--- a/libvirt/network_dns.go
+++ b/libvirt/network_dns.go
@@ -201,6 +201,17 @@ func getDNSForwardersFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkD
 	return dnsForwarders, nil
 }
 
+// getDNSEnableFromResource returns string to enable ("yes") or disable ("no") dns
+// in the network definition
+func getDNSEnableFromResource(d *schema.ResourceData) (string, error) {
+	if dnsLocalOnly, ok := d.GetOk(dnsPrefix + ".enabled"); ok {
+		if dnsLocalOnly.(bool) {
+			return "yes", nil // this "boolean" must be "yes"|"no"
+		}
+	}
+	return "no", nil
+}
+
 // getDNSSRVFromResource returns a list of libvirt's DNS SRVs
 // in the network definition
 func getDNSSRVFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkDNSSRV, error) {

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -65,6 +65,60 @@ func TestAccLibvirtNetwork_LocalOnly(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtNetwork_DNSEnable(t *testing.T) {
+	randomNetworkResource := acctest.RandString(10)
+	randomNetworkName := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_network" "%s" {
+					name      = "%s"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					dns {
+						enabled = true
+					}
+				}`, randomNetworkResource, randomNetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dns.0.enabled", "true"),
+					testAccCheckLibvirtNetworkDNSEnableOrDisable("libvirt_network."+randomNetworkResource, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtNetwork_DNSDisable(t *testing.T) {
+	randomNetworkResource := acctest.RandString(10)
+	randomNetworkName := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_network" "%s" {
+					name      = "%s"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					dns {
+						enabled = false
+					}
+				}`, randomNetworkResource, randomNetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dns.0.enabled", "false"),
+					testAccCheckLibvirtNetworkDNSEnableOrDisable("libvirt_network."+randomNetworkResource, false),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtNetwork_DNSForwarders(t *testing.T) {
 	randomNetworkResource := acctest.RandString(10)
 	randomNetworkName := acctest.RandString(10)


### PR DESCRIPTION
Use Case
-------------
- Latest libvirt provide a way to disable the `dns` using `<dns enable=no/>` as template but looks like in the provider code we don't have an implementation for it.
- Another use case by default if you don't have any entry on the libvirt network definition then also `dnsmasq` instance run on that network interface, so you can't bind that interface with any other dns (like coredns)

Without the PR
--------------------
```console
$ cat main.tf 
provider "libvirt" {
  uri = "qemu+tcp://libvirt.default/system"
}

resource "libvirt_network" "net" {
  name = "test1-afdd"

  mode   = "nat"
  bridge = "tt0"

  domain = "test1.tt.testing"
  addresses = ["192.162.126.0/24"]

  dns = [{
    local_only = true
  }]

  autostart = true
}

# virsh net-dumpxml test1-afdd 
<network>
  <name>test1-afdd</name>
  <uuid>6dd0ccac-b89b-4091-880f-e94f5e4d54e8</uuid>
  <forward mode='nat'>
    <nat>
      <port start='1024' end='65535'/>
    </nat>
  </forward>
  <bridge name='tt0' stp='on' delay='0'/>
  <mac address='52:54:00:06:d2:f7'/>
  <domain name='test1.tt.testing' localOnly='yes'/>
  <ip family='ipv4' address='192.162.126.1' prefix='24'>
    <dhcp>
      <range start='192.162.126.2' end='192.162.126.254'/>
    </dhcp>
  </ip>
</network>

# netstat -ntpl | grep 53
tcp        0      0 192.162.126.1:53        0.0.0.0:*               LISTEN      19559/dnsmasq       
tcp        0      0 192.168.122.1:53        0.0.0.0:*               LISTEN      1644/dnsmasq        
```

With PR
-----------

```console
$ cat main.tf 
provider "libvirt" {
  uri = "qemu+tcp://libvirt.default/system"
}

resource "libvirt_network" "net" {
  name = "test1-afdd"

  mode   = "nat"
  bridge = "tt0"

  domain = "test1.tt.testing"
  addresses = ["192.162.126.0/24"]

  dns = [{
    enable = false
    local_only = true
  }]

  autostart = true
}

# virsh net-dumpxml test1-afdd 
<network>
  <name>test1-afdd</name>
  <uuid>0491a9dd-dead-48ce-9c63-082f56f1ba3e</uuid>
  <forward mode='nat'>
    <nat>
      <port start='1024' end='65535'/>
    </nat>
  </forward>
  <bridge name='tt0' stp='on' delay='0'/>
  <mac address='52:54:00:77:56:6f'/>
  <domain name='test1.tt.testing' localOnly='yes'/>
  <dns enable='no'/>
  <ip family='ipv4' address='192.162.126.1' prefix='24'>
    <dhcp>
      <range start='192.162.126.2' end='192.162.126.254'/>
    </dhcp>
  </ip>

# netstat -ntpl | grep 53
tcp        0      0 192.168.122.1:53        0.0.0.0:*               LISTEN      1644/dnsmasq
```
