### PR TITLE
Fix unsupported configuration "'unsupported configuration: disk type 'virtio' of 'vda' does not support ejectable media')"

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -500,7 +500,16 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 
 			if strings.HasSuffix(url.Path, ".iso") {
 				disk.Device = "cdrom"
+				disk.Target = &libvirtxml.DomainDiskTarget{
+					Dev: fmt.Sprintf("hd%s", diskLetterForIndex(numOfISOs)),
+					Bus: "ide",
+				}
+				disk.Driver = &libvirtxml.DomainDiskDriver{
+					Name: "qemu",
+				}
+				numOfISOs++
 			}
+
 			if !strings.HasSuffix(url.Path, ".qcow2") {
 				disk.Driver.Type = "raw"
 			}
@@ -524,6 +533,10 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 				}
 
 				numOfISOs++
+			}
+
+			if !strings.HasSuffix(file.(string), ".qcow2") {
+				disk.Driver.Type = "raw"
 			}
 		}
 


### PR DESCRIPTION
We handle the code for disks built from `file=` separately than `url=`, which resulted in an inconsistency in setting the bus to `ide` in one case but not the other, which does not work, as `virtio` is not supported for ejectable media, which makes acceptance tests fail:

```
Error defining libvirt domain: virError(Code=67, Domain=10,
Message='unsupported configuration: disk type 'virtio' of 'vda' does not
support ejectable media')
```

This fixes it by setting `bus=ide` to disks built from ISO files specified by `url=`.

There is some opportunity for a refactoring here. Like handling the target in a similar code path for both, but my attempt resulted in a rabbit hole, so I am fixing it in a boring way for now.
