### PR TITLE
Fix qemu-guest-agent address retrieval when MAC contains two zeroes

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -99,7 +99,9 @@ func domainIfaceHasAddress(domain libvirt.Domain, iface libvirtxml.DomainInterfa
 	log.Printf("[DEBUG] ifaces with addresses: %+v\n", ifacesWithAddr)
 
 	for _, ifaceWithAddr := range ifacesWithAddr {
-		if mac == strings.ToUpper(ifaceWithAddr.Hwaddr) {
+		if mac == strings.ToUpper(ifaceWithAddr.Hwaddr) ||
+			strings.Replace(mac, "00", "0", -1) == strings.ToUpper(ifaceWithAddr.Hwaddr) {
+
 			log.Printf("[DEBUG] found IPs for MAC=%+v: %+v\n", mac, ifaceWithAddr.Addrs)
 			return true, false, nil
 		}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -895,7 +895,8 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 		// not sure if using the target device name is a better idea here
 		var addrs []string
 		for _, ifaceWithAddr := range ifacesWithAddr {
-			if strings.ToUpper(ifaceWithAddr.Hwaddr) == mac {
+			if strings.ToUpper(ifaceWithAddr.Hwaddr) == mac ||
+				strings.ToUpper(ifaceWithAddr.Hwaddr) == strings.Replace(mac, "00", "0", -1) {
 				for _, addr := range ifaceWithAddr.Addrs {
 					addrs = append(addrs, addr.Addr)
 				}


### PR DESCRIPTION
When MAC address contains two zeroes the whole octet set to zero - i.e. single zero on the qemu-ga output:
```
2020-03-23T19:14:54.231+0300 [DEBUG] plugin.terraform-provider-libvirt: 2020/03/23 19:14:54 [DEBUG] qemu-agent response: {"return":[{"name":"lo0","hardware-address":"0:0:0:0:0:0","ip-addresses":[{"ip-address-type":"ipv4","prefix":8,"ip-address":"127.0.0.1"},{"ip-address-type":"ipv6","prefix":128,"ip-address":"::1"},{"ip-address-type":"ipv6","prefix":64,"ip-address":"fe80::1"}]},{"name":"en1","hardware-address":"52:54:0:fa:9c:3b","ip-addresses":[{"ip-address-type":"ipv6","prefix":64,"ip-address":"fe80::104b:5f65:737c:4b7a"},{"ip-address-type":"ipv4","prefix":24,"ip-address":"10.70.131.226"}]}]}
2020-03-23T19:14:54.231+0300 [DEBUG] plugin.terraform-provider-libvirt: 2020/03/23 19:14:54 [DEBUG] Parsed response {Interfaces:[{Name:lo0 Hwaddr:0:0:0:0:0:0 IPAddresses:[{Type:ipv4 Address:127.0.0.1 Prefix:8} {Type:ipv6 Address:::1 Prefix:128} {Type:ipv6 Address:fe80::1 Prefix:64}]} {Name:en1 Hwaddr:52:54:0:fa:9c:3b IPAddresses:[{Type:ipv6 Address:fe80::104b:5f65:737c:4b7a Prefix:64} {Type:ipv4 Address:10.70.131.226 Prefix:24}]}]}
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 2020/03/23 19:14:54 [DEBUG] Interfaces obtained via qemu-agent: [{Name:lo0 Hwaddr:0:0:0:0:0:0 Addrs:[{Type:0 Addr:127.0.0.1 Prefix:8} {Type:1 Addr:::1 Prefix:128} {Type:1 Addr:fe80::1 Prefix:64}]} {Name:en1 Hwaddr:52:54:0:fa:9c:3b Addrs:[{Type:1 Addr:fe80::104b:5f65:737c:4b7a Prefix:64} {Type:0 Addr:10.70.131.226 Prefix:24}]}]
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 2020/03/23 19:14:54 [DEBUG] read: addresses for '52:54:00:FA:9C:3B': []
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 2020/03/23 19:14:54 [DEBUG] read: ifaces for 'dev-test-bridge':
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: ([]map[string]interface {}) (len=1 cap=1) {
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 	(map[string]interface {}) (len=10) {
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=4) "vepa": (string) "",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=3) "mac": (string) (len=17) "52:54:00:FA:9C:3B",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=14) "wait_for_lease": (bool) true,
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=9) "addresses": ([]string) <nil>,
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=12) "network_name": (string) "",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=6) "bridge": (string) (len=3) "br0",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=7) "macvtap": (string) "",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=11) "passthrough": (string) "",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=8) "hostname": (string) "",
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 		(string) (len=10) "network_id": (string) ""
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: 	}
2020-03-23T19:14:54.232+0300 [DEBUG] plugin.terraform-provider-libvirt: }
```

Because of direct string comparison condition is failing:
`mac == strings.ToUpper(ifaceWithAddr.Hwaddr)`

Possibly fixes:

- https://github.com/dmacvicar/terraform-provider-libvirt/issues/710

Tested with agent on MacOS Catalina 10.15.3