### PR TITLE
Add coreos ignition through guestfs on s390 platform

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -1,11 +1,16 @@
 package libvirt
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,7 +235,143 @@ func newDiskForCloudInit(virConn *libvirt.Connect, volumeKey string) (libvirtxml
 	return disk, nil
 }
 
-func setCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
+func getFirstDiskPath(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) (string, error) {
+	prefix := fmt.Sprintf("disk.%d", 0)
+
+	if volumeKey, ok := d.GetOk(prefix + ".volume_id"); ok {
+		diskVolume, err := virConn.LookupStorageVolByKey(volumeKey.(string))
+		if err != nil {
+			return "", fmt.Errorf("Error lookup storage disk volume: %s", err)
+		}
+		diskVolumeFile, err := diskVolume.GetPath()
+		if err != nil {
+			return "", fmt.Errorf("Error get path of disk volume: %s", err)
+		}
+		return diskVolumeFile, nil
+	}
+	return "", fmt.Errorf("failed to find disk 0")
+}
+
+func getStderr(stderr io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stderr)
+	return buf.String()
+}
+
+func inlineUpdateCoreOsIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) error {
+	if ignition, ok := d.GetOk("coreos_ignition"); ok {
+
+		// Get the root disk (first disk) volume location
+		rootPath, err := getFirstDiskPath(d, domainDef, virConn)
+		if err != nil {
+			return err
+		}
+
+		// Get the ingition file to be uploaded
+		ignitionKey, err := getIgnitionVolumeKeyFromTerraformID(ignition.(string))
+		if err != nil {
+			return err
+		}
+		diskVolume, err := virConn.LookupStorageVolByKey(ignitionKey)
+		if err != nil {
+			return err
+		}
+		fileToUpload, err := diskVolume.GetPath()
+		if err != nil {
+			return err
+		}
+		err = guestfishExecution(rootPath, fileToUpload)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var execCommand = exec.Command
+
+func guestfishExecution(rootPath string, fileToUpload string) error {
+	// This is the file in coreos image going to be copied from local
+	fileRemoteLocation := "/ignition/config.ign"
+
+	// eval  $(guestfish --listen -a $1)
+	cmd := execCommand("guestfish", "--listen", "-a", rootPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("Get stdout failed: %v", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("Get stderr failed: %v", err)
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("Start command failed: %v", err)
+	}
+
+	// if the command start successfully, the output will be following format
+	// GUESTFISH_PID=xxxx; export GUESTFISH_PID, so we need get the PID and set by using os.Setenv
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stdout)
+	guestfishPidLabel := strings.Split(buf.String(), ";")
+	guestfishPidValue := strings.Split(guestfishPidLabel[0], "=")
+	os.Setenv(guestfishPidValue[0], guestfishPidValue[1])
+
+	// guestfish --remote -- run
+	cmd = execCommand("guestfish", "--remote", "--", "run")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Launch failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// guestfish --remote -- exit
+	defer func() {
+		cmd := execCommand("guestfish", "--remote", "--", "exit")
+		cmd.Run()
+	}()
+
+	// guestfish --remote -- findfs-label
+	cmd = execCommand("guestfish", "--remote", "--", "findfs-label", "boot")
+	output, err := cmd.Output()
+
+	if err != nil {
+		return fmt.Errorf("Failed to find fs label: %v", err)
+	}
+
+	bootDisk := strings.TrimSpace(string(output))
+	if len(bootDisk) == 0 {
+		return fmt.Errorf("failed to get the boot filesystem")
+	}
+
+	// guestfish --remote -- mount $2 /
+	cmd = execCommand("guestfish", "--remote", "--", "mount", bootDisk, "/")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Mount failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// This is the real command that upload the file from current location (the local file system)
+	// to remote file location (the coreos file system)
+	// guestfish --remote -- upload $4 $3/$4
+	cmd = execCommand("guestfish", "--remote", "--", "upload", fileToUpload, fileRemoteLocation)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Upload failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// guestfish --remote -- umount-all
+	cmd = execCommand("guestfish", "--remote", "--", "umount-all")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Unmount failed: %v, %s", err, getStderr(stderr))
+	}
+
+	return nil
+}
+
+// Use fw_cfg device to update coresos
+func fwcfgUpdateCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 	if ignition, ok := d.GetOk("coreos_ignition"); ok {
 		ignitionKey, err := getIgnitionVolumeKeyFromTerraformID(ignition.(string))
 		if err != nil {
@@ -250,6 +391,15 @@ func setCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) err
 	}
 
 	return nil
+}
+
+func updateCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) error {
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "s390" {
+		// There is no support for fw_cfg in s390x, so instead of doing fw_cfg
+		// we have to inline update the coreos ignition file
+		return inlineUpdateCoreOsIgnition(d, domainDef, virConn)
+	}
+	return fwcfgUpdateCoreOSIgnition(d, domainDef)
 }
 
 func setVideo(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {

--- a/libvirt/guestfish_test.go
+++ b/libvirt/guestfish_test.go
@@ -1,0 +1,248 @@
+package libvirt
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type GuestfsStatus int
+
+const (
+	Stopped GuestfsStatus = iota
+	Added
+	Started
+	Mounted
+)
+
+var currentGuestfishStatus = Stopped
+
+func (s GuestfsStatus) String() string {
+	return []string{"Stopped", "Added", "Started", "Mounted"}[s]
+}
+
+/*
+var supportedCommands = [][]string{
+	{
+		"guestfish", "--listen", "-a", "*",
+	},
+	{
+		"guestfish", "--remote", "--", "run",
+	},
+	{
+		"guestfish", "--remote", "--", "findfs-label", "boot",
+	},
+	{
+		"guestfish", "--remote", "--", "mount", "*", "/",
+	},
+	{
+		"guestfish", "--remote", "--", "upload", "*.ign", "/ignition/config.ign",
+	},
+	{
+		"guestfish", "--remote", "--", "umount-all",
+	},
+	{
+		"guestfish", "--remote", "--", "exit",
+	},
+} */
+
+var supportedCommandTree = map[string]interface{}{
+	"guestfish": map[string]interface{}{
+		"--listen": map[string]interface{}{
+			"-a": map[string]interface{}{
+				".*": nil,
+			},
+		},
+		"--remote": map[string]interface{}{
+			"--": map[string]interface{}{
+				"run": nil,
+				"findfs-label": map[string]interface{}{
+					"boot": nil,
+				},
+				"mount": map[string]interface{}{
+					".*": map[string]interface{}{
+						"/": nil,
+					},
+				},
+				"upload": map[string]interface{}{
+					".*.ign": map[string]interface{}{
+						"/ignition/config.ign": nil,
+					},
+				},
+				"umount-all": nil,
+				"exit":       nil,
+			},
+		},
+	},
+}
+
+// fakeExecCommand is used to replace the real command in unit test
+func fakeExecCommand(executable string, args ...string) *exec.Cmd {
+	newArgs := []string{"-test.run=TestHelperCommand", "--", executable}
+	newArgs = append(newArgs, args...)
+
+	cmd := exec.Command(os.Args[0], newArgs...)
+	cmd.Env = []string{"USE_HELPER_COMMAND=1"}
+
+	cmdToValidate := []string{executable}
+	cmdToValidate = append(cmdToValidate, args...)
+
+	fmt.Printf("### Executing command: %s\n", strings.Join(cmd.Args, " "))
+
+	if valid := validateCommandSyntax(cmdToValidate...); !valid {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("STDERR=%s", fmt.Sprintf("invalid command: %s", strings.Join(cmdToValidate, " "))))
+		cmd.Env = append(cmd.Env, "EXIT_STATUS=1")
+	} else {
+		if valid, msg := validateCommandSemanticsAndGenerateOutput(cmdToValidate...); valid {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("STDOUT=%s", msg))
+			cmd.Env = append(cmd.Env, "EXIT_STATUS=0")
+		} else {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("STDERR=%s", msg))
+			cmd.Env = append(cmd.Env, "EXIT_STATUS=2")
+		}
+	}
+	return cmd
+}
+
+// validateCommand checks whether the command's syntax is valid or not
+func validateCommandSyntax(args ...string) bool {
+	if len(args) < 4 {
+		return false
+	}
+
+	newArgs := args
+	if newArgs[0] == "sudo" && newArgs[1] == "--preserve-env" {
+		newArgs = newArgs[2:]
+	}
+
+	cmdTree := supportedCommandTree
+	// check each argument one by one
+	for index, arg := range newArgs {
+		if v, ok := cmdTree[arg]; ok {
+			if index+1 == len(newArgs) {
+				return v == nil
+			}
+			cmdTree = v.(map[string]interface{})
+		} else {
+			matched := false
+			for k, v := range cmdTree {
+				if matched, _ = regexp.MatchString(k, arg); matched {
+					if index+1 == len(newArgs) {
+						return v == nil
+					}
+					cmdTree = v.(map[string]interface{})
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// validateCommandSemantic checks whether the command's semantics is valid or not.
+// if return true, then the retunred string is the specific output message for the command;
+// if return false, then the returned string is an error message.
+func validateCommandSemanticsAndGenerateOutput(args ...string) (bool, string) {
+	newArgs := args
+	if newArgs[0] == "sudo" && newArgs[1] == "--preserve-env" {
+		newArgs = newArgs[2:]
+	}
+
+	errMsg := fmt.Sprintf("Can't execute command '%v' when the guestfish status is %s", strings.Join(args, " "), currentGuestfishStatus)
+
+	if newArgs[1] == "--listen" {
+		if Stopped == currentGuestfishStatus {
+			currentGuestfishStatus = Added
+			return true, "GUESTFISH_PID=4513; export GUESTFISH_PID"
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "run" {
+		if Added == currentGuestfishStatus {
+			currentGuestfishStatus = Started
+			return true, ""
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "findfs-label" {
+		if Started == currentGuestfishStatus {
+			return true, "/dev/sda1"
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "mount" {
+		if Started == currentGuestfishStatus {
+			currentGuestfishStatus = Mounted
+			return true, ""
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "upload" {
+		if Mounted == currentGuestfishStatus {
+			return true, ""
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "umount-all" {
+		if Mounted == currentGuestfishStatus {
+			currentGuestfishStatus = Started
+			return true, ""
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "exit" {
+		if Stopped < currentGuestfishStatus {
+			return true, ""
+		}
+
+		return false, errMsg
+	}
+	return true, ""
+}
+
+func TestHelperCommand(t *testing.T) {
+	if os.Getenv("USE_HELPER_COMMAND") != "1" {
+		return
+	}
+
+	stdOutMsg := os.Getenv("STDOUT")
+	if len(stdOutMsg) > 0 {
+		fmt.Fprintf(os.Stdout, stdOutMsg)
+	}
+
+	stdErrMsg := os.Getenv("STDERR")
+	if len(stdErrMsg) > 0 {
+		fmt.Fprintf(os.Stderr, stdErrMsg)
+	}
+
+	exitCode, _ := strconv.Atoi(os.Getenv("EXIT_STATUS"))
+	os.Exit(exitCode)
+}
+
+func TestGuestfishExecution(t *testing.T) {
+
+	execCommand = fakeExecCommand
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	err := guestfishExecution("/root/path", "my.ign")
+
+	if err != nil {
+		t.Errorf("failed to call guestfishExecution, error: %v", err)
+	}
+}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -469,7 +469,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	setFirmware(d, &domainDef)
 	setBootDevices(d, &domainDef)
 
-	if err := setCoreOSIgnition(d, &domainDef); err != nil {
+	if err := updateCoreOSIgnition(d, &domainDef, virConn); err != nil {
 		return err
 	}
 

--- a/website/docs/r/coreos_ignition.html.markdown
+++ b/website/docs/r/coreos_ignition.html.markdown
@@ -14,6 +14,12 @@ a CoreOS Domain during first boot.
 
 ~> **Note:** to make use of Ignition files with CoreOS the host must be running QEMU v2.6 or greater.
 
+~> **Note:** On x86 platform `-fw_cfg` device is used to pass ignition to coreos, but on s390x platform
+`-fw_cfg` is not supported. As alternative, `guestfish` utility is used to inject ignition files into
+coreos image directly on s390x platform. So `guestfish` must be installed on the machine that running
+terraform libvirt provider on s390x platform. For more information, please
+refer to [coreos ignition support for s390x](https://github.com/dmacvicar/terraform-provider-libvirt/issues/624)
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Fixes: #624 

Add support for s390x on coreos ignition

now x86 platform use fw_cfg to process coreos ingition
but fw_cfg is not usable in s390 platform.

so we need use libguestfs to update the coreos image by
injecting the ignition into it.

we have some comments like following to try but that's not for coreos
https://gitlab.gnome.org/GNOME/gnome-boxes/blob/master/src/unattended-file.vala
