### PR TITLE
Update network_config.cfg in examples.

### DIFF
--- a/examples/v0.11/ubuntu/network_config.cfg
+++ b/examples/v0.11/ubuntu/network_config.cfg
@@ -1,7 +1,4 @@
-network:
-  version: 2
-  config:
-  - type: physical
-    name: ens3
-    subnets:
-      - type: dhcp
+version: 2
+ethernets:
+  ens3:
+    dhcp4: true

--- a/examples/v0.12/ubuntu/network_config.cfg
+++ b/examples/v0.12/ubuntu/network_config.cfg
@@ -1,7 +1,4 @@
-network:
-  version: 2
-  config:
-  - type: physical
-    name: ens3
-    subnets:
-      - type: dhcp
+version: 2
+ethernets:
+  ens3:
+    dhcp4: true


### PR DESCRIPTION
This fixes the issue with network adapters not coming up with the ubuntu example. 

https://github.com/dmacvicar/terraform-provider-libvirt/issues/619


As noted in the Issue ticket, this may also impact Leap15 examples.




1. remove network:, as this is automatically added when loading from the network-config in the iso
2. match format in https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html#network-config-v2


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
