### PR TITLE
check if volume backing store format is present before creating #569

### DIFF
--- a/libvirt/volume_def.go
+++ b/libvirt/volume_def.go
@@ -60,11 +60,15 @@ func newDefBackingStoreFromLibvirt(baseVolume *libvirt.StorageVol) (libvirtxml.S
 	if err != nil {
 		return libvirtxml.StorageVolumeBackingStore{}, fmt.Errorf("could not get base image path: %s", err)
 	}
-	backingStoreDef := libvirtxml.StorageVolumeBackingStore{
-		Path: baseVolPath,
-		Format: &libvirtxml.StorageVolumeTargetFormat{
+	var backingStoreVolFormat *libvirtxml.StorageVolumeTargetFormat
+	if baseVolumeDef.Target.Format != nil {
+		backingStoreVolFormat = &libvirtxml.StorageVolumeTargetFormat{
 			Type: baseVolumeDef.Target.Format.Type,
-		},
+		}
+	}
+	backingStoreDef := libvirtxml.StorageVolumeBackingStore{
+		Path:   baseVolPath,
+		Format: backingStoreVolFormat,
 	}
 	return backingStoreDef, nil
 }


### PR DESCRIPTION
* cover case when backing volume xml doesn't contain format element
* ~~add test for NewDefBackingStoreFromLibvirt~~
* ~~interface StorageVol introduced to allow mocking~~
* ~~libvirt.StorageVol is mocked using github.com/golang/mock~~
* ~~NewDefBackingStoreFromLibvirt now accepts StorageVol interface on input~~

~~I used github.com/golang/mock for mocking since it seemed to me as a better option rather than writing mocking implementations of interfaces like it's done in libvirt/libvirt_domain_mock_test.go~~

Closes #569 