### PR TITLE
Update .travis.yml to satisfy build config validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os:       linux
 dist:     xenial
-sudo:     false
 language: go
 go:
   - 1.11.x
@@ -7,7 +7,6 @@ env:
   - GO111MODULE=on GOFLAGS=-mod=vendor LIBVIRT_DEFAULT_URI='qemu+unix:///session' TF_LIBVIRT_DISABLE_PRIVILEGED_TESTS=1 TF_LIBVIRT_RNG_DEV='/dev/random'
 git:
   depth: 1
-  go_import_path: github.com/dmacvicar/terraform-provider-libvirt
 install:        true
 before_script:
   - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.0/terraform_0.12.0_linux_amd64.zip


### PR DESCRIPTION
Travis CI had the following complaints about the build configuration:
root: deprecated key sudo (The key `sudo` has no effect anymore.)
git: unknown key go_import_path (github.com/dmacvicar/terraform ...)
root: missing os, using the default linux

These have been resolved.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
