### PR TITLE
Taint volume when network downlad fail

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -254,6 +254,10 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	if _, ok := d.GetOk("source"); ok {
 		err = img.Import(newCopier(client.libvirt, volume, volumeDef.Capacity.Value), volumeDef)
 		if err != nil {
+		//  don't save volume ID  in case of error. This will taint the volume after.
+		// If we don't throw away the id, we will keep instead a broken volume.
+		// see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
+		d.Set("id", "")	
 			return fmt.Errorf("Error while uploading source %s: %s", img.String(), err)
 		}
 	}


### PR DESCRIPTION
# what does this PR


fix #494 

This pr will fix the error in case the download get interrupted by network erorrs.
Time ago I have just tested it with a sigkill which was not producing a valid test, since when we kill terraform it will not handle that spec error