### PR TITLE
When volume size is not given, set the backing store size as the size

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -209,7 +209,7 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 				return err
 			}
 
-			// if the volumen does not specify size, set it to the size of the backing store
+			// if the volume does not specify size, set it to the size of the backing store
 			if _, ok := d.GetOk("size"); !ok {
 				volumeDef.Capacity.Value = backingStoreVolumeDef.Capacity.Value
 			}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -196,8 +196,9 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 				return fmt.Errorf("Can't retrieve base volume with name '%s': %v", baseVolumeName.(string), err)
 			}
 		}
+
 		if baseVolume != nil {
-			backingStoreDef, err := newDefBackingStoreFromLibvirt(baseVolume)
+			backingStoreFragmentDef, err := newDefBackingStoreFromLibvirt(baseVolume)
 			if err != nil {
 				return fmt.Errorf("Could not retrieve backing store definition: %s", err.Error())
 			}
@@ -213,7 +214,7 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 					return fmt.Errorf("When 'size' is specified, it shouldn't be smaller than the backing store specified with 'base_volume_id' or 'base_volume_name/base_volume_pool'")
 				}
 			}
-			volumeDef.BackingStore = &backingStoreDef
+			volumeDef.BackingStore = &backingStoreFragmentDef
 		}
 	}
 	if _, ok := d.GetOk("size"); ok {

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -142,6 +142,8 @@ func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtVolumeExists("libvirt_volume.backing-" + random, &volume),
 					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume." + random, &volume2),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+random, "size", "1073741824"),
 				),
 			},
 		},
@@ -171,6 +173,8 @@ func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtVolumeExists("libvirt_volume.backing-"+random, &volume),
 					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume." + random, &volume2),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+random, "size", "1073741824"),
 				),
 			},
 		},

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -122,8 +122,7 @@ func TestAccLibvirtVolume_Basic(t *testing.T) {
 func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 	var volume libvirt.StorageVol
 	var volume2 libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	random := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -131,18 +130,18 @@ func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-				resource "libvirt_volume" "%s" {
-					name = "%s"
+				resource "libvirt_volume" "backing-%s" {
+					name = "backing-%s"
 					size =  1073741824
 				}
-				resource "libvirt_volume" "backing-store" {
-					name = "backing-store"
-					base_volume_id = "${libvirt_volume.%s.id}"
+				resource "libvirt_volume" "%s" {
+					name = "%s"
+					base_volume_id = "${libvirt_volume.backing-%s.id}"
 			        }
-				`, randomVolumeResource, randomVolumeName, randomVolumeResource),
+				`, random, random, random, random, random),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
-					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume.backing-store", &volume2),
+					testAccCheckLibvirtVolumeExists("libvirt_volume.backing-" + random, &volume),
+					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume." + random, &volume2),
 				),
 			},
 		},
@@ -152,8 +151,7 @@ func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 	var volume libvirt.StorageVol
 	var volume2 libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	random := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -161,17 +159,18 @@ func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-					resource "libvirt_volume" "%s" {
-						name = "%s"
-						size =  1073741824
-					}
-					resource "libvirt_volume" "backing-store" {
-						name = "backing-store"
-						base_volume_name = "${libvirt_volume.%s.name}"
-				  }	`, randomVolumeResource, randomVolumeName, randomVolumeResource),
+				resource "libvirt_volume" "backing-%s" {
+					name = "backing-%s"
+					size =  1073741824
+				}
+				resource "libvirt_volume" "%s" {
+					name = "%s"
+                    base_volume_name = "${libvirt_volume.backing-%s.name}"
+			        }
+				`, random, random, random, random, random),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
-					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume.backing-store", &volume2),
+					testAccCheckLibvirtVolumeExists("libvirt_volume.backing-"+random, &volume),
+					testAccCheckLibvirtVolumeIsBackingStore("libvirt_volume." + random, &volume2),
 				),
 			},
 		},


### PR DESCRIPTION
Fix regression introduced with f86539c365b5bd12374318070894c504a1636c4b

Rework the logic to:

* First set the volume size to the given size, if something was given
* If the size is not given, and there is backing store, use the size of the backing store
* Only then check if the size of the volume is smaller than the backing store

Also, cleanup the testcase and add a check for the size when this one is not specified, but a backing store is given.

Fixes #561

