### PR TITLE
Improve terraform v0.13 migration doc

### DIFF
--- a/docs/migration-13.md
+++ b/docs/migration-13.md
@@ -23,7 +23,7 @@ https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.
 
 The major change from 0.12 to 0.13 is the Explicit Provider Source Locations.
 
-In your `main.tf` this will be the needed change. 
+With the local plugin package in place, the final step is to add a [provider requirement](https://www.terraform.io/docs/configuration/provider-requirements.html) to each of the modules in your configuration to state which provider you mean when you say "libvirt" elsewhere in the module. Add the next code snippet to the `main.tf` file (including all imported modules using this libvirt provider):
 
 ```hcl
 


### PR DESCRIPTION
Improve the terraform v0.13 migration document to explicitily say that the new providers code snippet must be added to all used terraform modules (not just the main one)/

Based on: https://github.com/dmacvicar/terraform-provider-libvirt/issues/747#issuecomment-678575669