### PR TITLE
Adjust generated dhcp to match libvirt limitation of max 65535 addresses

### DIFF
--- a/libvirt/utils_net.go
+++ b/libvirt/utils_net.go
@@ -117,7 +117,7 @@ func (fws *fileWebServer) Start() error {
 
 	handler := http.NewServeMux()
 	handler.Handle("/", http.FileServer(http.Dir(dir)))
-	fws.server = &http.Server{Addr: fmt.Sprintf(":%d", fws.Port), Handler: handler}
+	fws.server = &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", fws.Port), Handler: handler}
 	ln, err := net.Listen("tcp", fws.server.Addr)
 	if err != nil {
 		return err

--- a/libvirt/utils_test.go
+++ b/libvirt/utils_test.go
@@ -35,17 +35,41 @@ func TestFormatBoolYesNo(t *testing.T) {
 }
 
 func TestIPsRange(t *testing.T) {
-	_, net, err := net.ParseCIDR("192.168.18.1/24")
-	if err != nil {
-		t.Errorf("When parsing network: %s", err)
+	tt := []struct {
+		name         string
+		inputCIDR    string
+		expectdStart string
+		expectedEnd  string
+	}{
+		{
+			name:         "IPv4 range",
+			inputCIDR:    "192.168.18.1/24",
+			expectdStart: "192.168.18.0",
+			expectedEnd:  "192.168.18.255",
+		},
+		{
+			name:         "IPv6 range",
+			inputCIDR:    "fdff:beef:beef::1/64",
+			expectdStart: "fdff:beef:beef::",
+			expectedEnd:  "fdff:beef:beef::ffff",
+		},
 	}
 
-	start, end := networkRange(net)
-	if start.String() != "192.168.18.0" {
-		t.Errorf("unexpected range start for '%s': %s", net, start)
-	}
-	if end.String() != "192.168.18.255" {
-		t.Errorf("unexpected range start for '%s': %s", net, start)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, net, err := net.ParseCIDR(tc.inputCIDR)
+			if err != nil {
+				t.Errorf("When parsing network: %s", err)
+			}
+
+			start, end := networkRange(net)
+			if start.String() != tc.expectdStart {
+				t.Errorf("unexpected range start for '%s': %s, expected: %s", net, start, tc.expectdStart)
+			}
+			if end.String() != tc.expectedEnd {
+				t.Errorf("unexpected range end for '%s': %s, expected: %s", net, end, tc.expectedEnd)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR fixes the issue with IPv6 and DHCP mentioned in https://github.com/dmacvicar/terraform-provider-libvirt/issues/752 and ensures that only 2^16 addresses are used for the DHCP range (which is somehow a limitation of libvirt).