### PR TITLE
Log useful error message if xsltproc cannot be executed

### DIFF
--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -89,6 +89,7 @@ func transformXML(xml string, xslt string) (string, error) {
 		xmlFile.Name())
 	transformedXML, err := cmd.Output()
 	if err != nil {
+		log.Printf("[ERROR] Failed to run xsltproc (is it installed?)")
 		return xml, err
 	}
 	log.Printf("[DEBUG] Transformed XML with user specified XSLT:\n%s", transformedXML)


### PR DESCRIPTION
transformXML requires the xsltproc executable but will fail silently
if it does not exist.  This commit makes it log a message when that
happens to help guide the user.
