### PR TITLE
[Feature] Support for libvirt_domain tags

### DIFF
--- a/examples/v0.11/coreos/main.tf
+++ b/examples/v0.11/coreos/main.tf
@@ -70,6 +70,7 @@ resource "libvirt_domain" "coreos-machine" {
     # Requires qemu-agent container if network is not native to libvirt
     wait_for_lease = true
   }
+
   ## mounts filesystem local to the kvm host. used to patch in the
   ## qemu-guest-agent as docker container
   #filesystem {
@@ -78,7 +79,7 @@ resource "libvirt_domain" "coreos-machine" {
   #  readonly = true
   #}
   tags {
-    OS       = "CoreOS"
+    OS = "CoreOS"
     NodeType = "${count.index <= 3 ? "master" : "worker"}"
   }
 }

--- a/examples/v0.11/coreos/main.tf
+++ b/examples/v0.11/coreos/main.tf
@@ -5,7 +5,7 @@ provider "libvirt" {
 
 # -[Variables]-------------------------------------------------------------
 variable "hosts" {
-  default = 1
+  default = 7
 }
 
 variable "hostname_format" {
@@ -38,8 +38,8 @@ resource "libvirt_ignition" "ignition" {
 resource "libvirt_domain" "coreos-machine" {
   count  = "${var.hosts}"
   name   = "${format(var.hostname_format, count.index + 1)}"
-  vcpu   = "1"
-  memory = "2048"
+  vcpu   = "${count.index <= 3 ? 4 : 8}"
+  memory = "${count.index <= 3 ? 4096 : 16384}"
 
   ## Use qemu-agent in conjunction with the container
   #qemu_agent = true
@@ -78,6 +78,10 @@ resource "libvirt_domain" "coreos-machine" {
   #  target = "qemu_docker_images"
   #  readonly = true
   #}
+  tags {
+    OS = "CoreOS"
+    NodeType = "${count.index <= 3 ? "master" : "worker"}"
+  }
 }
 
 # -[Output]-------------------------------------------------------------

--- a/examples/v0.11/coreos/main.tf
+++ b/examples/v0.11/coreos/main.tf
@@ -70,7 +70,6 @@ resource "libvirt_domain" "coreos-machine" {
     # Requires qemu-agent container if network is not native to libvirt
     wait_for_lease = true
   }
-
   ## mounts filesystem local to the kvm host. used to patch in the
   ## qemu-guest-agent as docker container
   #filesystem {
@@ -79,7 +78,7 @@ resource "libvirt_domain" "coreos-machine" {
   #  readonly = true
   #}
   tags {
-    OS = "CoreOS"
+    OS       = "CoreOS"
     NodeType = "${count.index <= 3 ? "master" : "worker"}"
   }
 }

--- a/examples/v0.11/coreos/main.tf
+++ b/examples/v0.11/coreos/main.tf
@@ -78,7 +78,7 @@ resource "libvirt_domain" "coreos-machine" {
   #  target = "qemu_docker_images"
   #  readonly = true
   #}
-  tags {
+  tags = {
     OS = "CoreOS"
     NodeType = "${count.index <= 3 ? "master" : "worker"}"
   }

--- a/examples/v0.12/coreos/main.tf
+++ b/examples/v0.12/coreos/main.tf
@@ -5,7 +5,7 @@ provider "libvirt" {
 
 # -[Variables]-------------------------------------------------------------
 variable "hosts" {
-  default = 1
+  default = 7
 }
 
 variable "hostname_format" {
@@ -38,8 +38,8 @@ resource "libvirt_ignition" "ignition" {
 resource "libvirt_domain" "coreos-machine" {
   count  = var.hosts
   name   = format(var.hostname_format, count.index + 1)
-  vcpu   = "1"
-  memory = "2048"
+  vcpu   = count.index <= 3 ? 4 : 8
+  memory = count.index <= 3 ? 4096 : 16384
 
   ## Use qemu-agent in conjunction with the container
   #qemu_agent = true
@@ -77,6 +77,10 @@ resource "libvirt_domain" "coreos-machine" {
   #  target = "qemu_docker_images"
   #  readonly = true
   #}
+  tags = {
+    OS = "CoreOS"
+    NodeType = "${count.index <= 3 ? "master" : "worker"}"
+  }
 }
 
 # -[Output]-------------------------------------------------------------

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -1,6 +1,7 @@
 package libvirt
 
 import (
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"log"
@@ -28,6 +29,18 @@ const domWaitLeaseStillWaiting = "waiting-addresses"
 const domWaitLeaseDone = "all-addresses-obtained"
 
 var errDomainInvalidState = errors.New("invalid state for domain")
+
+// TerraformInstanceXML type
+type TerraformInstanceXML struct {
+	XMLName xml.Name          `xml:"https://terraform.io instance"`
+	Tags    []TerraformTagXML `xml:"tag"`
+}
+
+// TerraformTagXML type
+type TerraformTagXML struct {
+	Key   string `xml:"name,attr"`
+	Value string `xml:",chardata"`
+}
 
 func domainWaitForLeases(domain *libvirt.Domain, waitForLeases []*libvirtxml.DomainInterface,
 	timeout time.Duration, rd *schema.ResourceData) error {
@@ -763,6 +776,57 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 		}
 
 		domainDef.Devices.Interfaces = append(domainDef.Devices.Interfaces, netIface)
+	}
+
+	return nil
+}
+
+func tagsToXML(tags map[string]interface{}, metadata *TerraformInstanceXML) (out string, err error) {
+	// Overwrite existing tags while keeping additional metadata
+	metadata.Tags = []TerraformTagXML{}
+	for key, value := range tags {
+		metadata.Tags = append(metadata.Tags, TerraformTagXML{
+			Key:   key,
+			Value: value.(string),
+		})
+	}
+	var bytesOut []byte
+	if bytesOut, err = xml.Marshal(metadata); err != nil {
+		return "", fmt.Errorf("Failed to marshal metadata XML: %s", err)
+	}
+	return string(bytesOut), nil
+}
+
+func setMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) {
+	metadata := TerraformInstanceXML{}
+	if err = xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); domain.Metadata.XML != "" && err != nil {
+		return fmt.Errorf("XML Unmarshal Error: %s", err)
+	}
+	if _, ok := d.GetOk("tags"); ok {
+		tags := d.Get("tags").(map[string]interface{})
+		var out string
+		if out, err = tagsToXML(tags, &metadata); err != nil {
+			return err
+		}
+		domain.Metadata = &libvirtxml.DomainMetadata{
+			XML: out,
+		}
+		log.Printf("[DEBUG] Created Metadata XML: %s", domain.Metadata.XML)
+	}
+	return nil
+}
+
+func getMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) error {
+	if domain.Metadata != nil && domain.Metadata.XML != "" {
+		metadata := TerraformInstanceXML{}
+		if err := xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); err != nil {
+			return fmt.Errorf("XML Unmarshal Error: %s", err)
+		}
+		out := make(map[string]string)
+		for _, tag := range metadata.Tags {
+			out[tag.Key] = tag.Value
+		}
+		d.Set("tags", out)
 	}
 
 	return nil

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -1,7 +1,6 @@
 package libvirt
 
 import (
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"log"
@@ -29,18 +28,6 @@ const domWaitLeaseStillWaiting = "waiting-addresses"
 const domWaitLeaseDone = "all-addresses-obtained"
 
 var errDomainInvalidState = errors.New("invalid state for domain")
-
-// TerraformInstanceXML type
-type TerraformInstanceXML struct {
-	XMLName xml.Name          `xml:"https://terraform.io instance"`
-	Tags    []TerraformTagXML `xml:"tag"`
-}
-
-// TerraformTagXML type
-type TerraformTagXML struct {
-	Key   string `xml:"name,attr"`
-	Value string `xml:",chardata"`
-}
 
 func domainWaitForLeases(domain *libvirt.Domain, waitForLeases []*libvirtxml.DomainInterface,
 	timeout time.Duration, rd *schema.ResourceData) error {
@@ -776,57 +763,6 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 		}
 
 		domainDef.Devices.Interfaces = append(domainDef.Devices.Interfaces, netIface)
-	}
-
-	return nil
-}
-
-func tagsToXML(tags map[string]interface{}, metadata *TerraformInstanceXML) (out string, err error) {
-	// Overwrite existing tags while keeping additional metadata
-	metadata.Tags = []TerraformTagXML{}
-	for key, value := range tags {
-		metadata.Tags = append(metadata.Tags, TerraformTagXML{
-			Key:   key,
-			Value: value.(string),
-		})
-	}
-	var bytesOut []byte
-	if bytesOut, err = xml.Marshal(metadata); err != nil {
-		return "", fmt.Errorf("Failed to marshal metadata XML: %s", err)
-	}
-	return string(bytesOut), nil
-}
-
-func setMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) {
-	metadata := TerraformInstanceXML{}
-	if err = xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); domain.Metadata.XML != "" && err != nil {
-		return fmt.Errorf("XML Unmarshal Error: %s", err)
-	}
-	if _, ok := d.GetOk("tags"); ok {
-		tags := d.Get("tags").(map[string]interface{})
-		var out string
-		if out, err = tagsToXML(tags, &metadata); err != nil {
-			return err
-		}
-		domain.Metadata = &libvirtxml.DomainMetadata{
-			XML: out,
-		}
-		log.Printf("[DEBUG] Created Metadata XML: %s", domain.Metadata.XML)
-	}
-	return nil
-}
-
-func getMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) error {
-	if domain.Metadata != nil && domain.Metadata.XML != "" {
-		metadata := TerraformInstanceXML{}
-		if err := xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); err != nil {
-			return fmt.Errorf("XML Unmarshal Error: %s", err)
-		}
-		out := make(map[string]string)
-		for _, tag := range metadata.Tags {
-			out[tag.Key] = tag.Value
-		}
-		d.Set("tags", out)
 	}
 
 	return nil

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -43,6 +43,7 @@ func newDomainDef() libvirtxml.Domain {
 				Type: "hvm",
 			},
 		},
+		Metadata: &libvirtxml.DomainMetadata{},
 		Memory: &libvirtxml.DomainMemory{
 			Unit:  "MiB",
 			Value: 512,

--- a/libvirt/domain_metadata.go
+++ b/libvirt/domain_metadata.go
@@ -37,7 +37,7 @@ func tagsToXML(tags map[string]interface{}, metadata *TerraformInstanceXML) (out
 	return string(bytesOut), nil
 }
 
-func setMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) {
+func setMetadataFromXML(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) {
 	metadata := TerraformInstanceXML{}
 	if err = xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); domain.Metadata.XML != "" && err != nil {
 		return fmt.Errorf("XML Unmarshal Error: %s", err)
@@ -56,7 +56,7 @@ func setMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) 
 	return nil
 }
 
-func getMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) error {
+func getMetadataFromXML(d *schema.ResourceData, domain *libvirtxml.Domain) error {
 	if domain.Metadata != nil && domain.Metadata.XML != "" {
 		metadata := TerraformInstanceXML{}
 		if err := xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); err != nil {

--- a/libvirt/domain_metadata.go
+++ b/libvirt/domain_metadata.go
@@ -1,0 +1,73 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/libvirt/libvirt-go-xml"
+)
+
+// TerraformInstanceXML type
+type TerraformInstanceXML struct {
+	XMLName xml.Name          `xml:"https://terraform.io instance"`
+	Tags    []TerraformTagXML `xml:"tag"`
+}
+
+// TerraformTagXML type
+type TerraformTagXML struct {
+	Key   string `xml:"name,attr"`
+	Value string `xml:",chardata"`
+}
+
+func tagsToXML(tags map[string]interface{}, metadata *TerraformInstanceXML) (out string, err error) {
+	// Overwrite existing tags while keeping additional metadata
+	metadata.Tags = []TerraformTagXML{}
+	for key, value := range tags {
+		metadata.Tags = append(metadata.Tags, TerraformTagXML{
+			Key:   key,
+			Value: value.(string),
+		})
+	}
+	var bytesOut []byte
+	if bytesOut, err = xml.Marshal(metadata); err != nil {
+		return "", fmt.Errorf("Failed to marshal metadata XML: %s", err)
+	}
+	return string(bytesOut), nil
+}
+
+func setMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) (err error) {
+	metadata := TerraformInstanceXML{}
+	if err = xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); domain.Metadata.XML != "" && err != nil {
+		return fmt.Errorf("XML Unmarshal Error: %s", err)
+	}
+	if _, ok := d.GetOk("tags"); ok {
+		tags := d.Get("tags").(map[string]interface{})
+		var out string
+		if out, err = tagsToXML(tags, &metadata); err != nil {
+			return err
+		}
+		domain.Metadata = &libvirtxml.DomainMetadata{
+			XML: out,
+		}
+		log.Printf("[DEBUG] Created Metadata XML: %s", domain.Metadata.XML)
+	}
+	return nil
+}
+
+func getMetadata(d *schema.ResourceData, domain *libvirtxml.Domain) error {
+	if domain.Metadata != nil && domain.Metadata.XML != "" {
+		metadata := TerraformInstanceXML{}
+		if err := xml.Unmarshal([]byte(domain.Metadata.XML), &metadata); err != nil {
+			return fmt.Errorf("XML Unmarshal Error: %s", err)
+		}
+		out := make(map[string]string)
+		for _, tag := range metadata.Tags {
+			out[tag.Key] = tag.Value
+		}
+		d.Set("tags", out)
+	}
+
+	return nil
+}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -469,7 +469,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	setFirmware(d, &domainDef)
 	setBootDevices(d, &domainDef)
 
