### PR TITLE
Implement network detection for static IPs

### DIFF
--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"net"
 
 	libvirt "github.com/libvirt/libvirt-go"
 	"github.com/libvirt/libvirt-go-xml"
@@ -78,28 +79,60 @@ func getHostXMLDesc(ip, mac, name string) string {
 }
 
 // Adds a new static host to the network
-func addHost(n *libvirt.Network, ip, mac, name string) error {
+func addHost(n *libvirt.Network, ip, mac, name string, xmlIdx int) error {
 	xmlDesc := getHostXMLDesc(ip, mac, name)
 	log.Printf("Adding host with XML:\n%s", xmlDesc)
 	// From https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkUpdateFlags
 	// Update live and config for hosts to make update permanent across reboots
-	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_ADD_LAST, libvirt.NETWORK_SECTION_IP_DHCP_HOST, -1, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CONFIG | libvirt.NETWORK_UPDATE_AFFECT_LIVE)
+	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_ADD_LAST, libvirt.NETWORK_SECTION_IP_DHCP_HOST, xmlIdx, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CONFIG|libvirt.NETWORK_UPDATE_AFFECT_LIVE)
 }
 
 // Update a static host from the network
-func updateHost(n *libvirt.Network, ip, mac, name string) error {
+func updateHost(n *libvirt.Network, ip, mac, name string, xmlIdx int) error {
 	xmlDesc := getHostXMLDesc(ip, mac, name)
 	log.Printf("Updating host with XML:\n%s", xmlDesc)
 	// From https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkUpdateFlags
 	// Update live and config for hosts to make update permanent across reboots
-	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_MODIFY, libvirt.NETWORK_SECTION_IP_DHCP_HOST, -1, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CONFIG | libvirt.NETWORK_UPDATE_AFFECT_LIVE)
+	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_MODIFY, libvirt.NETWORK_SECTION_IP_DHCP_HOST, xmlIdx, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CONFIG|libvirt.NETWORK_UPDATE_AFFECT_LIVE)
+}
+
+// Get the network index of the target network
+func getNetworkIdx(n *libvirtxml.Network, ip string) (int, error) {
+	xmlIdx := -1
+
+	if n == nil {
+		return xmlIdx, fmt.Errorf("failed to convert to libvirt XML")
+	}
+
+	for idx, netIps := range n.IPs {
+		_, netw, err := net.ParseCIDR(fmt.Sprintf("%s/%d", netIps.Address, netIps.Prefix))
+		if err != nil {
+			return xmlIdx, err
+		}
+
+		if netw.Contains(net.ParseIP(ip)) {
+			xmlIdx = idx
+			break
+		}
+	}
+
+	return xmlIdx, nil
 }
 
 // Tries to update first, if that fails, it will add it
 func updateOrAddHost(n *libvirt.Network, ip, mac, name string) error {
-	err := updateHost(n, ip, mac, name)
+	xmlNet, _ := getXMLNetworkDefFromLibvirt(n)
+	// We don't check the error above
+	// if we can't parse the network to xml for some kind fo reasons
+	// we will return the default '-1' value.
+	xmlIdx, err := getNetworkIdx(&xmlNet, ip)
+	if err == nil {
+		log.Printf("Error during detecting network index: %s\nUsing default value: %d", err, xmlIdx)
+	}
+
+	err = updateHost(n, ip, mac, name, xmlIdx)
 	if virErr, ok := err.(libvirt.Error); ok && virErr.Code == libvirt.ERR_OPERATION_INVALID && virErr.Domain == libvirt.FROM_NETWORK {
-		return addHost(n, ip, mac, name)
+		return addHost(n, ip, mac, name, xmlIdx)
 	}
 	return err
 }

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -2,6 +2,11 @@ package libvirt
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	libvirt "github.com/libvirt/libvirt-go"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -9,15 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
-	"unsafe"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	libvirt "github.com/libvirt/libvirt-go"
-	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 func TestAccLibvirtDomain_Basic(t *testing.T) {
@@ -985,103 +982,6 @@ func TestAccLibvirtDomain_Filesystems(t *testing.T) {
 						"libvirt_domain."+randomDomainName, "filesystem.0.target", "tmp"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "filesystem.0.readonly", "false"),
-				),
-			},
-		},
-	})
-}
-
-func createPts() (string, error) {
-
-	var ptsNumber int
-
-	fd, err := syscall.Open("/dev/ptmx", int(syscall.O_RDWR), 0)
-	if err != nil {
-		fmt.Printf("Error creating pts %v", err)
-	}
-
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGPTN), uintptr(unsafe.Pointer(&ptsNumber)))
-
-	if ep != 0 {
-		return "", syscall.Errno(ep)
-	}
-
-	return fmt.Sprintf("/dev/pts/%d", ptsNumber), nil
-
-}
-
-func TestAccLibvirtDomain_Consoles(t *testing.T) {
-	skipIfPrivilegedDisabled(t)
-
-	var domain libvirt.Domain
-	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-
-	pts1, err := createPts()
-	if err != nil {
-		t.Errorf("error creating pts %v", err)
-	}
-
-	pts2, err := createPts()
-	if err != nil {
-		t.Errorf("error creating pts %v", err)
-	}
-
-	var config = fmt.Sprintf(`
-	resource "libvirt_domain" "%s" {
-		name = "%s"
-		console {
-			type        = "pty"
-			target_port = "0"
-			source_path = "%s"
-		}
-		console {
-			type        = "pty"
-			target_port = "0"
-			target_type = "virtio"
-			source_path = "%s"
-		}
-		console {
-			type        = "tcp"
-			target_port = "0"
-			target_type = "virtio"
-			source_host = "127.0.1.1"
-			source_service = "cisco-sccp"
-		}
-	}`, randomDomainName, randomDomainName, pts1, pts2)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLibvirtDomainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.0.type", "pty"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.0.target_port", "0"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.0.source_path", pts1),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.1.type", "pty"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.1.target_port", "0"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.1.target_type", "virtio"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.1.source_path", pts2),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.2.type", "tcp"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.2.target_port", "0"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.2.target_type", "virtio"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.2.source_host", "127.0.1.1"),
-					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomDomainName, "console.2.source_service", "cisco-sccp"),
 				),
 			},
 		},

