### PR TITLE
Updating build instructions to adhere to the terraform provider standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ Follow the instructions for your distribution:
 
 ## Building from source
 
-Before building, you will need the following
+### Requirements
 
-* libvirt 1.2.14 or newer development headers
-* latest [golang](https://golang.org/dl/) version
-* `cgo` is required by the [libvirt-go](https://github.com/libvirt/libvirt-go) package. `export CGO_ENABLED="1"`
+-	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
+-	[Go](https://golang.org/doc/install) (to build the provider plugin)
+-   [libvirt](https://libvirt.org/downloads.html) 1.2.14 or newer development headers
+-   `cgo` is required by the [libvirt-go](https://github.com/libvirt/libvirt-go) package. `export CGO_ENABLED="1"`
+
 
 This project uses [go modules](https://github.com/golang/go/wiki/Modules) to vendor all its
 dependencies.
@@ -74,8 +76,18 @@ takes advantage of features available only inside of the latest stable release.
 
 You need also need libvirt-dev(el) package installed.
 
+###Building The Provider
+
+Clone repository to: `$GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt`
+
 ```console
-go get github.com/dmacvicar/terraform-provider-libvirt
+mkdir -p $GOPATH/src/github.com/dmacvicar; cd $GOPATH/src/github.com/dmacvicar
+git clone git@github.com:dmacvicar/terraform-provider-libvirt
+```
+
+Enter the provider directory and build the provider
+
+```console
 cd $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Clone repository to: `$GOPATH/src/github.com/dmacvicar/terraform-provider-libvir
 
 ```console
 mkdir -p $GOPATH/src/github.com/dmacvicar; cd $GOPATH/src/github.com/dmacvicar
-git clone git@github.com:dmacvicar/terraform-provider-libvirt
+git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
 ```
 
 Enter the provider directory and build the provider

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Follow the instructions for your distribution:
 
 ### Requirements
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
+-	[Terraform](https://www.terraform.io/downloads.html)
 -	[Go](https://golang.org/doc/install) (to build the provider plugin)
--   [libvirt](https://libvirt.org/downloads.html) 1.2.14 or newer development headers
--   `cgo` is required by the [libvirt-go](https://github.com/libvirt/libvirt-go) package. `export CGO_ENABLED="1"`
+-	[libvirt](https://libvirt.org/downloads.html) 1.2.14 or newer development headers
+-	`cgo` is required by the [libvirt-go](https://github.com/libvirt/libvirt-go) package. `export CGO_ENABLED="1"`
 
 
 This project uses [go modules](https://github.com/golang/go/wiki/Modules) to vendor all its
@@ -76,7 +76,7 @@ takes advantage of features available only inside of the latest stable release.
 
 You need also need libvirt-dev(el) package installed.
 
-###Building The Provider
+### Building The Provider
 
 Clone repository to: `$GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt`
 


### PR DESCRIPTION
Fixes #620 

I updated the README to adhere to the "standards" set by the official Terraform provider READMEs. Theses changes will add more clarity when a user wants to build a specific version. Additionally, these build instructions are how I will be completing the Docker examples.

A couple of questions for @MalloZup, is the `cgo` requirement still a thing? I was able to build the plugin without setting `export CGO_ENABLED="1"`. If so, I think we should remove it from the `Building from source` section. 

