### PR TITLE
Support execute guestfish at remote libvirt host

### DIFF
--- a/libvirt/guestfish_test.go
+++ b/libvirt/guestfish_test.go
@@ -246,16 +246,16 @@ func TestHelperCommand(t *testing.T) {
 	os.Exit(exitCode)
 }
 
-func TestGuestfishExecution(t *testing.T) {
+func TestGuestfishExecutionLocal(t *testing.T) {
 
 	execCommand = fakeExecCommand
 	defer func() {
 		execCommand = exec.Command
 	}()
 
-	err := guestfishExecution("/root/path", "my.ign")
+	err := guestfishExecutionLocal("/root/path", "my.ign")
 
 	if err != nil {
-		t.Errorf("failed to call guestfishExecution, error: %v", err)
+		t.Errorf("failed to call guestfishExecutionLocal, error: %v", err)
 	}
 }

--- a/libvirt/helper/sshconn/sshconn.go
+++ b/libvirt/helper/sshconn/sshconn.go
@@ -1,0 +1,70 @@
+package sshconn
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/ssh"
+)
+
+type SSHConn struct {
+	Host    string
+	Port    int
+	User    string
+	Keypath string
+	Client  *ssh.Client
+	Session *ssh.Session
+}
+
+func (s *SSHConn) Connect() error {
+	var keypath string
+	if s.Keypath == "" {
+		homepath, err := homedir.Dir()
+		if err != nil {
+			return err
+		}
+		keypath = homepath + "/.ssh/id_rsa"
+	} else {
+		keypath = s.Keypath
+	}
+
+	key, err := ioutil.ReadFile(keypath)
+	if err != nil {
+		return err
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return err
+	}
+
+	config := &ssh.ClientConfig{}
+	config.SetDefaults()
+	config.User = s.User
+	config.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
+	config.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+
+	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
+	client, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		return err
+	} else {
+		s.Client = client
+		return nil
+	}
+}
+
+func (s *SSHConn) ExecCommand(cmd string) (string, error) {
+	session, err := s.Client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	bs, err := session.CombinedOutput(cmd)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}


### PR DESCRIPTION
In remote libvirt mode, libvirt volumes will be created on remote
host, but guestfish commands are running on terraform host.

In this change, will run those guestfish commands at remote
libvirt host via ssh, And this change assumes
the public key of the user that running terraform has been added
into libvirt host's authorized_keys.

Fixed #659

Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