--- a/libvirt/resource_libvirt_linux_test.go
+++ b/libvirt/resource_libvirt_linux_test.go
@@ -1,0 +1,110 @@
+package libvirt
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+	"unsafe"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	libvirt "github.com/libvirt/libvirt-go"
+)
+
+func createPts() (string, error) {
+
+	var ptsNumber int
+
+	fd, err := syscall.Open("/dev/ptmx", int(syscall.O_RDWR), 0)
+	if err != nil {
+		fmt.Printf("Error creating pts %v", err)
+	}
+
+	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGPTN), uintptr(unsafe.Pointer(&ptsNumber)))
+
+	if ep != 0 {
+		return "", syscall.Errno(ep)
+	}
+
+	return fmt.Sprintf("/dev/pts/%d", ptsNumber), nil
+
+}
+
+func TestAccLibvirtDomainConsoles(t *testing.T) {
+	skipIfPrivilegedDisabled(t)
+
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	pts1, err := createPts()
+	if err != nil {
+		t.Errorf("error creating pts %v", err)
+	}
+
+	pts2, err := createPts()
+	if err != nil {
+		t.Errorf("error creating pts %v", err)
+	}
+
+	var config = fmt.Sprintf(`
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		console {
+			type        = "pty"
+			target_port = "0"
+			source_path = "%s"
+		}
+		console {
+			type        = "pty"
+			target_port = "0"
+			target_type = "virtio"
+			source_path = "%s"
+		}
+		console {
+			type        = "tcp"
+			target_port = "0"
+			target_type = "virtio"
+			source_host = "127.0.1.1"
+			source_service = "cisco-sccp"
+		}
+	}`, randomDomainName, randomDomainName, pts1, pts2)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.0.type", "pty"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.0.target_port", "0"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.0.source_path", pts1),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.1.type", "pty"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.1.target_port", "0"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.1.target_type", "virtio"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.1.source_path", pts2),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.type", "tcp"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.target_port", "0"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.target_type", "virtio"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.source_host", "127.0.1.1"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "console.2.source_service", "cisco-sccp"),
+				),
+			},
+		},
+	})
+}
+


### PR DESCRIPTION
An idea how to fix https://github.com/dmacvicar/terraform-provider-libvirt/issues/759 to enable the network detection (we still need to solve the xml generation for the host/dhcp entry).

I moved `TestAccLibvirtDomain_Consoles` into a separate file with `linux` only otherwise I was not able to run the tests locally, since `syscall.TIOCGPTN` is not supported on MacOS.