-	if err := setMetadata(d, &domainDef); err != nil {
+	if err := setMetadataFromXML(d, &domainDef); err != nil {
 		return err
 	}
 
@@ -765,7 +765,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arch", domainDef.OS.Type.Arch)
 	d.Set("autostart", autostart)
 
-	if err := getMetadata(d, &domainDef); err != nil {
+	if err := getMetadataFromXML(d, &domainDef); err != nil {
 		return err
 	}
 

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -906,7 +906,7 @@ func TestAccLibvirtDomain_Tags(t *testing.T) {
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
 		name = "%s"
-		tags {
+		tags = {
 			%s = "%s"
 		}
 	}

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
    [below](#define-boot-device-order).
 * `emulator` - (Optional) The path of the emulator to use
 * `qemu_agent` (Optional) By default is disabled, set to true for enabling it. More info [qemu-agent](https://wiki.libvirt.org/page/Qemu_guest_agent).
+* `tags` - (Optional) A hashmap of tags that are associated with the domain.
 ### Kernel and boot arguments
 
 * `kernel` - (Optional) The path of the kernel to boot
@@ -544,6 +545,17 @@ Set hd as default and fallback to network.
 ```hcl
 boot_device {
   dev = [ "hd", "network"]
+}
+```
+
+### Add tags to the domain
+
+By setting tags for the domain you can more easily filter and export the terraform state to external tools:
+
+```hcl
+tags {
+  type = "master"
+  etcd = "true"
 }
 ```
 


### PR DESCRIPTION
## Reason
Quite a few external tools make use of the virtual machine `tags` to sort them for further use. Currently there is at least support in AWS and Azure instances as well as vSphere machines. An example usage would be creating an ansible inventory.

## Changes
This merge request adds an optional paramater that does not affect existing configurations. Based on the input a custom xml is generated and added to the standard domain metadata. Updates to the tags are done live and to the configuration of the machine.
An existing but unused parameter `metadata` was removed from the `libvirt_domain` but could be kept and be integrated in the future.

A minimal change was made to existing domain unit test. No additional test was added.

## Breaking Changes
None

## Discussion
Currently the custom xml uses the namespace "terraform.io" which might not be appropriate for an unofficial provider. The full github path just seemed a bit too long.

  (Closes: GH-583)