### PR TITLE
domain: telnet console support

### DIFF
--- a/examples/ubuntu/ubuntu-example.tf
+++ b/examples/ubuntu/ubuntu-example.tf
@@ -51,7 +51,7 @@ resource "libvirt_domain" "domain-ubuntu" {
   }
 
   console {
-    type        = "pty"
+    type        = "tcp"
     target_type = "virtio"
     target_port = "1"
   }

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -390,18 +390,36 @@ func setConsoles(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 				Port: &consoleTargetPort,
 			}
 		}
-		if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
-			console.Source = &libvirtxml.DomainChardevSource{
-				Dev: &libvirtxml.DomainChardevSourceDev{
-					Path: sourcePath.(string),
-				},
-			}
-		}
 		if targetType, ok := d.GetOk(prefix + ".target_type"); ok {
 			if console.Target == nil {
 				console.Target = &libvirtxml.DomainConsoleTarget{}
 			}
 			console.Target.Type = targetType.(string)
+		}
+		switch d.Get(prefix + ".type").(string) {
+		case "tcp":
+			sourceHost := d.Get(prefix + ".source_host")
+			sourceService := d.Get(prefix + ".source_service")
+			console.Source = &libvirtxml.DomainChardevSource{
+				TCP: &libvirtxml.DomainChardevSourceTCP{
+					Mode:    "bind",
+					Host:    sourceHost.(string),
+					Service: sourceService.(string),
+				},
+			}
+			console.Protocol = &libvirtxml.DomainChardevProtocol{
+				Type: "telnet",
+			}
+		case "pty":
+			fallthrough
+		default:
+			if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
+				console.Source = &libvirtxml.DomainChardevSource{
+					Dev: &libvirtxml.DomainChardevSourceDev{
+						Path: sourcePath.(string),
+					},
+				}
+			}
 		}
 		domainDef.Devices.Consoles = append(domainDef.Devices.Consoles, console)
 	}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -277,6 +277,18 @@ func resourceLibvirtDomain() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"source_host": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "127.0.0.1",
+						},
+						"source_service": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "0",
+						},
 						"target_port": {
 							Type:     schema.TypeString,
 							Required: true,

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -833,6 +833,13 @@ func TestAccLibvirtDomain_Consoles(t *testing.T) {
 			target_type = "virtio"
 			source_path = "/dev/pts/2"
 		}
+		console {
+			type        = "tcp"
+			target_port = "0"
+			target_type = "virtio"
+			source_host = "127.0.1.1"
+			source_service = "cisco-sccp"
+		}
 	}`, randomDomainName, randomDomainName)
 
 	resource.Test(t, resource.TestCase{
@@ -858,6 +865,16 @@ func TestAccLibvirtDomain_Consoles(t *testing.T) {
 						"libvirt_domain."+randomDomainName, "console.1.target_type", "virtio"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "console.1.source_path", "/dev/pts/2"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.type", "tcp"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.target_port", "0"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.target_type", "virtio"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.source_host", "127.0.1.1"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.source_service", "cisco-sccp"),
 				),
 			},
 		},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -463,14 +463,25 @@ resource "libvirt_domain" "my_machine" {
 }
 ```
 
-~> **Note well:**
-  <ul>
-    <li>You can repeat the `console` block to create more than one console, in the
-        same way that you can repeat `disk` blocks (see [above](#handling-disks)).</li>
-    <li>The `target_type` is optional for the first console and defaults to `serial`.</li>
-    <li>All subsequent `console` blocks must specify a `target_type` of `virtio`.</li>
-    <li>The `source_path` is optional for all consoles.</li>
-  </ul>
+Attributes:
+
+* `type` - Console device type. Valid values are "pty" and "tcp".
+* `target_port` - Target port
+* `target_type` - (Optional) for the first console and defaults to `serial`.
+  Subsequent `console` blocks must have a different type - usually `virtio`.
+
+Additional attributes when type is "pty":
+
+* `source_path` - (Optional) Source path
+
+Additional attributes when type is "tcp":
+
+* `source_host` - (Optional) IP address to listen on. Defaults to 127.0.0.1.
+* `source_service` - (Optional) Port number or a service name. Defaults to a
+  random port.
+
+Note that you can repeat the `console` block to create more than one console.
+This works the same way as with the `disk` blocks (see [above](#handling-disks)).
 
 See [libvirt Domain XML Console element](https://libvirt.org/formatdomain.html#elementsConsole)
 for more information.


### PR DESCRIPTION
Add a new console connection type - telnet over tcp. This feature is
useful when LAN access to the domain is required but the guest OS is
not provisioned with networking.

Treat all other console types as they were pty based. This is needed
to avoid regression with unknown types since no value bounds check
was in place.

As the telnet default port is a system port, use cisco-sccp service
in the tests. This service name is IANA assigned, is not likely to
be seen on a Linux and resolves on a wide set of distros.

Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
