### PR TITLE
Fix pty console integration tests

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -445,7 +445,13 @@ func setConsoles(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 				Type: "telnet",
 			}
 		case "pty":
-			fallthrough
+			if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
+				console.Source = &libvirtxml.DomainChardevSource{
+					Pty: &libvirtxml.DomainChardevSourcePty{
+						Path: sourcePath.(string),
+					},
+				}
+			}
 		default:
 			if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
 				console.Source = &libvirtxml.DomainChardevSource{


### PR DESCRIPTION
`setConsoles()` should create a `pty` console using the `DomainChardevSourcePty` XML struct and not `fallthrough` the `DomainChardevSourceDev` case, which produces an input/output error when _libvirt_ tried to use the console.
