### PR TITLE
Avoid delays on volume operations

### DIFF
--- a/libvirt/volume.go
+++ b/libvirt/volume.go
@@ -38,7 +38,6 @@ func volumeWaitForExists(virConn *libvirt.Connect, key string) error {
 		Target:     []string{volExistsID},
 		Refresh:    volumeExists(virConn, key),
 		Timeout:    1 * time.Minute,
-		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -56,7 +55,6 @@ func volumeWaitDeleted(virConn *libvirt.Connect, key string) error {
 		Target:     []string{volNotExistsID},
 		Refresh:    volumeExists(virConn, key),
 		Timeout:    1 * time.Minute,
-		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 


### PR DESCRIPTION
## Problem

Every time a volume is created/updated/destroyed, we wait for 5 seconds before starting to poll libvirt for a success/error event.

In most cases this is completely unnecessary: the polling is not even needed as the operation is instant or almost so. Even in those cases in which it takes a long time, the delay is unnecessary and will just be substituted by the first round of polling.

## Reproducer

Create a 1 MB empty volume:

```hcl
provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_volume" "main_disk" {
  name             = "reproducer"
  size = 1*1024*1024
  pool             = "default"
}
```

Output:
```
$ terraform apply -auto-approve

libvirt_volume.main_disk: Creating...
libvirt_volume.main_disk: Creation complete after 5s [id=/var/lib/libvirt/images/reproducer]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
(note the 5s delay)

## Proposed solution

Remove the delay.

## Behavior after the patch

```
$ terraform apply -auto-approve

libvirt_volume.main_disk: Creating...
libvirt_volume.main_disk: Creation complete after 0s [id=/var/lib/libvirt/images/reproducer]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Command finishes instantly.