### PR TITLE
Create coreos ignition guestfs upload directory for s390 platform

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -351,6 +351,13 @@ func guestfishExecution(rootPath string, fileToUpload string) error {
 		return fmt.Errorf("Mount failed: %v, %s", err, getStderr(stderr))
 	}
 
+	// guestfish --remote -- mkdir-p /ignition
+	cmd = execCommand("guestfish", "--remote", "--", "mkdir-p", "/ignition")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Mkdir failed: %v, %s", err, getStderr(stderr))
+	}
+
 	// This is the real command that upload the file from current location (the local file system)
 	// to remote file location (the coreos file system)
 	// guestfish --remote -- upload $4 $3/$4

--- a/libvirt/guestfish_test.go
+++ b/libvirt/guestfish_test.go
@@ -40,6 +40,9 @@ var supportedCommands = [][]string{
 		"guestfish", "--remote", "--", "mount", "*", "/",
 	},
 	{
+		"guestfish", "--remote", "--", "mkdir-p", "/ignition",
+	},
+	{
 		"guestfish", "--remote", "--", "upload", "*.ign", "/ignition/config.ign",
 	},
 	{
@@ -67,6 +70,9 @@ var supportedCommandTree = map[string]interface{}{
 					".*": map[string]interface{}{
 						"/": nil,
 					},
+				},
+				"mkdir-p": map[string]interface{}{
+					"/ignition": nil,
 				},
 				"upload": map[string]interface{}{
 					".*.ign": map[string]interface{}{
@@ -184,6 +190,13 @@ func validateCommandSemanticsAndGenerateOutput(args ...string) (bool, string) {
 	if newArgs[3] == "mount" {
 		if Started == currentGuestfishStatus {
 			currentGuestfishStatus = Mounted
+			return true, ""
+		}
+		return false, errMsg
+	}
+
+	if newArgs[3] == "mkdir-p" {
+		if Mounted == currentGuestfishStatus {
 			return true, ""
 		}
 		return false, errMsg


### PR DESCRIPTION
Create guestfish upload directory for coreos ignition

Now #629 added support for s390x on coreos ignition, 
but it didn't create the upload directory before uploading ignition file.

Goal of this PR is creating the upload directory, and make sure #629 works regardless of whether the /ignition directory exists.
