### PR TITLE
Synchonize network defines to workaround libvirt bridge name race condition

### DIFF
--- a/libvirt/config.go
+++ b/libvirt/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	libvirt "github.com/libvirt/libvirt-go"
 	"log"
+	"sync"
 )
 
 // Config struct for the libvirt-provider
@@ -15,6 +16,9 @@ type Config struct {
 type Client struct {
 	libvirt     *libvirt.Connect
 	poolMutexKV *mutexkv.MutexKV
+	// define only one network at a time
+	// https://gitlab.com/libvirt/libvirt/-/issues/78
+	networkMutex sync.Mutex
 }
 
 // Client libvirt, generate libvirt client given URI

--- a/libvirt/helper/suppress/strings.go
+++ b/libvirt/helper/suppress/strings.go
@@ -1,8 +1,8 @@
 package suppress
 
 import (
-	"strings"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"strings"
 )
 
 func CaseDifference(_, old, new string, _ *schema.ResourceData) bool {

--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -46,7 +46,6 @@ func getNetModeFromResource(d *schema.ResourceData) string {
 func getNetDevFromResource(d *schema.ResourceData) string {
 	return strings.ToLower(d.Get("dev").(string))
 }
-
 // getIPsFromResource gets the IPs configurations from the resource definition
 func getIPsFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkIP, error) {
 	addresses, ok := d.GetOk("addresses")
@@ -133,23 +132,13 @@ func getNetworkIPConfig(address string) (*libvirtxml.NetworkIP, *libvirtxml.Netw
 	return dni, dhcp, nil
 }
 
-// getBridgeFromResource returns a libvirt's NetworkBridge from the
-// ResourceData provided or creates a new one if not specified
-// based on the network name.
+// getBridgeFromResource returns a libvirt's NetworkBridge
+// from the ResourceData provided.
 func getBridgeFromResource(d *schema.ResourceData) *libvirtxml.NetworkBridge {
-	// use a bridge provided by the user, or create one otherwise
-	var bridgeName string
+	// use a bridge provided by the user, or create one otherwise (libvirt will assign on automatically when empty)
+	bridgeName := ""
 	if b, ok := d.GetOk("bridge"); ok {
 		bridgeName = b.(string)
-	} else {
-		netNameI, _ := d.GetOk("name")
-		netName := netNameI.(string)
-		// Interface names are limited to 15 characters, so the network
-		// name has to be trimmed to 12.
-		if len(netName) > 12 {
-			netName = netName[:12]
-		}
-		bridgeName = netName + "-br"
 	}
 
 	bridge := &libvirtxml.NetworkBridge{

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -113,7 +113,7 @@ func qemuAgentGetInterfacesInfo(domain Domain, wait4ipv4 bool) []libvirt.DomainI
 		Pending:    []string{qemuGetIfaceWait},
 		Target:     []string{qemuGetIfaceDone},
 		Refresh:    qemuAgentInterfacesRefreshFunc(domain, wait4ipv4),
-		MinTimeout:  1 * time.Minute,
+		MinTimeout: 1 * time.Minute,
 		Delay:      30 * time.Second, // Wait this time before starting checks
 		Timeout:    5 * time.Minute,
 	}

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -113,7 +113,7 @@ func qemuAgentGetInterfacesInfo(domain Domain, wait4ipv4 bool) []libvirt.DomainI
 		Pending:    []string{qemuGetIfaceWait},
 		Target:     []string{qemuGetIfaceDone},
 		Refresh:    qemuAgentInterfacesRefreshFunc(domain, wait4ipv4),
-		MinTimeout: 1 * time.Minute,
+		MinTimeout:  1 * time.Minute,
 		Delay:      30 * time.Second, // Wait this time before starting checks
 		Timeout:    5 * time.Minute,
 	}

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -468,11 +468,19 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error applying XSLT stylesheet: %s", err)
 	}
 
-	log.Printf("[DEBUG] Creating libvirt network at %s: %s", connectURI, data)
-	network, err := virConn.NetworkDefineXML(data)
-	if err != nil {
-		return fmt.Errorf("Error defining libvirt network: %s - %s", err, data)
+	var network *libvirt.Network
+	{ // define only one network at a time
+		// see https://gitlab.com/libvirt/libvirt/-/issues/78
+		meta.(*Client).networkMutex.Lock()
+		defer meta.(*Client).networkMutex.Unlock()
+
+		log.Printf("[DEBUG] Creating libvirt network at %s: %s", connectURI, data)
+		network, err = virConn.NetworkDefineXML(data)
+		if err != nil {
+			return fmt.Errorf("Error defining libvirt network: %s - %s", err, data)
+		}
 	}
+
 	err = network.Create()
 	if err != nil {
 		// in some cases, the network creation fails but an artifact is created

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -127,6 +127,61 @@ func TestAccLibvirtNetwork_DNSDisable(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtNetwork_TwoNetworks(t *testing.T) {
+	skipIfPrivilegedDisabled(t)
+
+	randomNetworkResource1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	randomNetworkResource2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomNetworkName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "libvirt_network" "%s" {
+					  name = "%s"
+					  mode = "nat"
+					  addresses = [ "10.0.1.0/24" ]
+					  dhcp {
+						enabled = true
+					  }
+					  dns {
+						enabled = true
+						local_only = true
+					  }
+					}
+
+					output "%s" {
+					  value = libvirt_network.%s.name
+					}
+
+					resource "libvirt_network" "%s" {
+					  name = "%s"
+					  mode = "nat"
+					  addresses = [ "10.10.1.0/24" ]
+					  dhcp {
+						enabled = true
+					  }
+					  dns {
+						enabled = true
+						local_only = true
+					  }
+					}
+
+					output "%s" {
+					  value = libvirt_network.%s.name
+					}`, randomNetworkResource1, randomNetworkName1, randomNetworkResource1, randomNetworkResource1,
+					randomNetworkResource2, randomNetworkName2, randomNetworkResource2, randomNetworkResource2),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtNetwork_DNSForwarders(t *testing.T) {
 	skipIfPrivilegedDisabled(t)
 

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -35,8 +35,8 @@ resource "libvirt_network" "kube_network" {
 
   # (optional) the bridge device defines the name of a bridge device
   # which will be used to construct the virtual network.
-  # If left undefined and is required, name will be { resource.name }-br
-  # bridge = "k8snet-br"
+  # (only necessary in "bridge" mode)
+  # bridge = "br7"
 
   # (optional) the MTU for the network. If not supplied, the underlying device's
   # default is used (usually 1500)


### PR DESCRIPTION
This PR means to supersede/replace https://github.com/dmacvicar/terraform-provider-libvirt/pull/740
 
libvirt assigns the same bridge to networks defined in parallel (See https://gitlab.com/libvirt/libvirt/-/issues/78).

This code synchronizes network definition.

Note that there is still a problem in the code that generates wrong DHCP ranges. I could only prove it comes from our generated XML, but I could not figure how the race happens. We will need to address that as a separate issue.
I believe we need to remove most of the network code, and be a thin layer on top of libvirt. It may require us to align our definitions, eg. no _dhcp_ option in the _network_ block, and a explicit _range_ option.

Fixes https://github.com/dmacvicar/terraform-provider-libvirt/issues/703