### PR TITLE
Remove sporious test changes

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -626,8 +626,7 @@ func TestAccLibvirtDomain_NetworkInterface(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:             config,
-				ExpectNonEmptyPlan: false, // TODO: find why if set to true, the test fails
-				Destroy:            false,
+				ExpectNonEmptyPlan: false, 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
PR [#714](https://github.com/dmacvicar/terraform-provider-libvirt/pull/714/) introduced spurious changes in the test configuration for `resource_libvirt_domain_test.go`. The added `Destroy` parameter has no effect and the comment regarding the `ExpectNonEmptyPlan` is outdated.
