### PR TITLE
remove default value from disk scsi

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -159,7 +159,6 @@ func resourceLibvirtDomain() *schema.Resource {
 						"scsi": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
 						},
 						"wwn": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

Linux distribution: Leap 15.1
Terraform version: Terraform v0.12.13
Provider and libvirt versions:
```
terraform-provider-libvirt was not built correctly
Compiled against library: libvirt 5.1.0
Using library: libvirt 5.10.0
Running hypervisor: QEMU 4.1.1
Running against daemon: 5.10.0
```
Provider version distributed for sumaform, but I also tested building from head (commit: `db13b678ab16fe9dca024c3daea6e56fb4cc4ae2`)

Terraform return an `Error: Provider produced inconsistent final plan` error when we have an extra disk on sumaform, using the dynamic disk block.
Full error:
```
Error: Provider produced inconsistent final plan

When expanding the plan for
module.server.module.suse_manager.libvirt_domain.domain[0] to include new
values learned so far during apply, provider "libvirt" produced an invalid new
value for .disk: block count changed from 1 to 2.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.

```

With some research, we found out that this is a problem in terraform itself. Terraform doesn't deal well with dynamic block generation when using some functions to manipulate the array of elements(like split or concat). In https://github.com/hashicorp/terraform/issues/21157 the slice function is corrected, but they are probably missing the fix to the concat function.

If we remove the default value for disk scsi, the disk block don't have any value know before apply, and in this way terraform is able to handle the plan inconsistency, since all values will be known after apply.

Remove this default values doesn't look to impact in the provider execution, since after apply the value will be false also.

## Reproduce
Clone this branch: https://github.com/uyuni-project/sumaform/tree/libvirt_concat_error
```
cp main_example_with_libvirt_error.tf main.tf
terraform init
terraform apply
```
Run terraform apply again and the error disappears since both disks are created and now terraform can compute the correct values.