### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you are using Go >= 1.11, you don't need to build inside GOPATH:
 ```
 export GO111MODULE=on
 export GOFLAGS=-mod=vendor
+go mod vendor
 make install
 ```
 


### PR DESCRIPTION
When attempting to follow the build instructions, I have to manually  run `go mod vendor` before `make install` or I get an error:

```
$ export GO111MODULE=on
$ ~/go/src/github.com/dmacvicar/terraform-provider-libvirt ➤ export GOFLAGS=-mod=vendor
$ ~/go/src/github.com/dmacvicar/terraform-provider-libvirt ➤ make install
go install -ldflags "-X main.version=$(git describe --always --abbrev=40 --dirty)"
go: inconsistent vendoring in /home/vmorris/go/src/github.com/dmacvicar/terraform-provider-libvirt:
	github.com/stretchr/testify@v1.5.1: is explicitly required in go.mod, but vendor/modules.txt indicates github.com/stretchr/testify@v1.4.0

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
make: *** [install] Error 1
```


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
