### PR TITLE
Fix Test failure TestAccLibvirtVolume_RepeatedName

### DIFF
--- a/libvirt/volume.go
+++ b/libvirt/volume.go
@@ -68,7 +68,12 @@ func volumeWaitDeleted(virConn *libvirt.Connect, key string) error {
 func volumeDelete(client *Client, key string) error {
 	volume, err := client.libvirt.LookupStorageVolByKey(key)
 	if err != nil {
-		return fmt.Errorf("Can't retrieve volume %s: %v", key, err)
+		virErr := err.(libvirt.Error)
+		if virErr.Code != libvirt.ERR_NO_STORAGE_VOL {
+			return fmt.Errorf("volumeDelete: Can't retrieve volume %s: %v", key, err)
+		}
+		// Volume already deleted.
+		return nil
 	}
 	defer volume.Free()
 


### PR DESCRIPTION
Fix https://github.com/dmacvicar/terraform-provider-libvirt/issues/730
by making volumeDelete return nil if
client.libvirt.LookupStorageVolByKey returns an ERR_NO_STORAGE_VOL
error.  This is in the same vein as recent changes made by @moio in
commit 4d5aa53fb.
