### PR TITLE
feat(domain): add fw_cfg_name option

### DIFF
--- a/examples/v0.12/flatcar-linux/README.md
+++ b/examples/v0.12/flatcar-linux/README.md
@@ -1,0 +1,55 @@
+## Flatcar Linux simple cluster setup
+
+### Requirements
+
+This setup works with the following config:
+```shell
+$ libvirtd --version
+libvirtd (libvirt) 5.5.0
+$ terraform version
+Terraform v0.12.6
+```
+
+### Flatcar Linux
+
+Ths example is strongly inspired by the CoreOS [example](https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.12/coreos).
+
+QEMU-agent is not used, network is configured with static IP to keep things simple.
+
+```shell
+$ virsh net-dumpxml --network cluster-net
+...
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.100' end='192.168.122.254'/>
+      <host mac='52:54:00:00:00:a1' name='node-01' ip='192.168.122.101'/>
+      <host mac='52:54:00:00:00:a2' name='node-02' ip='192.168.122.102'/>
+      <host mac='52:54:00:00:00:a3' name='node-03' ip='192.168.122.103'/>
+    </dhcp>
+  </ip>
+...
+```
+
+Do not forget to download Flatcar Linux image and to add it the pool of your [choice](https://docs.flatcar-linux.org/os/booting-with-libvirt/#choosing-a-channel).
+
+You can specify the number of hosts by updating: 
+```hcl
+variable "hosts" {
+  default = 2
+}
+```
+
+(:warning: you will need to update `units/etcd-member.conf` to add or remove or node to the initial cluster :warning:)
+
+Add you SSH pub key or provide a hashed password.
+
+Finally, `fw_cfg_name` is the "path" where ignition file will be mounted [doc](https://docs.flatcar-linux.org/os/booting-with-libvirt/#creating-the-domain-xml).
+
+```hcl
+resource "libvirt_domain" "node" {
+  ...
+  fw_cfg_name = "opt/org.flatcar-linux/config"
+  ...
+}
+```
+

--- a/examples/v0.12/flatcar-linux/ignition.tf
+++ b/examples/v0.12/flatcar-linux/ignition.tf
@@ -1,0 +1,68 @@
+data "ignition_config" "ignition" {
+  users = [
+    data.ignition_user.core.id,
+  ]
+
+  files = [
+    element(data.ignition_file.hostname.*.id, count.index)
+  ]
+
+  networkd = [
+    "${data.ignition_networkd_unit.network-dhcp.id}",
+  ]
+
+  systemd = [
+    "${data.ignition_systemd_unit.etcd-member[count.index].id}",
+  ]
+
+  count = var.hosts
+}
+
+data "ignition_file" "hostname" {
+  filesystem = "root"
+  path       = "/etc/hostname"
+  mode       = 420
+
+  content {
+    content = format(var.hostname_format, count.index + 1)
+  }
+
+  count = var.hosts
+}
+
+data "ignition_user" "core" {
+  name = "core"
+
+  ssh_authorized_keys = ["ssh-rsa <your-ssh-pub-key>"]
+}
+
+data "ignition_networkd_unit" "network-dhcp" {
+  name    = "00-wired.network"
+  content = "${file("${path.module}/units/00-wired.network")}"
+}
+
+data "ignition_systemd_unit" "etcd-member" {
+  name    = "etcd-member.service"
+  enabled = true
+  dropin {
+    content = "${data.template_file.etcd-member[count.index].rendered}"
+    name    = "20-etcd-member.conf"
+  }
+  count = var.hosts
+}
+
+resource "random_string" "token" {
+  length  = 16
+  special = false
+}
+
+data "template_file" "etcd-member" {
+  template = "${file("${path.module}/units/20-etcd-member.conf")}"
+  count    = var.hosts
+  vars = {
+    node_name     = format(var.hostname_format, count.index + 1)
+    private_ip    = format("192.168.122.1%02d", count.index + 1)
+    cluster_token = random_string.token.result
+  }
+}
+

--- a/examples/v0.12/flatcar-linux/main.tf
+++ b/examples/v0.12/flatcar-linux/main.tf
@@ -1,0 +1,48 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+variable "hosts" {
+  default = 2
+}
+
+variable "hostname_format" {
+  type    = string
+  default = "node-%02d"
+}
+
+resource "libvirt_volume" "flatcar-disk" {
+  name             = "flatcar-${format(var.hostname_format, count.index + 1)}.qcow2"
+  count            = var.hosts
+  base_volume_name = "flatcar_production_qemu_image.img"
+  pool             = "container-linux"
+  format           = "qcow2"
+}
+
+resource "libvirt_ignition" "ignition" {
+  name    = "${format(var.hostname_format, count.index + 1)}-ignition"
+  pool    = "container-linux"
+  count   = var.hosts
+  content = element(data.ignition_config.ignition.*.rendered, count.index)
+}
+
+resource "libvirt_domain" "node" {
+  count  = var.hosts
+  name   = format(var.hostname_format, count.index + 1)
+  vcpu   = 1
+  memory = 2048
+
+  disk {
+    volume_id = element(libvirt_volume.flatcar-disk.*.id, count.index)
+  }
+
+  network_interface {
+    network_name   = "default"
+    mac            = "52:54:00:00:00:a${count.index + 1}"
+    wait_for_lease = true
+  }
+
+  coreos_ignition = element(libvirt_ignition.ignition.*.id, count.index)
+  fw_cfg_name = "opt/org.flatcar-linux/config"
+}
+

--- a/examples/v0.12/flatcar-linux/units/00-wired.network
+++ b/examples/v0.12/flatcar-linux/units/00-wired.network
@@ -1,0 +1,5 @@
+[Math]
+Name=eth0
+
+[Network]
+DHCP=ipv4

--- a/examples/v0.12/flatcar-linux/units/20-etcd-member.conf
+++ b/examples/v0.12/flatcar-linux/units/20-etcd-member.conf
@@ -1,0 +1,11 @@
+[Service]
+Environment="ETCD_IMAGE_TAG=v3.2.0"
+Environment="ETCD_DATA_DIR=/var/lib/etcd"
+Environment="ETCD_OPTS=--name ${node_name} \
+  --listen-client-urls http://0.0.0.0:2379 \
+  --advertise-client-urls http://${private_ip}:2379 \
+  --listen-peer-urls http://0.0.0.0:2380 \
+  --initial-advertise-peer-urls http://${private_ip}:2380 \
+  --initial-cluster node-01=http://192.168.122.101:2380,node-02=http://192.168.122.102:2380 \
+  --initial-cluster-token ${cluster_token} \
+  --initial-cluster-state new"

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -236,16 +236,20 @@ func setCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) err
 		if err != nil {
 			return err
 		}
+		// `fw_cfg_name` stands for firmware config is defined by a key and a value
+		// credits for this cryptic name: https://github.com/qemu/qemu/commit/81b2b81062612ebeac4cd5333a3b15c7d79a5a3d
+		if fwCfg, ok := d.GetOk("fw_cfg_name"); ok {
 
-		domainDef.QEMUCommandline = &libvirtxml.DomainQEMUCommandline{
-			Args: []libvirtxml.DomainQEMUCommandlineArg{
-				{
-					Value: "-fw_cfg",
+			domainDef.QEMUCommandline = &libvirtxml.DomainQEMUCommandline{
+				Args: []libvirtxml.DomainQEMUCommandlineArg{
+					{
+						Value: "-fw_cfg",
+					},
+					{
+						Value: fmt.Sprintf("name=%s,file=%s", fwCfg, ignitionKey),
+					},
 				},
-				{
-					Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignitionKey),
-				},
-			},
+			}
 		}
 	}
 

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -105,6 +105,12 @@ func resourceLibvirtDomain() *schema.Resource {
 				ForceNew: true,
 				Default:  "",
 			},
+			"fw_cfg_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "opt/com.coreos/config",
+			},
 			"filesystem": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `coreos_ignition` - (Optional) The
   [libvirt_ignition](/docs/providers/libvirt/r/coreos_ignition.html) resource
   that is to be used by the CoreOS domain.
+* `fw_cfg_name` - (Optional) The name of the firmware config path where ignition file is stored: default is `opt/com.coreos/config`. If you are using [Flatcar Linux](https://docs.flatcar-linux.org/os/booting-with-libvirt/#creating-the-domain-xml), the value is `opt/org.flatcar-linux/config`.
 * `arch` - (Optional) The architecture for the VM (probably x86_64 or i686),
   you normally won't need to set this unless you are building a special VM
 * `machine` - (Optional) The machine type,


### PR DESCRIPTION
Hi, 

This PR implements #626 (and this is my first PR on a Terraform plugin :rocket: ). I already squashed my commits. 

Goal of this PR is to allow the user to give the firmware configuration path (`opt/something/something`) when using an ignition file.

For the unit test, I simply copied this one:
https://github.com/dmacvicar/terraform-provider-libvirt/blob/5c01d18431ea2b9df4870990be6a1736ec6f322a/libvirt/resource_libvirt_domain_test.go#L714 and I updated the `testAccCheckIgnitionXML` because `opt/com.coreos/config` was hardcoded. 

Thanks !