### PR TITLE
minor: don't print out unneeded info.

### DIFF
--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -118,7 +118,6 @@ func testAccCheckNetworkExists(name string, network *libvirt.Network) resource.T
 		}
 
 		virConn := testAccProvider.Meta().(*Client).libvirt
-		fmt.Printf("%p", virConn)
 		networkRetrived, err := virConn.LookupNetworkByUUIDString(rs.Primary.ID)
 		if err != nil {
 			return err


### PR DESCRIPTION
In the helper function, we don't need to print out connection on helper test.

This is more coherent with other codebase calls.

