### PR TITLE
Initial support for generating local documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build
+__pycache__

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,21 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = ../website/docs
+BUILDDIR      = build
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -b $@ -c $(ROOT_DIR) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+
+# Generating documentation
+
+Requirements:
+
+* Sphinx
+* Python recommonmark
+* sphinx_rtd_theme
+
+Then do:
+
+```
+make html
+```
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import subprocess
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+from recommonmark.transform import AutoStructify
+
+project = 'terraform-provider-libvirt'
+copyright = '2019, Duncan Mac-Vicar P. & contributors'
+author = 'Duncan Mac-Vicar P.'
+
+version = subprocess.check_output(('git', 'describe', '--tags')).decode("utf-8")
+
+source_suffix = {
+    '.html.markdown': 'markdown',
+}
+
+templates_path = ['_templates']
+exclude_patterns = ["_build"]
+html_theme = 'sphinx_rtd_theme'
+extensions = ['removefrontmatter','recommonmark']
+
+html_theme_options = {
+    'collapse_navigation': False,
+}
+
+master_doc = 'toc'
+
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+        'enable_eval_rst': True,
+        'auto_toc_tree_section': 'Resources',
+        'auto_toc_maxdepth': 3,
+        'commonmark_suffixes': ['.html.markdown'],
+    }, 'env')
+    app.add_transform(AutoStructify)
+
+

--- a/docs/removefrontmatter.py
+++ b/docs/removefrontmatter.py
@@ -1,0 +1,8 @@
+import re
+
+# Remove the frint matter (YAML) from markdown files
+def source_read_handler(app, docname, source):
+    source[0] = re.sub(r'^---\n(.+\n)*---\n', '', source[0])
+
+def setup(app):
+    app.connect('source-read', source_read_handler)

--- a/website/docs/resources.html.markdown
+++ b/website/docs/resources.html.markdown
@@ -1,0 +1,9 @@
+
+# Resources
+
+```eval_rst
+.. toctree::
+   :glob:
+
+   r/**
+```

--- a/website/docs/toc.html.markdown
+++ b/website/docs/toc.html.markdown
@@ -1,0 +1,14 @@
+
+# terraform-provider-libvirt Documentation
+
+```eval_rst
+.. toctree::
+   index
+```
+
+```eval_rst
+.. toctree::
+   :maxdepth: 2
+
+   resources
+```


### PR DESCRIPTION

We have the _website_ directory in the tree, using upstream layout to be prepared for inclusion in the _terraform-providers_ project.

This PR adds a _docs_ directory with a Sphinx configuration that allows to generate html documentation from the original layout.

```bash
cd docs
make html
```

Should generate a beautiful website:

![Screenshot from 2019-10-09 00-57-19](https://user-images.githubusercontent.com/15332/66439806-29f91e80-ea31-11e9-84cd-78aa14eca500.png)
![Screenshot from 2019-10-09 00-57-45](https://user-images.githubusercontent.com/15332/66439810-2c5b7880-ea31-11e9-9875-8c39b0cb7cbd.png)

There are minor details that can be improved, but I think it is a good first step.

After this PR, my plan would be to enable CI to automatically publish the documentation, and then move some of it from _README_, and link it appropriately.
