### PR TITLE
Force creation of network when we can't update due to libvirt limitation

### DIFF
--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/libvirt/libvirt-go"
-	"github.com/libvirt/libvirt-go-xml"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 func waitForNetworkActive(network libvirt.Network) resource.StateRefreshFunc {


### PR DESCRIPTION
*Edited by @dmacvicar *

>this PR fixes issue #784
>
>We are passing libvirt.NETWORK_UPDATE_COMMAND_MODIFY with an empty element to remove an element, when the right thing to do should be to pass ibvirt.NETWORK_UPDATE_COMMAND_DELETE and passing the actual element. This creates the error about the empty XML element.
>
>However, it is not possible to update this attribute anyway ([source](https://gitlab.com/search?utf8=%E2%9C%93&search=virNetworkDefUpdateNoSupport&group_id=130330&project_id=192693&scope=&search_code=true&snippets=false&repository_ref=master&nav_source=navbar)), so the right fix is to `ForceNew`
