### PR TITLE
Don't error when a volume exist already during apply

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -106,18 +106,12 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 		return pool.Refresh(0)
 	})
 
-	// Check whether the storage volume already exists. Its name needs to be
-	// unique.
-	if _, err := pool.LookupStorageVolByName(d.Get("name").(string)); err == nil {
-		return fmt.Errorf("storage volume '%s' already exists", d.Get("name").(string))
+	volumeDef := newDefVolume()
+	if name, ok := d.GetOk("name"); ok {
+		volumeDef.Name = name.(string)
 	}
 
-	volumeDef := newDefVolume()
-	volumeDef.Name = d.Get("name").(string)
-
-	var (
-		img image
-	)
+	var img image
 
 	givenFormat, isFormatGiven := d.GetOk("format")
 	if isFormatGiven {


### PR DESCRIPTION
# What does this PR:

This PR correct a wrong behavior introduced by https://github.com/dmacvicar/terraform-provider-libvirt/commit/96f4032f04b2a625b12d188cae4315887bf9fc66

(https://github.com/dmacvicar/terraform-provider-libvirt/pull/256 )


At commit message we can read following:
``` 
The storage volume name needs to be unique. If this is not the case, the
storage volume will be overwritten which is not problematic itself.
However, `terraform destroy` will fail since it will try and delete the
same storage volume twice.
```


# further analysis:

I think the usecase provided by https://github.com/dmacvicar/terraform-provider-libvirt/pull/256 
is legitim. 

But I think the current way we are solving that USER problem with HCL is not correct.
By doing this we cause problems like as mentioned, if an user has already a volume in place with that name, we shouldn't error out, we should overwrite as libvirt does. We might solve that UX problem differently in future, but isn't worth to me to add an extra error because .

# Alternative fix:

In addition to this, I think we could just don't error out on `terraform destroy`. 

Instead of beeing an error
```
Storage volume not found: no storage vol with matching name 'vol_1'
```

This could be a warning


fix #613 

@dmacvicar cc
@zeenix  opinions welcome