### PR TITLE
fix(domain): update domain running state when refreshed

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -563,10 +563,15 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	// We save runnig state to not mix what we have and what we want
+	requiredStatus := d.Get("running")
+
 	err = resourceLibvirtDomainRead(d, meta)
 	if err != nil {
 		return err
 	}
+
+	d.Set("running", requiredStatus)
 
 	// we must read devices again in order to set some missing ip/MAC/host mappings
 	for i := 0; i < d.Get("network_interface.#").(int); i++ {
@@ -731,6 +736,11 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading domain autostart setting: %s", err)
 	}
 
+	domainRunningNow, err := domainIsRunning(*domain)
+	if err != nil {
+		return fmt.Errorf("Error reading domain running state : %s", err)
+	}
+
 	d.Set("name", domainDef.Name)
 	d.Set("vcpu", domainDef.VCPU)
 	d.Set("memory", domainDef.Memory)
@@ -739,6 +749,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cpu", domainDef.CPU)
 	d.Set("arch", domainDef.OS.Type.Arch)
 	d.Set("autostart", autostart)
+	d.Set("running", domainRunningNow)
 
 	cmdLines, err := splitKernelCmdLine(domainDef.OS.Cmdline)
 	if err != nil {


### PR DESCRIPTION
##  System Information

### Linux distribution

``` Debian GNU/Linux 10 (buster) ```

### Terraform version

```sh
Terraform v0.12.12
```

### Provider and libvirt versions

```sh
Compiled against library: libvirt 5.0.0
Using library: libvirt 5.0.0
Running hypervisor: QEMU 3.1.0
Running against daemon: 5.0.0
```
___

## Checklist

Your issue is it a bug or something that does not work as expected.

## Description of Issue

I'm currently using libvirt locally on my PC. Whenever I shutdown my computer, all the domains are stopped (which is correct, I don't wan't some tests domain to restart whenever I restart the host). Until then, all's good.

But when I want to restart my stack after a reboot, terraform says that there is nothing to do. As the domains are in stopped state, I expected terraform to put them online again (in order to get immutable infrastructure). I noticed that the running property doesn't get updated when terraform tries a refresh.

### What did I do

I used the method domainIsRunning in order to get the domain state, and updated the schema running property. Tests were all good, but there seems to be a bug which is not related to this PR.

___
## Additional information:

Apparmor is disabled.

First PR, and first GO code : sorry if I did something wrong in the way.
Please tell me in order to improve.

On a side note, there is also something wrong with the network state refresh.
When I ran the tests, i got this :
```
Error: Error creating libvirt domain: virError(Code=55, Domain=19, Message='Requested operation is not valid: network 'default' is not active')

$ sudo virsh net-list --all
 Name          State      Autostart   Persistent
--------------------------------------------------
 default       inactive   no          yes
```
