### PR TITLE
domain: better support for multiple CDROMs

### DIFF
--- a/examples/cdroms/main.tf
+++ b/examples/cdroms/main.tf
@@ -1,0 +1,28 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+resource "libvirt_cloudinit_disk" "commoninit" {
+  name      = "commoninit.iso"
+  user_data = "#cloud-config"
+}
+
+# Up to 4 local file CDROMs can be attached to the domain. When attached,
+# cloudinit reserves one of the slots.
+resource "libvirt_domain" "example" {
+  name = "example"
+
+  cloudinit = "${libvirt_cloudinit_disk.commoninit.id}"
+
+  disk {
+    file = "${path.module}/image.iso"
+  }
+
+  disk {
+    file = "${path.module}/image2.iso"
+  }
+
+  disk {
+    file = "${path.module}/image3.iso"
+  }
+}


### PR DESCRIPTION
File ISO disk and cloudinit both used a hardcoded target device name, causing a
conflict when defining both at the same time. The conflict could also be
triggered by defining multiple file ISO disks.

* libvirt_domain.alpine: Error defining libvirt domain: virError(Code=27,
Domain=20, Message='XML error: target 'hda' duplicated for disk sources
'/tmp/alpine-standard-3.9.2-x86_64.iso' and '/pool/ci-iso'')

After this change, the CDROM target device name might be different for certain
terraform descriptions from what it was. However, from libvirt's documentation,

"The actual device name specified is not guaranteed to map to the device name
in the guest OS. Treat it as a device ordering hint."

The CDROM disk boot order is unaffected by this change.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
