### PR TITLE
Add dev attribute to network configuration

### DIFF
--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -43,6 +43,9 @@ func getNetModeFromResource(d *schema.ResourceData) string {
 	return strings.ToLower(d.Get("mode").(string))
 }
 
+func getNetDevFromResource(d *schema.ResourceData) string {
+	return strings.ToLower(d.Get("dev").(string))
+}
 // getIPsFromResource gets the IPs configurations from the resource definition
 func getIPsFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkIP, error) {
 	addresses, ok := d.GetOk("addresses")

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -32,7 +32,7 @@ func TestNetworkDefUnmarshall(t *testing.T) {
 			<bridge name="virbr0" stp="on" delay="5" macTableManager="libvirt"/>
 			<mac address='00:16:3E:5D:C7:9E'/>
 			<domain name="example.com" localOnly="no"/>
-			<forward mode='nat'>
+			<forward mode='nat' dev='eth0'>
 				<nat>
 					<address start='1.2.3.4' end='1.2.3.10'/>
 				</nat>
@@ -71,6 +71,9 @@ func TestNetworkDefUnmarshall(t *testing.T) {
 	}
 	if b.Forward.Mode != "nat" {
 		t.Errorf("wrong forward mode: '%s'", b.Forward.Mode)
+	}
+	if b.Forward.Dev != "eth0" {
+		t.Errorf("wrong forward dev: '%s'", b.Forward.Dev)
 	}
 	if len(b.Forward.NAT.Addresses) == 0 {
 		t.Errorf("wrong number of addresses: %s", b.Forward.NAT.Addresses)

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -62,6 +62,11 @@ func resourceLibvirtNetwork() *schema.Resource {
 				ForceNew: true,
 				Default:  netModeNat,
 			},
+			"dev": { // device for forward
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
 			"bridge": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -382,6 +387,7 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	// check the network mode
 	networkDef.Forward = &libvirtxml.NetworkForward{
 		Mode: getNetModeFromResource(d),
+		Dev: getNetDevFromResource(d),
 	}
 	if networkDef.Forward.Mode == netModeIsolated || networkDef.Forward.Mode == netModeNat || networkDef.Forward.Mode == netModeRoute {
 

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -20,6 +20,10 @@ resource "libvirt_network" "kube_network" {
 
   # mode can be: "nat" (default), "none", "route", "bridge"
   mode = "nat"
+  
+  # (optional) the network device for forward
+  # should be the network device or bridge. prevents talk between nat networks
+  # dev = "eth0"
 
   #  the domain used by the DNS server in this network
   domain = "k8s.local"


### PR DESCRIPTION
Fixes https://github.com/dmacvicar/terraform-provider-libvirt/issues/720

This adds the dev attribute if selected to the <forward /> tag in the network xml