### PR TITLE
Replace mitchell/packer with google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/dmacvicar/terraform-provider-libvirt
 require (
 	github.com/c4milo/gotoolkit v0.0.0-20170704181456-e37eeabad07e // indirect
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/uuid v1.1.2
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/hooklift/assert v0.0.0-20170704181755-9d1defd6d214 // indirect
 	github.com/hooklift/iso9660 v1.0.0
 	github.com/libvirt/libvirt-go v5.0.0+incompatible
 	github.com/libvirt/libvirt-go-xml v5.0.0+incompatible
 	github.com/mattn/goveralls v0.0.2
-	github.com/mitchellh/packer v1.3.2
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/terraform-providers/terraform-provider-ignition v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -213,8 +215,6 @@ github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/packer v1.3.2 h1:y6IhjXub7GZMSLy1aHMgrFIB/NIj0sZNGawD3QKVcLs=
-github.com/mitchellh/packer v1.3.2/go.mod h1:3TnGTkplC/koV8K6bCfCN1NB34Tye7lmUzo55/X5wqw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=

--- a/libvirt/cloudinit_def.go
+++ b/libvirt/cloudinit_def.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hooklift/iso9660"
 	libvirt "github.com/libvirt/libvirt-go"
-	"github.com/mitchellh/packer/common/uuid"
 )
 
 const userDataFileName string = "user-data"
@@ -119,7 +119,7 @@ func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 // The ID is made by the volume ID (the internal one used by libvirt)
 // joined by the ";" with a UUID
 func (ci *defCloudInit) buildTerraformKey(volumeKey string) string {
-	return fmt.Sprintf("%s;%s", volumeKey, uuid.TimeOrderedUUID())
+	return fmt.Sprintf("%s;%s", volumeKey, uuid.New())
 }
 
 func getCloudInitVolumeKeyFromTerraformID(id string) (string, error) {

--- a/libvirt/coreos_ignition_def.go
+++ b/libvirt/coreos_ignition_def.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	libvirt "github.com/libvirt/libvirt-go"
-	"github.com/mitchellh/packer/common/uuid"
 )
 
 type defIgnition struct {
@@ -104,7 +104,7 @@ func (ign *defIgnition) CreateAndUpload(client *Client) (string, error) {
 // The ID is made by the volume ID (the internal one used by libvirt)
 // joined by the ";" with a UUID
 func (ign *defIgnition) buildTerraformKey(volumeKey string) string {
-	return fmt.Sprintf("%s;%s", volumeKey, uuid.TimeOrderedUUID())
+	return fmt.Sprintf("%s;%s", volumeKey, uuid.New())
 }
 
 func getIgnitionVolumeKeyFromTerraformID(id string) (string, error) {


### PR DESCRIPTION
Closes #770

Use a UUID specific package rather than Hashicorp's Packer tool which is for
baking Virtual Machine images.

Tested with terraform 0.13 by:
1. `terraform destroy` an existing 3 VM/domain cluster that was created with 0.6.2 release.
2. `terraform apply` 3 domain cluster.
3. `make testacc` with remote qemu+ssh host - FAILED, see below:
   ```
   libvirtd --version
   libvirtd (libvirt) 6.0.0
   ```


Test failures look unrelated to uuid changes - perhaps not possible to run with remote host..
```
$ LIBVIRT_DEFAULT_URI='qemu+ssh://karl@kvmhost1/system' make testacc
<snip>
=== RUN   TestAccLibvirtDomain_Volume
    testing.go:635: Step 0 error: errors during apply:

        Error: Error creating libvirt domain: virError(Code=1, Domain=10, Message='internal error: process exited while connecting to monitor: ERROR: ld.so: object 'libesets_pac.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
        2020-11-08T00:51:07.352288Z qemu-system-x86_64: -blockdev {"driver":"file","filename":"/tmp/terraform-provider-libvirt-pool-mwdqnldjed/lplxwrwaim","node-name":"libvirt-1-storage","auto-read-only":true,"discard":"unmap"}: Could not open '/tmp/terraform-provider-libvirt-pool-mwdqnldjed/lplxwrwaim': Permission denied')

          on /tmp/tf-test144857928/main.tf line 13:
          (source code not available)
```
