### PR TITLE
Added a contrib folder which contains Docker examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Be aware that this variables may be subject to change again in future versions.
     *   [kubic-terraform-kvm](https://github.com/kubic-project/kubic-terraform-kvm) Kubic Terraform script using KVM/libvirt
 
 * [Community Driven Docker Examples](contrib/)
-   Docker examples showing how to use the Libirt Provider
+   Docker examples showing how to use the Libvirt Provider
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Be aware that this variables may be subject to change again in future versions.
 
 * [kubic](https://github.com/kubic-project)
     *   [kubic-terraform-kvm](https://github.com/kubic-project/kubic-terraform-kvm) Kubic Terraform script using KVM/libvirt
+
+* [Community Driven Docker Examples](contrib/)
+   Docker examples showing how to use the Libirt Provider
+
 ## Authors
 
 * Duncan Mac-Vicar P. <dmacvicar@suse.de>

--- a/contrib/Alpine/Dockerfile_all_in_one
+++ b/contrib/Alpine/Dockerfile_all_in_one
@@ -1,0 +1,79 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
+# Provider Version
+ARG VERSION
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Building Libvirt Plugin Docker
+FROM golang:alpine AS libvirt
+
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Install Needed Packages. Libc-dev installs musl-dev
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache git make gcc pkgconfig libvirt-dev libc-dev
+
+# Pull Go lint for building
+RUN go get -u golang.org/x/lint/golint
+
+# Make directory
+RUN mkdir -p $GOPATH/src/github.com/dmacvicar/
+
+# Set Work Directory for Clone
+WORKDIR $GOPATH/src/github.com/dmacvicar/
+
+# Clone Project
+RUN git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+
+# Set Workdir for bin build
+WORKDIR $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+
+# Checkout Version and download go dependencies
+RUN git checkout $VERSION && env GO111MODULE=on go mod download
+
+# Build and move the Binary
+RUN make build && mv terraform-provider-libvirt $GOPATH/bin/
+
+# Base Image
+FROM alpine:latest
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# Libvirt is needed to run the provider. libxslt needed to use XML/XSLT. cdrkit needed to use cloud init images
+# openssh-client to talk to remote libvirt server
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache libvirt gcc libxslt cdrkit openssh-client
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/ash

--- a/contrib/Alpine/Dockerfile_build_dependent
+++ b/contrib/Alpine/Dockerfile_build_dependent
@@ -1,0 +1,47 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Grab the Terraform Libvirt Provider binary
+FROM provider-libvirt:v0.5.2-musl AS libvirt
+
+# Base Image
+FROM alpine:latest
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# Libvirt is needed to run the provider. libxslt needed to use XML/XSLT. cdrkit needed to use cloud init images
+# openssh-client to talk to remote libvirt server
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache libvirt gcc libxslt cdrkit openssh-client
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/ash

--- a/contrib/Alpine/README.md
+++ b/contrib/Alpine/README.md
@@ -6,15 +6,13 @@ container.
 of `glibc`.
 
 
-## All-in-One Container Usage
-Building Container:
-
+## All-in-One Container Build Example
 ```console
 docker build -f Dockerfile_all_in_one -t terraform:development-alpine . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
 ```
 
 
-## Build-Dependent Container Usage
+## Build-Dependent Container Build Example
 Build appropriate `Build` container, in this case it would be `Dockerfile_musl`:
 
 ```cosnole

--- a/contrib/Alpine/README.md
+++ b/contrib/Alpine/README.md
@@ -1,0 +1,28 @@
+# Alpine Container
+This container is build from the `Alpine` distribution. This container is meant to serve as a slim down minimalistic 
+container.
+
+**NOTE**: If pulling from the `build` containers, make sure to pull from the `musl` container. Alpine uses `musl` instead
+of `glibc`.
+
+
+## All-in-One Container Usage
+Building Container:
+
+```console
+docker build -f Dockerfile_all_in_one -t terraform:development-alpine . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+
+
+## Build-Dependent Container Usage
+Build appropriate `Build` container, in this case it would be `Dockerfile_musl`:
+
+```cosnole
+docker build -f Dockerfile_musl -t provider-libvirt:v0.5.2-musl . --build-arg VERSION=v0.5.2
+```
+
+Now build the main container:
+```console
+docker build -f Dockerfile_build_dependent -t terraform:development-alpine . --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+

--- a/contrib/Alpine/README.md
+++ b/contrib/Alpine/README.md
@@ -1,5 +1,5 @@
 # Alpine Container
-This container is build from the `Alpine` distribution. This container is meant to serve as a slim down minimalistic 
+This container is built from the `Alpine` distribution. This container is meant to serve as a slim down minimalistic 
 container.
 
 **NOTE**: If pulling from the `build` containers, make sure to pull from the `musl` container. Alpine uses `musl` instead

--- a/contrib/Build/Dockerfile_glibc
+++ b/contrib/Build/Dockerfile_glibc
@@ -1,0 +1,34 @@
+# Building Libvirt Plugin Docker
+FROM golang:stretch
+
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Install Needed Packages
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install \
+    -y --no-install-recommends \
+    git make pkg-config gcc libc-dev libvirt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pull Go lint for building
+RUN go get -u golang.org/x/lint/golint
+
+# Make directory
+RUN mkdir -p $GOPATH/src/github.com/dmacvicar/
+
+# Set Work Directory for Clone
+WORKDIR $GOPATH/src/github.com/dmacvicar/
+
+# Clone Project
+RUN git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+
+# Set Workdir for bin build
+WORKDIR $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+
+# Checkout Version and download go dependencies
+RUN git checkout $VERSION && env GO111MODULE=on go mod download
+
+# Build and move the Binary
+RUN make build && mv terraform-provider-libvirt $GOPATH/bin/

--- a/contrib/Build/Dockerfile_musl
+++ b/contrib/Build/Dockerfile_musl
@@ -1,0 +1,31 @@
+# Building Libvirt Plugin Docker
+FROM golang:alpine
+
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Install Needed Packages. Libc-dev installs musl-dev
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache git make gcc pkgconfig libvirt-dev libc-dev
+
+# Pull Go lint for building
+RUN go get -u golang.org/x/lint/golint
+
+# Make directory
+RUN mkdir -p $GOPATH/src/github.com/dmacvicar/
+
+# Set Work Directory for Clone
+WORKDIR $GOPATH/src/github.com/dmacvicar/
+
+# Clone Project
+RUN git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+
+# Set Workdir for bin build
+WORKDIR $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+
+# Checkout Version and download go dependencies
+RUN git checkout $VERSION && env GO111MODULE=on go mod download
+
+# Build and move the Binary
+RUN make build && mv terraform-provider-libvirt $GOPATH/bin/

--- a/contrib/Build/README.md
+++ b/contrib/Build/README.md
@@ -1,0 +1,30 @@
+# Build Containers
+These containers build the terraform libvirt provider. There are two Dockerfiles due to the fact that some linux
+systems use `musl` while others use `glibc`. These are just two different implementations of the `libc`, each having 
+their benefits. "Most" systems use `glibc` but there are a couple linux distributions like `Alpine` that use `musl`. When
+in doubt, use `glibc`.
+
+These containers will be mostly used as one of the stages in the multi-stage Dockefiles you'll find here. They also have
+the benefit of storing the binary in the container, thus you could use a `docker copy` to grab the binary and use it 
+on your local system. 
+
+## General Usage
+As stated before in the general [README](../), these containers have build args. `VERSION` controls what 
+build/version of the terraform libvirt provider you are going to compile. You can set `VERSION` to any branch or tag of
+the repo. If you set `VERSION` to `v0.5.2` it would build that specific branch/tag of the project. Another common 
+branch to set it to would be `master`. 
+
+
+To build the two containers use these commands:
+
+```console
+docker build -f Dockerfile_glibc -t provider-libvirt:v0.5.2-glibc . --build-arg VERSION=v0.5.2
+```
+
+Which would build the `glibc` version with the code of the `v0.5.2` branch.
+
+```console
+docker build -f Dockerfile_musl -t provider-libvirt:master-musl . --build-arg VERSION=master
+```
+
+Which would build the `musl` version with the code of the `master` branch.

--- a/contrib/Build/README.md
+++ b/contrib/Build/README.md
@@ -9,11 +9,7 @@ the benefit of storing the binary in the container, thus you could use a `docker
 on your local system. 
 
 ## General Usage
-As stated before in the general [README](../), these containers have build args. `VERSION` controls what 
-build/version of the terraform libvirt provider you are going to compile. You can set `VERSION` to any branch or tag of
-the repo. If you set `VERSION` to `v0.5.2` it would build that specific branch/tag of the project. Another common 
-branch to set it to would be `master`. 
-
+As stated before in the general [README](../), these containers have build arguments. 
 
 To build the two containers use these commands:
 

--- a/contrib/Debian/Dockerfile_all_in_one
+++ b/contrib/Debian/Dockerfile_all_in_one
@@ -1,0 +1,85 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
+# Provider Version
+ARG VERSION
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Building Libvirt Plugin Docker
+FROM golang:stretch as libvirt
+
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Install Needed Packages
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install \
+    -y --no-install-recommends \
+    git make pkg-config gcc libc-dev libvirt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pull Go lint for building
+RUN go get -u golang.org/x/lint/golint
+
+# Make directory
+RUN mkdir -p $GOPATH/src/github.com/dmacvicar/
+
+# Set Work Directory for Clone
+WORKDIR $GOPATH/src/github.com/dmacvicar/
+
+# Clone Project
+RUN git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+
+# Set Workdir for bin build
+WORKDIR $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+
+# Checkout Version and download go dependencies
+RUN git checkout $VERSION && env GO111MODULE=on go mod download
+
+# Build and move the Binary
+RUN make build && mv terraform-provider-libvirt $GOPATH/bin/
+
+# Base Image
+FROM ubuntu:18.04
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# libvirt0 is needed to run the provider. xsltproc needed to use XML/XSLT. mkisofs needed to use cloud init images
+# ca-certificates to avoid terraform init 509 error. openssh-client to talk to remote libvirt server
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install \
+    -y --no-install-recommends \
+    libvirt0 xsltproc mkisofs ca-certificates openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/bash

--- a/contrib/Debian/Dockerfile_build_dependent
+++ b/contrib/Debian/Dockerfile_build_dependent
@@ -1,0 +1,50 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Grab the Terraform Libvirt Provider binary
+FROM provider-libvirt:v0.5.2-debian AS libvirt
+
+# Base Image
+FROM ubuntu:18.04
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# libvirt0 is needed to run the provider. xsltproc needed to use XML/XSLT. mkisofs needed to use cloud init images
+# ca-certificates to avoid terraform init 509 error. openssh-client to talk to remote libvirt server
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install \
+    -y --no-install-recommends \
+    libvirt0 xsltproc mkisofs ca-certificates openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/bash

--- a/contrib/Debian/README.md
+++ b/contrib/Debian/README.md
@@ -1,5 +1,5 @@
 # Debian Based Container
-This container is build from a `Debian` based distribution, in this case we are using `Ubuntu`.
+This container is built from a `Debian` based distribution, in this case we are using `Ubuntu`.
 
 **NOTE**: If pulling from the `build` containers, make sure to pull from the `glibc` container.
 

--- a/contrib/Debian/README.md
+++ b/contrib/Debian/README.md
@@ -1,0 +1,28 @@
+# Debian Based Container
+This container is build from a `Debian` based distribution, in this case we are using `Ubuntu`. This container has
+all the "bloat" of a normal Ubuntu instance. Thus you will find common packages already installed like `nano`, `gcc`, 
+etc. This option would be good for people who want to test the functionality of the terraform libvirt provider.
+
+**NOTE**: If pulling from the `build` containers, make sure to pull from the `glibc` container.
+
+
+## All-in-One Container Usage
+Building Container:
+
+```console
+docker build -f Dockerfile_all_in_one -t terraform:development-ubuntu . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+
+
+## Build-Dependent Container Usage
+Build appropriate `Build` container, in this case it would be `Dockerfile_glibc`:
+
+```cosnole
+docker build -f Dockerfile_glibc -t provider-libvirt:v0.5.2-glibc . --build-arg VERSION=v0.5.2
+```
+
+Now build the main container:
+```console
+docker build -f Dockerfile_build_dependent -t terraform:development-ubuntu . --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+

--- a/contrib/Debian/README.md
+++ b/contrib/Debian/README.md
@@ -1,20 +1,16 @@
 # Debian Based Container
-This container is build from a `Debian` based distribution, in this case we are using `Ubuntu`. This container has
-all the "bloat" of a normal Ubuntu instance. Thus you will find common packages already installed like `nano`, `gcc`, 
-etc. This option would be good for people who want to test the functionality of the terraform libvirt provider.
+This container is build from a `Debian` based distribution, in this case we are using `Ubuntu`.
 
 **NOTE**: If pulling from the `build` containers, make sure to pull from the `glibc` container.
 
 
-## All-in-One Container Usage
-Building Container:
-
+## All-in-One Container Build Example
 ```console
 docker build -f Dockerfile_all_in_one -t terraform:development-ubuntu . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
 ```
 
 
-## Build-Dependent Container Usage
+## Build-Dependent Container Build Example
 Build appropriate `Build` container, in this case it would be `Dockerfile_glibc`:
 
 ```cosnole

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,6 +1,6 @@
 # Community Driven Docker Examples
 These docker containers are meant to serve as an isolated development environment. The most common use case for these 
-containers is to run your terraform environment in a isolate container talking to a `remote` libvirt system. 
+containers are to run your terraform environment in an isolate container talking to a `remote` libvirt system. 
 
 Please refer to the distro's `README.md` for specific instructions.
 
@@ -12,7 +12,7 @@ information and instructions.
 
 **Distro Containers**
 - [Alpine Containers](Alpine/)
-- [Debian Conainers](Debian/)
+- [Debian Containers](Debian/)
 - [openSUSE Containers](openSUSE/)
 
 **Build Containers**
@@ -127,7 +127,7 @@ ENTRYPOINT ["terraform"]
 With this Dockerfile built, you now need to swap the `FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform` with 
 your images name and tag.
 
-**Note**: Even if you get the terraform binary built for your respective architecture, you might need to built other
+**Note**: Even if you get the terraform binary built for your respective architecture, you might need to build other
 providers you utilize in your terraform files. As the default providers are not built for unsupported architectures.
 
 ### Tips and Tricks

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,137 @@
+# Community Driven Docker Examples
+These docker containers are meant to serve as an isolated develop/deployment environment. Each docker container has the 
+terraform libvirt provider built and placed in the custom plugins folder. The most common use case for these containers 
+is to run your terraform environment in a isolate container talking to a `remote` libvirt system. 
+
+Please refer to the distro's `README.md` for specific instructions.
+
+Additionally, you will find a `Build` folder along side the distro folders. The docker containers within the `Build`
+folder will compile the terraform libvirt provider for you. Please refer to the `Build` folder's `README.md` for more 
+information and instructions.
+
+## Table of Content
+- [Alpine Containers](Alpine/)
+- [Build Containers](Build/)
+- [Debian Conainers](Debian/)
+- [openSUSE Containers](openSUSE/)
+
+
+## General Usage
+There are two types of containers you'll find for each distro, `All-in-One` and `Build-Dependent`.
+
+### All-in-One v.s Build-Dependent Containers
+The `All-in-One` container is a single Dockerfile that you can build and run. The Dockerfile takes advantage of 
+Docker's multi-stage build functionality. It allows you to build a binary or object in a "sub container" and then 
+access the binary or object in your "main container". This Dockerfile is useful if you want to get up and running 
+quickly, but might lead to confusion down the road if plan on using multiple versions of the terraform libvirt provider.
+
+The `Build-Dependent` container relies on another Dockerfile which contains the build of the plugin. To use this 
+container you need to first build the appropriate build Dockerfile and tag it correctly. Once that is done, you are
+able to reference it inside the `Build-Dependent`'s Dockerfile. This design is useful when you are dealing with 
+multiple versions of the terraform libvirt provider such as a stable build, `0.5.2`, which works with Terraform `0.11.X` 
+and the less stable branch, `master`, which currently works with Terraform `0.12.x`.
+
+### Build Args
+There are a couple build args to be aware of when building these various containers.
+
+For the `Build` containers, you will only need to worry about the `VERSION` arg. The `VERSION` arg lets you build a specific
+branch/tag of the terraform libvirt provider.
+
+
+
+Build Examples:
+```console
+docker build -f Dockerfile_glibc -t provider-libvirt:v0.5.2-glibc . --build-arg VERSION=v0.5.2
+``` 
+
+This command would checkout the tag `v0.5.2`, thus building the terraform libvirt provider with the given code in 
+`v0.5.2`.
+
+```console
+docker build -f Dockerfile_glibc -t provider-libvirt:master-glibc . --build-arg VERSION=master
+```
+
+This command would checkout the `master` branch, thus building the latest code. 
+
+For the `distro` containers there are three build args, `TERRAFORM_VERSION`, `GO_ARCH`, and `GO_OS`.
+
+The build arg, `TERRAFORM_VERSION`, lets you select which terraform version you want to run. By default this is set to 
+`0.12.0`, but can be overwritten by setting it in a Docker `build-arg`.
+
+The `GO_ARCH` and `GO_OS` need to be passed in when building the container as they do **not** have defaults. The purpose
+of these args are to allow multiple architectures to run these docker containers, see 
+[below](#Running-on-non-supported-Terraform-Architectures) . If you are unsure of what your `GO_ARCH` and `GO_OS` 
+should be please refer to [this](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63). For most users 
+running on `amd64`, use `GO_OS=linux` and `GO_ARCH=amd64`.
+
+
+Docker Build Examples:
+```console
+docker build -f Dockerfile_build_dependent -t terraform:development-tumbleweed . --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+
+This command builds a distro container, tags it as `terraform:development-tumbleweed`, sets the `GO_OS` to linux and
+`GO_ARCH` to amd64 and sets the terraform version to `0.11.14`.
+
+```console
+docker build -f Dockerfile_build_dependent -t terraform:development-debian . --build-arg GO_OS=linux --build-arg GO_ARCH=s390x
+```
+
+This command builds a distro container, tags it as `terraform:development-debian`, sets the `GO_OS` to linux and
+`GO_ARCH` to s390x and will use the default value of `0.12.0` for terraform.
+
+### Running on non-supported Terraform Architectures 
+Terraform currently does support other architectures other then `amd64`, thus running on other architectures like 
+`s390x` can be troublesome. 
+
+Luckily, the docker containers only need a slight modification to run on `s390x`. **Note**: The `Build` containers will run
+on any architectures that support GO and should not need modification.
+
+In the distro containers you should see a line like:
+
+```dockerfile
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+``` 
+
+Currently, that is pulling in the official Terraform docker container. To get it to work on your desired architecture
+you need to build the Terraform binary yourself. You can do that by building the Dockerfile below:
+
+```dockerfile
+FROM golang:alpine
+
+ARG TERRAFORM_VERSION
+ENV TERRAFORM_VERSION=$TERRAFORM_VERSION
+
+RUN apk add --update git bash openssh
+
+ENV TF_DEV=true
+ENV TF_RELEASE=true
+
+WORKDIR $GOPATH/src/github.com/hashicorp/terraform
+RUN git clone https://github.com/hashicorp/terraform.git ./ && \
+    git checkout v${TERRAFORM_VERSION} && \
+    /bin/bash scripts/build.sh
+
+WORKDIR $GOPATH
+ENTRYPOINT ["terraform"]
+``` 
+
+With this Dockerfile built, you now need to swap the `FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform` with 
+your images tag.
+
+**Note**: Even if you get the terraform binary built for your respective architecture you might need to built other
+providers you utilize in your terraform files, as the default providers are not built for unsupported architectures.
+
+### Tips and Tricks
+- The use of Docker Volumes helps transfer Terraform config files back and forth between your local system and the docker
+container.
+
+- Most `remote` libvirt systems require SSH Key auth. To generate a new SSH Key in Dockerfile use the following code:
+    ```dockerfile
+    # Make SSH Key
+    RUN mkdir -p /root/.ssh/
+    RUN touch /root/.ssh/id_rsa
+    RUN chmod 600 /root/.ssh/id_rsa
+    RUN echo "Host *" > /root/.ssh/config && echo " StrictHostKeyChecking no" >> /root/.ssh/config
+    ```

--- a/contrib/openSUSE/Dockerfile_all_in_one
+++ b/contrib/openSUSE/Dockerfile_all_in_one
@@ -1,0 +1,78 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Provider Version
+ARG VERSION
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Building Libvirt Plugin Docker
+FROM golang:stretch as libvirt
+
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Install Needed Packages
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install \
+    -y --no-install-recommends \
+    git make pkg-config gcc libc-dev libvirt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pull Go lint for building
+RUN go get -u golang.org/x/lint/golint
+
+# Make directory
+RUN mkdir -p $GOPATH/src/github.com/dmacvicar/
+
+# Set Work Directory for Clone
+WORKDIR $GOPATH/src/github.com/dmacvicar/
+
+# Clone Project
+RUN git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+
+# Set Workdir for bin build
+WORKDIR $GOPATH/src/github.com/dmacvicar/terraform-provider-libvirt
+
+# Checkout Version and download go dependencies
+RUN git checkout $VERSION && env GO111MODULE=on go mod download
+
+# Build and move the Binary
+RUN make build && mv terraform-provider-libvirt $GOPATH/bin/
+
+# Base Image
+FROM opensuse/tumbleweed:latest
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# libvirt-client is needed to run the provider. libxslt-tools needed to use XML/XSLT. mkisofs needed to use cloud init images
+RUN zypper update \
+    && zypper dist-upgrade \
+    && zypper --non-interactive install --no-recommends libvirt-client libxslt-tools mkisofs openssh
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/bash

--- a/contrib/openSUSE/Dockerfile_all_in_one
+++ b/contrib/openSUSE/Dockerfile_all_in_one
@@ -4,6 +4,9 @@ ARG GO_OS
 # Set to arch name of your system
 ARG GO_ARCH
 
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
 # Provider Version
 ARG VERSION
 

--- a/contrib/openSUSE/Dockerfile_build_dependent
+++ b/contrib/openSUSE/Dockerfile_build_dependent
@@ -1,0 +1,46 @@
+# Set to linux or name of OS
+ARG GO_OS
+
+# Set to arch name of your system
+ARG GO_ARCH
+
+# Terraform Version
+ARG TERRAFORM_VERSION=0.12.0
+
+# Grab the Terraform binary
+FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+
+# Grab the Terraform Libvirt Provider binary
+FROM provider-libvirt:v0.5.2-debian AS libvirt
+
+# Base Image
+FROM opensuse/tumbleweed:latest
+
+ARG GO_OS
+ENV GO_OS=$GO_OS
+ARG GO_ARCH
+ENV GO_ARCH=$GO_ARCH
+
+# Set working directory
+WORKDIR /root/
+
+# Make Directory for Provider Binaries
+RUN mkdir -p /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Copy binaries from containers
+COPY --from=terraform /bin/terraform /bin/
+COPY --from=libvirt /go/bin/terraform-provider-libvirt /root/.terraform.d/plugins/${GO_OS}_${GO_ARCH}/
+
+# Install Dependencies
+# libvirt-client is needed to run the provider. libxslt-tools needed to use XML/XSLT. mkisofs needed to use cloud init images
+RUN zypper update \
+    && zypper dist-upgrade \
+    && zypper --non-interactive install --no-recommends libvirt-client libxslt-tools mkisofs openssh
+
+# Copy Terraform Files
+# COPY libvirt.tf /root/
+
+# Terraform commands
+# RUN terraform init
+
+ENTRYPOINT /bin/bash

--- a/contrib/openSUSE/README.md
+++ b/contrib/openSUSE/README.md
@@ -1,0 +1,27 @@
+# openSUSE Container
+This container is based on openSUSE's `Tubmleweed`. `Tumbleweed` was chosen over `Leap` due to its multi-arch
+support.
+
+**NOTE**: If pulling from the `build` containers, make sure to pull from the `glibc` container.
+
+
+## All-in-One Container Usage
+Building Container:
+
+```console
+docker build -f Dockerfile_all_in_one -t terraform:development-tumbleweed . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+
+
+## Build-Dependent Container Usage
+Build appropriate `Build` container, in this case it would be `Dockerfile_glibc`:
+
+```cosnole
+docker build -f Dockerfile_glibc -t provider-libvirt:v0.5.2-glibc . --build-arg VERSION=v0.5.2
+```
+
+Now build the main container:
+```console
+docker build -f Dockerfile_build_dependent -t terraform:development-tumbleweed . --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
+```
+

--- a/contrib/openSUSE/README.md
+++ b/contrib/openSUSE/README.md
@@ -5,15 +5,14 @@ support.
 **NOTE**: If pulling from the `build` containers, make sure to pull from the `glibc` container.
 
 
-## All-in-One Container Usage
-Building Container:
+## All-in-One Container Build Example
 
 ```console
 docker build -f Dockerfile_all_in_one -t terraform:development-tumbleweed . --build-arg VERSION=v0.5.2 --build-arg GO_OS=linux --build-arg GO_ARCH=amd64 --build-arg TERRAFORM_VERSION=0.11.14
 ```
 
 
-## Build-Dependent Container Usage
+## Build-Dependent Container Build Example
 Build appropriate `Build` container, in this case it would be `Dockerfile_glibc`:
 
 ```cosnole


### PR DESCRIPTION
Added a contrib folder which contains Docker examples for Alpine, Debian, openSUSE. Additionally, included a build Dockerfile for building the provider.  Provided documentation for all Dockerfiles via README.md files.

Fixes #617 


@MalloZup Sorry about the other Branch/PR.