### PR TITLE
allow creating a bridged network

### DIFF
--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -249,7 +249,7 @@ func testAccCheckLibvirtNetworkBridge(resourceName string, bridgeName string) re
 			return fmt.Errorf("Bridge type of network should be not nil")
 		}
 
-		if networkDef.Bridge.Name != bridgeName || networkDef.Bridge.STP != "on" {
+		if networkDef.Bridge.Name != bridgeName {
 			fmt.Printf("%#v", networkDef)
 			return fmt.Errorf("fail: network brigde property were not set correctly")
 		}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -432,8 +432,7 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		if networkDef.Bridge.Name == "" {
 			return fmt.Errorf("'bridge' must be provided when using the bridged network mode")
 		}
-		// Bridges cannot forward
-		networkDef.Forward = nil
+		networkDef.Bridge.STP = ""
 	} else {
 		return fmt.Errorf("unsupported network mode '%s'", networkDef.Forward.Mode)
 	}


### PR DESCRIPTION
There were a couple of 'restrictions' which prevented virtual networks in bridge mode from being created.

1) the forward mode was removed from the xml (yes bridged networks can forward).  This caused libvirt to allocate a new bridge vs use the existing provided bridge.  Resulting in 'file exists' error messages.
2) STP was forced on (this is actually kinda dangerous.  Spanning tree protocol, should only be enabled when the operator/owner expressly asks for it. You can force large networks into learning mode crippling the network, or have a core switch turn off your top of rack uplink port and then you have to go buy your local network admin a bottle of scotch to get it turned back on... yep this is the voice of experience).   In bridged mode setting STP is not allowed.

https://libvirt.org/formatnetwork.html#examplesBridge

Fixes: #616 #443 #401 #364 



Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
