### PR TITLE
Skip display setup for aarch64 as well

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/goveralls v0.0.2
 	github.com/mitchellh/packer v1.3.2
 	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	github.com/terraform-providers/terraform-provider-ignition v1.2.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 )

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/terraform-providers/terraform-provider-ignition v1.2.1 h1:dlRZGcokysc9Z2gTVm+neSghAMv9/2WA/pYiGZ6JHCg=
 github.com/terraform-providers/terraform-provider-ignition v1.2.1/go.mod h1:tUlGVBhkz+z79iffnt7vKISS199MdPd85+l6SNpoS/s=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -305,8 +305,8 @@ func setVideo(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 }
 
 func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch string) error {
-	// For s390x, ppc64 and ppc64le spice is not supported
-	if arch == "s390x" || strings.HasPrefix(arch, "ppc64") {
+	// For aarch64, s390x, ppc64 and ppc64le spice is not supported
+	if arch == "aarch64" || arch == "s390x" || strings.HasPrefix(arch, "ppc64") {
 		domainDef.Devices.Graphics = nil
 		return nil
 	}


### PR DESCRIPTION
The two supported options, vnc and spice are currently pulling in CirrosLogic device emulation, which only exists on x86_64. 

eventually this will have to be reworked to offer virtio-gpu based display which is supported on aarch64, but this gets me one step further. 