### PR TITLE
#703 - Permit creation of multiple libvirt networks

### DIFF
--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -46,6 +46,7 @@ func getNetModeFromResource(d *schema.ResourceData) string {
 func getNetDevFromResource(d *schema.ResourceData) string {
 	return strings.ToLower(d.Get("dev").(string))
 }
+
 // getIPsFromResource gets the IPs configurations from the resource definition
 func getIPsFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkIP, error) {
 	addresses, ok := d.GetOk("addresses")
@@ -132,13 +133,18 @@ func getNetworkIPConfig(address string) (*libvirtxml.NetworkIP, *libvirtxml.Netw
 	return dni, dhcp, nil
 }
 
-// getBridgeFromResource returns a libvirt's NetworkBridge
-// from the ResourceData provided.
+// getBridgeFromResource returns a libvirt's NetworkBridge from the
+// ResourceData provided or creates a new one if not specified
+// based on the network name.
 func getBridgeFromResource(d *schema.ResourceData) *libvirtxml.NetworkBridge {
-	// use a bridge provided by the user, or create one otherwise (libvirt will assign on automatically when empty)
-	bridgeName := ""
+	// use a bridge provided by the user, or create one otherwise
+	log.Printf("VEMVEMVEMVEMVEMVEMVEMVEMVEMVEM")
+	var bridgeName string
 	if b, ok := d.GetOk("bridge"); ok {
 		bridgeName = b.(string)
+	} else {
+		netName, _ := d.GetOk("name")
+		bridgeName = netName.(string) + "-br"
 	}
 
 	bridge := &libvirtxml.NetworkBridge{

--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -138,7 +138,6 @@ func getNetworkIPConfig(address string) (*libvirtxml.NetworkIP, *libvirtxml.Netw
 // based on the network name.
 func getBridgeFromResource(d *schema.ResourceData) *libvirtxml.NetworkBridge {
 	// use a bridge provided by the user, or create one otherwise
-	log.Printf("VEMVEMVEMVEMVEMVEMVEMVEMVEMVEM")
 	var bridgeName string
 	if b, ok := d.GetOk("bridge"); ok {
 		bridgeName = b.(string)

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -113,7 +113,7 @@ func qemuAgentGetInterfacesInfo(domain Domain, wait4ipv4 bool) []libvirt.DomainI
 		Pending:    []string{qemuGetIfaceWait},
 		Target:     []string{qemuGetIfaceDone},
 		Refresh:    qemuAgentInterfacesRefreshFunc(domain, wait4ipv4),
-		MinTimeout:  1 * time.Minute,
+		MinTimeout: 1 * time.Minute,
 		Delay:      30 * time.Second, // Wait this time before starting checks
 		Timeout:    5 * time.Minute,
 	}

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -35,8 +35,8 @@ resource "libvirt_network" "kube_network" {
 
   # (optional) the bridge device defines the name of a bridge device
   # which will be used to construct the virtual network.
-  # (only necessary in "bridge" mode)
-  # bridge = "br7"
+  # If left undefined and is required, name will be { resource.name }-br
+  # bridge = "k8snet-br"
 
   # (optional) the MTU for the network. If not supplied, the underlying device's
   # default is used (usually 1500)


### PR DESCRIPTION
Fixes a bug where multiple libvirt networks create but only one would start due to bridge name collisions.

I wasn't sure how to include a test for this, but it is a fairly small change..