### PR TITLE
Switch back to using File paths for disk volumes

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -428,19 +428,9 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 				return fmt.Errorf("Can't retrieve volume %s: %v", volumeKey.(string), err)
 			}
 
-			diskVolumeName, err := diskVolume.GetName()
+			diskVolumeFile, err := diskVolume.GetPath()
 			if err != nil {
-				return fmt.Errorf("Can't retrieve name for volume %s", volumeKey.(string))
-			}
-
-			diskPool, err := diskVolume.LookupPoolByVolume()
-			if err != nil {
-				return fmt.Errorf("Can't retrieve pool for volume %s", volumeKey.(string))
-			}
-
-			diskPoolName, err := diskPool.GetName()
-			if err != nil {
-				return fmt.Errorf("Can't retrieve name for pool of volume %s", volumeKey.(string))
+				return fmt.Errorf("Can't retrieve volume file %s", volumeKey.(string))
 			}
 
 			// find out the format of the volume in order to set the appropriate
@@ -469,9 +459,8 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 			}
 
 			disk.Source = &libvirtxml.DomainDiskSource{
-				Volume: &libvirtxml.DomainDiskSourceVolume{
-					Pool:   diskPoolName,
-					Volume: diskVolumeName,
+				File: &libvirtxml.DomainDiskSourceFile{
+					File: diskVolumeFile,
 				},
 			}
 		} else if rawURL, ok := d.GetOk(prefix + ".url"); ok {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -768,9 +768,9 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 				"file": diskDef.Source.File,
 			}
 		} else if diskDef.Source.File != nil {
-			// LEGACY way of handling volumes using "file", which we replaced
-			// by the diskdef.Source.Volume once we realized it existed.
-			// This code will be removed in future versions of the provider.
+			// Volumes need to be defined in libvirt XML using File paths
+			// to allow libvirt security helper utilities correctly identify the
+			// storage to apply the correct access polices
 			virVol, err := virConn.LookupStorageVolByPath(diskDef.Source.File.File)
 			if err != nil {
 				return fmt.Errorf("Error retrieving volume for disk: %s", err)
@@ -786,6 +786,9 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 				"volume_id": virVolKey,
 			}
 		} else {
+			// Compatibility way of handling volumes from XML, which is replaced
+			// by switching to use file paths to ensure libvirt security helper
+			// utilities can apply the correct access policies.
 			pool, err := virConn.LookupStoragePoolByName(diskDef.Source.Volume.Pool)
 			if err != nil {
 				return fmt.Errorf("Error retrieving pool for disk: %s", err)


### PR DESCRIPTION
Prefer resolving disk definitions to file paths for libvirt domain
creation to allow libvirt security helper utilities such as
virt-aa-helper correctly determine the files upon which to apply the
necessary security policies required for non-root user usage.

Fixes #126 