### PR TITLE
Catch one more case of missing volume

### DIFF
--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -310,7 +310,13 @@ func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 	info, err := volume.GetInfo()
 	if err != nil {
-		return fmt.Errorf("error retrieving volume info: %s", err)
+		virErr := err.(libvirt.Error)
+		if virErr.Code != libvirt.ERR_NO_STORAGE_VOL {
+			return fmt.Errorf("error retrieving volume info: %s", err)
+		}
+		log.Printf("Volume '%s' may have been deleted outside Terraform", d.Id())
+		d.SetId("")
+		return nil
 	}
 	d.Set("size", info.Capacity)
 

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -310,7 +310,7 @@ func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 	info, err := volume.GetInfo()
 	if err != nil {
-		return fmt.Errorf("error retrieving volume name: %s", err)
+		return fmt.Errorf("error retrieving volume info: %s", err)
 	}
 	d.Set("size", info.Capacity)
 

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -254,10 +254,10 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	if _, ok := d.GetOk("source"); ok {
 		err = img.Import(newCopier(client.libvirt, volume, volumeDef.Capacity.Value), volumeDef)
 		if err != nil {
-		//  don't save volume ID  in case of error. This will taint the volume after.
-		// If we don't throw away the id, we will keep instead a broken volume.
-		// see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
-		d.Set("id", "")	
+			//  don't save volume ID  in case of error. This will taint the volume after.
+			// If we don't throw away the id, we will keep instead a broken volume.
+			// see for reference: https://github.com/dmacvicar/terraform-provider-libvirt/issues/494
+			d.Set("id", "")
 			return fmt.Errorf("Error while uploading source %s: %s", img.String(), err)
 		}
 	}


### PR DESCRIPTION
If a pool is backed by a directory and a volume is removed from it without refreshing the pool, libvirt will not notice it's missing until volume details are requested by `terraform-provider-libvirt`, resulting in the following error message:

```
Error: error retrieving volume name: virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching path '/var/lib/libvirt/images/reproducer'')
```

This PR catches this particular case and allows `terraform-provider-libvirt` to continue by deploying a new volume.

Best reviewed commit-by-commit.

## Reproducer
main.tf:

```hcl
provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_volume" "main_disk" {
  name             = "reproducer"
  size = 1*1048576
  pool             = "default"
}
```

```
$ terraform apply -auto-approve

libvirt_volume.main_disk: Creating...
libvirt_volume.main_disk: Creation complete after 0s [id=/var/lib/libvirt/images/reproducer]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ sudo mv /var/lib/libvirt/images/reproducer /tmp/

$ terraform apply -auto-approve
libvirt_volume.main_disk: Refreshing state... [id=/var/lib/libvirt/images/reproducer]

Error: error retrieving volume name: virError(Code=50, Domain=18, Message='Storage volume not found: no storage vol with matching path '/var/lib/libvirt/images/reproducer'')
```