### PR TITLE
Even an isolated network has dhcp

### DIFF
--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -15,6 +15,9 @@ func HasDHCP(net libvirtxml.Network) bool {
 		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "" {
 			return true
 		}
+	} else {
+		// isolated network
+		return true
 	}
 	return false
 }

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -105,8 +105,8 @@ func TestBrokenNetworkDefUnmarshall(t *testing.T) {
 func TestHasDHCPNoForwardSet(t *testing.T) {
 	net := libvirtxml.Network{}
 
-	if HasDHCP(net) {
-		t.Error("Expected to not have forward enabled")
+	if !HasDHCP(net) {
+		t.Error("Expected to have DHCP")
 	}
 }
 


### PR DESCRIPTION
Fix #500

libvirt's isolated network can have dhcp.

- https://libvirt.org/formatnetwork.html#examplesPrivate

There is no `forward` element in this case.