### PR TITLE
[Feature] Domain disks configuration for Ceph network disks

### DIFF
--- a/examples/ceph/ceph-ubuntu-example.tf
+++ b/examples/ceph/ceph-ubuntu-example.tf
@@ -1,0 +1,102 @@
+# instance the provider
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+locals {
+  ceph_user = "libvirt"
+  ceph_uuid = "a453e843-abdd-4f56-b27f-a3eac672c8b4"
+  ceph_pool = "rbd"
+
+  ceph_mons = [
+    "rbd://10.0.0.1:6789",
+    "rbd://10.0.0.2:6789",
+    "rbd://10.0.0.3:6789",
+  ]
+
+  ceph_config = {
+    user = "${local.ceph_user}"
+    uuid = "${local.ceph_uuid}"
+    pool = "${local.ceph_pool}"
+    mons = "${local.ceph_mons}"
+  }
+}
+
+# Same pool as in the ubuntu example. But it won't be used for the actual vm disk
+resource "libvirt_pool" "ubuntu" {
+  name = "ubuntu"
+  type = "dir"
+  path = "/tmp/terraform-provider-libvirt-pool-ubuntu"
+}
+
+# We use a volume that already exists on the ceph cluster as a base for this vm
+resource "libvirt_volume" "ubuntu-server" {
+  name             = "ubuntu-server"
+  pool             = "rbd_image"
+  base_volume_name = "ubuntu-16.04-server-cloudimg"
+  format           = "raw"
+
+  ## To actually work with a base image from ceph we need the clone option
+  #clone            = true
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/cloud_init.cfg")}"
+}
+
+data "template_file" "network_config" {
+  template = "${file("${path.module}/network_config.cfg")}"
+}
+
+# for more info about paramater check this out
+# https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
+# Use CloudInit to add our ssh-key to the instance
+# you can add also meta_data field
+resource "libvirt_cloudinit_disk" "commoninit" {
+  name           = "commoninit.iso"
+  user_data      = "${data.template_file.user_data.rendered}"
+  network_config = "${data.template_file.network_config.rendered}"
+  pool           = "${libvirt_pool.ubuntu.name}"
+}
+
+# Create the machine
+resource "libvirt_domain" "domain-ubuntu" {
+  name   = "ubuntu-terraform"
+  memory = "512"
+  vcpu   = 1
+
+  cloudinit = "${libvirt_cloudinit_disk.commoninit.id}"
+
+  network_interface {
+    network_name = "default"
+  }
+
+  # IMPORTANT: this is a known bug on cloud images, since they expect a console
+  # we need to pass it
+  # https://bugs.launchpad.net/cloud-images/+bug/1573095
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  console {
+    type        = "tcp"
+    target_type = "virtio"
+    target_port = "1"
+  }
+
+  disk {
+    volume_id = "${libvirt_volume.ubuntu-server.id}"
+    ceph      = "${local.ceph_config}"
+  }
+
+  graphics {
+    type        = "spice"
+    listen_type = "address"
+    autoport    = true
+  }
+}
+
+# IPs: use wait_for_lease true or after creation use terraform refresh and terraform show for the ips of domain
+

--- a/examples/ceph/cloud_init.cfg
+++ b/examples/ceph/cloud_init.cfg
@@ -1,0 +1,19 @@
+#cloud-config
+# vim: syntax=yaml
+#
+# ***********************
+# 	---- for more examples look at: ------
+# ---> https://cloudinit.readthedocs.io/en/latest/topics/examples.html
+# ******************************
+#
+# This is the configuration syntax that the write_files module
+# will know how to understand. encoding can be given b64 or gzip or (gz+b64).
+# The content will be decoded accordingly and then written to the path that is
+# provided.
+#
+# Note: Content strings here are truncated for example purposes.
+ssh_pwauth: True
+chpasswd:
+  list: |
+     root:terraform-libvirt-linux
+  expire: False

--- a/examples/ceph/network_config.cfg
+++ b/examples/ceph/network_config.cfg
@@ -1,0 +1,7 @@
+network:
+  version: 2
+  config:
+  - type: physical
+    name: ens3
+    subnets:
+      - type: dhcp

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -159,6 +159,34 @@ func resourceLibvirtDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"ceph": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"user": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:             schema.TypeString,
+										DiffSuppressFunc: suppress.CaseDifference,
+										Required:         true,
+									},
+									"pool": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"mons": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Reason
As mentioned in #585 support for some of the common network drives would be useful in the provider. Also as mentioned in the issue it would be somewhat simpler to separate different implementations by just simply providing them when requested/implemented. I went ahead and got the Ceph version here.

## Changes
When provided with a Ceph configuration in the `libvirt_domain.disks` resource the provider will assume that the linked volume is provided by a network storage. If the Ceph config is not provided no further action will be taken.
If the config does exist the required set of XML domain configurations will be added to the VM.

## Breaking Changes
None I can think of but to use the clone functionality e.g. for OS base images, as given in the example, the PR #591 needs to be merged first. Normal empty disks work just fine without.


(Closes: GH-585)