### PR TITLE
Check custom volume size is a multiple of 512 bytes

### DIFF
--- a/libvirt/helper/suppress/volumes.go
+++ b/libvirt/helper/suppress/volumes.go
@@ -1,0 +1,38 @@
+package suppress
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"strconv"
+)
+
+// Suppress the diff if the specified volume size is not an even multiple of 1024 bytes
+func Qcow2RoundOffset(_, reportedSize, newSize string, k *schema.ResourceData) bool {
+	format := k.Get("format")
+
+	// On first apply these are nil strings, so there's always a diff
+	if reportedSize == "" || format == "" {
+		return false
+	}
+
+	nSize, _ := strconv.ParseUint(newSize, 10, 64)
+	rSize, _ := strconv.ParseUint(reportedSize, 10, 64)
+	newSizeRounded := roundUp(nSize)
+
+	// rounded size and reported size are the same
+	// image is qcow2 format, so suppress the diff
+	if newSizeRounded == rSize && format == "qcow2" {
+		return true
+	}
+
+	return false
+}
+
+// roundUpNewSize will make sure an existing/old image size
+// matches what qemu-img calculates by rounding up to the
+// nearest multiple of 1024
+func roundUp(i uint64) uint64 {
+	if i%1024 != 0 {
+		i = (i + 1024) - (i % 1024)
+	}
+	return i
+}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/dmacvicar/terraform-provider-libvirt/libvirt/helper/suppress"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"
 )
@@ -32,10 +33,11 @@ func resourceLibvirtVolume() *schema.Resource {
 				ForceNew: true,
 			},
 			"size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.Qcow2RoundOffset,
 			},
 			"format": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This is a naive attempt at working around? #741 - Size of created volume differs from the resource definition. The issue is that qcow2 uses sector sizes of 512 bytes, so any custom size is rounded up to align to a sector boundary, which leads to the resource destroy/create cycle in the issue.

The approach I've taken here is rather naive (just bail if custom size modulo 512 is non-zero), but it keeps things simple as opposed to fudging tfstate or reported values from qemu.

Here's an example setup:

```
terraform {
 required_version = ">= 0.13"
  required_providers {
    libvirt = {
      source  = "dmacvicar/libvirt"
      version = "0.6.2"
    }
  }
}

provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_volume" "test-volume" {
  name = "test-volume"
  size = 10000000
}
```

And a demonstration of rejecting outright an invalid size:

```
terraform apply  

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # libvirt_volume.test-volume will be created
  + resource "libvirt_volume" "test-volume" {
      + format = (known after apply)
      + id     = (known after apply)
      + name   = "test-volume"
      + pool   = "default"
      + size   = 10000000
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

libvirt_volume.test-volume: Creating...

Volume size 10000000 is not a multiple of 512 bytes. This would lead to volume replacement and data loss at the next apply invocation.

  on main.tf line 16, in resource "libvirt_volume" "test-volume":
  16: resource "libvirt_volume" "test-volume" {
```

I had a look through the test cases for volumes, but the testing framework seems too advanced for my novice level. I'll happily add one though if it makes sense!