### PR TITLE
Fix: block device test fails searching for loop dev

### DIFF
--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -1278,7 +1278,7 @@ func createTempBlockDev(devname string) (string, string, error) {
 	}
 
 	// Find an available loop device
-	cmd = exec.Command("/sbin/losetup", "--find")
+	cmd = exec.Command("sudo", "/sbin/losetup", "--find")
 	loopdevStr, err := cmd.Output()
 	fmt.Printf("Executing command: %s\n", strings.Join(cmd.Args, " "))
 	if err != nil {


### PR DESCRIPTION
Test TestAccLibvirtDomain_BlockDevice fails searching for available loop device because the command /sbin/losetup --find is not executed as root.
