### PR TITLE
resourceLibvirtVolumeCreate: tolerate existing volumes

### DIFF
--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -255,7 +254,8 @@ func TestAccLibvirtVolume_ManuallyDestroyed(t *testing.T) {
 	})
 }
 
-func TestAccLibvirtVolume_UniqueName(t *testing.T) {
+func TestAccLibvirtVolume_RepeatedName(t *testing.T) {
+	var volume libvirt.StorageVol
 	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	randomVolumeResource2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -289,8 +289,15 @@ func TestAccLibvirtVolume_UniqueName(t *testing.T) {
 		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      config,
-				ExpectError: regexp.MustCompile(`storage volume '` + randomVolumeName + `' (exists already|already exists)`),
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource2, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource2, "name", randomVolumeName),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
This PR addresses an issue we frequently encounter in our CI, which manifests when builds are interrupted halfway through (either manually or because of bugs) or when manual changes are done to the libvirt host.

Scenario is the following:
 - `main.tf` (actually, in general, any configuration input to Terraform) wants the creation of a certain volume
 - that volume (actually, its key) is not present in `terraform.tfstate` (or, in general, in the Terraform state). That could be because such a volume was never created by Terraform at that point, or because the Terraform state was wiped for any reason
 - actually, though, the volume does exist

My understanding is that:
 - in this circumstance, Terraform will not check for the volume existence (eg. it will not call `resourceLibvirtVolumeExists` on it)
 - rather, it will just just ignore it's there and, at `terraform apply` time, it will call `resourceLibvirtVolumeCreate` directly
 - the following error is produced:

```
Error: Error creating libvirt volume: virError(Code=90, Domain=18, Message='storage volume 'reproducer' exists already')
```

In general, I can see three possible solutions:

1- abort Terraform and signal the error (current behavior). Our problem: this does not self-heal at the next run of the CI (currently we have to clean up the situation manually)
2- destroy the volume and recreate it. This is a clean solution, the downside being that the destruction would not be visible at `terraform plan` time. Users might have valuable data in volumes destroyed this way, and will not know until it's too late
3- tolerate the presence of the volume and just use it as-is. Chances are some attributes, such as the size, will not match the user expectation until the next round of `apply`. **This is proposed in this PR**

I am not aware of a way to detect this at `terraform plan` time, which would be the cleanest solution if it were possible.