### PR TITLE
Seed the random number generator

### DIFF
--- a/libvirt/utils_net.go
+++ b/libvirt/utils_net.go
@@ -19,6 +19,7 @@ const (
 // with libvirt prefix
 func randomMACAddress() (string, error) {
 	buf := make([]byte, 3)
+	rand.Seed(time.Now().UnixNano())
 	_, err := rand.Read(buf)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Ensure operations calling randomMACAddress data get a
random MAC address, calls were providing the same mac address
in multiple environments and as a result getting the same
IP address if not isolated.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
