### PR TITLE
Use only randomChars in testAcc helpers

### DIFF
--- a/libvirt/resource_libvirt_cloud_init_test.go
+++ b/libvirt/resource_libvirt_cloud_init_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomResourceName := acctest.RandString(10)
+	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	// this structs are contents values we expect.
 	expectedContents := Expected{UserData: "#cloud-config", NetworkConfig: "network:", MetaData: "instance-id: bamboo"}
 	expectedContents2 := Expected{UserData: "#cloud-config2", NetworkConfig: "network2:", MetaData: "instance-id: bamboo2"}
 	expectedContentsEmpty := Expected{UserData: "#cloud-config2", NetworkConfig: "", MetaData: ""}
-	randomIsoName := acctest.RandString(10) + ".iso"
+	randomIsoName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha) + ".iso"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -97,7 +97,7 @@ func TestAccLibvirtCloudInit_CreateCloudInitDiskAndUpdate(t *testing.T) {
 // This test should fail without a proper "Exists" implementation
 func TestAccLibvirtCloudInit_ManuallyDestroyed(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomResourceName := acctest.RandString(10)
+	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	testAccCheckLibvirtCloudInitConfigBasic := fmt.Sprintf(`
     	resource "libvirt_cloudinit_disk" "%s" {

--- a/libvirt/resource_libvirt_coreos_ignition_test.go
+++ b/libvirt/resource_libvirt_coreos_ignition_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccLibvirtIgnition_Basic(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomServiceName := acctest.RandString(10) + ".service"
+	randomServiceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha) + ".service"
 	randomIgnitionName := acctest.RandString(9)
 	var config = fmt.Sprintf(`
 	data "ignition_systemd_unit" "acceptance-test-systemd" {

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestAccLibvirtDomain_Basic(t *testing.T) {
 	var domain libvirt.Domain
-	randomResourceName := acctest.RandString(10)
-	randomDomainName := acctest.RandString(10)
+	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -46,8 +46,8 @@ func TestAccLibvirtDomain_Basic(t *testing.T) {
 
 func TestAccLibvirtDomain_Detailed(t *testing.T) {
 	var domain libvirt.Domain
-	randomResourceName := acctest.RandString(10)
-	randomDomainName := acctest.RandString(10)
+	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -77,8 +77,8 @@ func TestAccLibvirtDomain_Detailed(t *testing.T) {
 func TestAccLibvirtDomain_Volume(t *testing.T) {
 	var domain libvirt.Domain
 	var volume libvirt.StorageVol
-	randomVolumeName := acctest.RandString(10)
-	randomDomainName := acctest.RandString(10)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var configVolAttached = fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
 		name = "%s"
@@ -122,9 +122,9 @@ func TestAccLibvirtDomain_Volume(t *testing.T) {
 func TestAccLibvirtDomain_VolumeTwoDisks(t *testing.T) {
 	var domain libvirt.Domain
 	var volume libvirt.StorageVol
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	randomVolumeName2 := acctest.RandString(9)
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var configVolAttached = fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
@@ -181,9 +181,9 @@ func TestAccLibvirtDomain_VolumeDriver(t *testing.T) {
 	var domain libvirt.Domain
 	var volumeRaw libvirt.StorageVol
 	var volumeQCOW2 libvirt.StorageVol
-	randomVolumeQCOW2 := acctest.RandString(10)
+	randomVolumeQCOW2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	randomVolumeRaw := acctest.RandString(9)
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
@@ -235,8 +235,8 @@ func TestAccLibvirtDomain_VolumeDriver(t *testing.T) {
 
 func TestAccLibvirtDomain_ScsiDisk(t *testing.T) {
 	var domain libvirt.Domain
-	randomVolumeName := acctest.RandString(10)
-	randomDomainName := acctest.RandString(10)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var configScsi = fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
 		name = "%s"
@@ -270,7 +270,7 @@ func TestAccLibvirtDomain_ScsiDisk(t *testing.T) {
 
 func TestAccLibvirtDomain_URLDisk(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	fws := fileWebServer{}
 	if err := fws.Start(); err != nil {
 		t.Fatal(err)
@@ -319,7 +319,7 @@ func TestAccLibvirtDomain_URLDisk(t *testing.T) {
 
 func TestAccLibvirtDomain_MultiISODisks(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	isoPath, err := filepath.Abs("testdata/tcl.iso")
 	if err != nil {
@@ -391,7 +391,7 @@ func TestAccLibvirtDomain_KernelInitrdCmdline(t *testing.T) {
 	var domain libvirt.Domain
 	var kernel libvirt.StorageVol
 	var initrd libvirt.StorageVol
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_volume" "kernel" {
@@ -442,8 +442,8 @@ func TestAccLibvirtDomain_KernelInitrdCmdline(t *testing.T) {
 
 func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	currentDir, err := os.Getwd()
 	if err != nil {
@@ -493,8 +493,8 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 func TestAccLibvirtDomain_CheckDHCPEntries(t *testing.T) {
 	var domain libvirt.Domain
 	var network libvirt.Network
-	randomDomainName := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var configWithDomain = fmt.Sprintf(`
 	    resource "libvirt_network" "%s" {
@@ -555,8 +555,8 @@ func TestAccLibvirtDomain_CheckDHCPEntries(t *testing.T) {
 func TestAccLibvirtDomain_Graphics(t *testing.T) {
 	var domain libvirt.Domain
 
-	randomDomainName := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var config = fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
 		name = "%s"
@@ -632,8 +632,8 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 func TestAccLibvirtDomain_IgnitionObject(t *testing.T) {
 	var domain libvirt.Domain
 	var volume libvirt.StorageVol
-	randomDomainName := acctest.RandString(10)
-	randomIgnitionName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomIgnitionName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var config = fmt.Sprintf(`
 	data "ignition_systemd_unit" "acceptance-test-systemd" {
 		name    = "example.service"
@@ -676,7 +676,7 @@ func TestAccLibvirtDomain_IgnitionObject(t *testing.T) {
 
 func TestAccLibvirtDomain_Cpu(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
@@ -705,7 +705,7 @@ func TestAccLibvirtDomain_Cpu(t *testing.T) {
 
 func TestAccLibvirtDomain_Video(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
@@ -734,7 +734,7 @@ func TestAccLibvirtDomain_Video(t *testing.T) {
 
 func TestAccLibvirtDomain_Autostart(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var autostartTrue = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
 		name      = "%s"
@@ -772,7 +772,7 @@ func TestAccLibvirtDomain_Autostart(t *testing.T) {
 
 func TestAccLibvirtDomain_Filesystems(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
@@ -818,7 +818,7 @@ func TestAccLibvirtDomain_Filesystems(t *testing.T) {
 
 func TestAccLibvirtDomain_Consoles(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
 		name = "%s"
@@ -1115,7 +1115,7 @@ func TestAccLibvirtDomainFirmware(t *testing.T) {
 
 func subtestAccLibvirtDomainFirmwareNoTemplate(t *testing.T, NVRAMPath string, firmware string) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
 		name     = "terraform-test-firmware-no-template"
@@ -1151,7 +1151,7 @@ func subtestAccLibvirtDomainFirmwareTemplate(t *testing.T, NVRAMPath string, fir
 	if err != nil {
 		t.Fatal(err)
 	}
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var domain libvirt.Domain
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
@@ -1188,7 +1188,7 @@ func subtestAccLibvirtDomainFirmwareTemplate(t *testing.T, NVRAMPath string, fir
 
 func TestAccLibvirtDomain_MachineType(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	// Using machine type of pc as this is earliest QEMU target
 	// and so most likely to be available
 	var config = fmt.Sprintf(`
@@ -1214,7 +1214,7 @@ func TestAccLibvirtDomain_MachineType(t *testing.T) {
 
 func TestAccLibvirtDomain_ArchType(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	// Using i686 as architecture in case anyone running tests on an i686 only host
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
@@ -1275,8 +1275,8 @@ func testAccCheckLibvirtNetworkExists(name string, network *libvirt.Network) res
 func TestAccLibvirtDomain_ShutoffDomain(t *testing.T) {
 	var domain libvirt.Domain
 	var volume libvirt.StorageVol
-	randomDomainName := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1333,7 +1333,7 @@ func TestAccLibvirtDomain_ShutoffMultiDomainsRunning(t *testing.T) {
 }
 
 func TestAccLibvirtDomain_CaseInsensitiveAttrs_MAC(t *testing.T) {
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var config = fmt.Sprintf(`
 	resource "libvirt_domain" "%s" {
 		name      = "%s"
@@ -1401,7 +1401,7 @@ func testAccCheckLibvirtDomainStateEqual(name string, domain *libvirt.Domain, ex
 
 func TestAccLibvirtDomain_Import(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1435,8 +1435,8 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 
 func TestAccLibvirtDomain_XSLT_UnsupportedAttribute(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_network" "%s" {
@@ -1499,8 +1499,8 @@ EOF
 // schema attributes
 func TestAccLibvirtDomain_XSLT_SupportedAttribute(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_network" "%s" {
@@ -1557,8 +1557,8 @@ EOF
 // as the supress diff function should take care of seeing they are equivalent
 func TestAccLibvirtDomain_XSLT_Whitespace(t *testing.T) {
 	var domain libvirt.Domain
-	randomDomainName := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	var config = fmt.Sprintf(`
 	resource "libvirt_network" "%s" {

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestAccLibvirtNetwork_Addresses(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	randomNetworkResourceFull := "libvirt_network." + randomNetworkResource
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -39,8 +39,8 @@ func TestAccLibvirtNetwork_Addresses(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_LocalOnly(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -66,8 +66,8 @@ func TestAccLibvirtNetwork_LocalOnly(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DNSEnable(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -93,8 +93,8 @@ func TestAccLibvirtNetwork_DNSEnable(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DNSDisable(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -120,8 +120,8 @@ func TestAccLibvirtNetwork_DNSDisable(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DNSForwarders(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -173,8 +173,8 @@ func TestAccLibvirtNetwork_DNSForwarders(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DNSHosts(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -303,8 +303,8 @@ func TestAccLibvirtNetwork_DNSHosts(t *testing.T) {
 
 func TestAccLibvirtNetwork_Import(t *testing.T) {
 	var network libvirt.Network
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resourceName := "libvirt_network." + randomNetworkResource
 
 	resource.Test(t, resource.TestCase{
@@ -333,8 +333,8 @@ func TestAccLibvirtNetwork_Import(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -361,8 +361,8 @@ func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_DhcpDisabled(t *testing.T) {
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -389,8 +389,8 @@ func TestAccLibvirtNetwork_DhcpDisabled(t *testing.T) {
 }
 
 func TestAccLibvirtNetwork_BridgedMode(t *testing.T) {
-	randomNetworkName := acctest.RandString(10)
-	randomBridgeName := acctest.RandString(10)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomBridgeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -446,7 +446,7 @@ func TestAccLibvirtNetwork_StaticRoutes(t *testing.T) {
 		}
 	}
 
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	config := fmt.Sprintf(`
 					resource "libvirt_network" "%s" {
 					name      = "%s"
@@ -490,8 +490,8 @@ func TestAccLibvirtNetwork_StaticRoutes(t *testing.T) {
 
 func TestAccLibvirtNetwork_Autostart(t *testing.T) {
 	var network libvirt.Network
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -531,8 +531,8 @@ func TestAccLibvirtNetwork_Autostart(t *testing.T) {
 
 func TestAccLibvirtNetwork_MTU(t *testing.T) {
 	var network libvirt.Network
-	randomNetworkResource := acctest.RandString(10)
-	randomNetworkName := acctest.RandString(10)
+	randomNetworkResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -94,8 +94,8 @@ func testAccCheckLibvirtVolumeIsBackingStore(name string, volume *libvirt.Storag
 
 func TestAccLibvirtVolume_Basic(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -122,7 +122,7 @@ func TestAccLibvirtVolume_Basic(t *testing.T) {
 func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 	var volume libvirt.StorageVol
 	var volume2 libvirt.StorageVol
-	random := acctest.RandString(10)
+	random := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -153,7 +153,7 @@ func TestAccLibvirtVolume_BackingStoreTestByID(t *testing.T) {
 func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 	var volume libvirt.StorageVol
 	var volume2 libvirt.StorageVol
-	random := acctest.RandString(10)
+	random := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -187,8 +187,8 @@ func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 // This test should fail without a proper "Exists" implementation
 func TestAccLibvirtVolume_ManuallyDestroyed(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	testAccCheckLibvirtVolumeConfigBasic := fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
 		name = "%s"
@@ -223,9 +223,9 @@ func TestAccLibvirtVolume_ManuallyDestroyed(t *testing.T) {
 }
 
 func TestAccLibvirtVolume_UniqueName(t *testing.T) {
-	randomVolumeName := acctest.RandString(10)
-	randomVolumeResource2 := acctest.RandString(10)
-	randomVolumeResource := acctest.RandString(10)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeResource2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	config := fmt.Sprintf(`
 	resource "libvirt_volume" "%s" {
 		name = "%s"
@@ -253,8 +253,8 @@ func TestAccLibvirtVolume_UniqueName(t *testing.T) {
 
 func TestAccLibvirtVolume_DownloadFromSource(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	fws := fileWebServer{}
 	if err := fws.Start(); err != nil {
@@ -294,10 +294,10 @@ func TestAccLibvirtVolume_DownloadFromSource(t *testing.T) {
 func TestAccLibvirtVolume_DownloadFromSourceFormat(t *testing.T) {
 	var volumeRaw libvirt.StorageVol
 	var volumeQCOW2 libvirt.StorageVol
-	randomVolumeNameRaw := acctest.RandString(10)
-	randomVolumeNameQCOW := acctest.RandString(10)
-	randomVolumeResourceRaw := acctest.RandString(10)
-	randomVolumeResourceQCOW := acctest.RandString(10)
+	randomVolumeNameRaw := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeNameQCOW := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeResourceRaw := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeResourceQCOW := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	qcow2Path, err := filepath.Abs("testdata/test.qcow2")
 	if err != nil {
 		t.Fatal(err)
@@ -343,8 +343,8 @@ func TestAccLibvirtVolume_DownloadFromSourceFormat(t *testing.T) {
 
 func TestAccLibvirtVolume_Format(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -374,8 +374,8 @@ func TestAccLibvirtVolume_Format(t *testing.T) {
 
 func TestAccLibvirtVolume_Import(t *testing.T) {
 	var volume libvirt.StorageVol
-	randomVolumeResource := acctest.RandString(10)
-	randomVolumeName := acctest.RandString(10)
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,


### PR DESCRIPTION
- breaking change from Terraform v12: it doesn't allow other chars. Numbers and non letter will
   cause failures
