### PR TITLE
Fix flatcar-linux example network typo

### DIFF
--- a/examples/v0.12/flatcar-linux/units/00-wired.network
+++ b/examples/v0.12/flatcar-linux/units/00-wired.network
@@ -1,4 +1,4 @@
-[Math]
+[Match]
 Name=eth0
 
 [Network]

--- a/examples/v0.13/flatcar-linux/units/00-wired.network
+++ b/examples/v0.13/flatcar-linux/units/00-wired.network
@@ -1,4 +1,4 @@
-[Math]
+[Match]
 Name=eth0
 
 [Network]


### PR DESCRIPTION
Per: https://docs.flatcar-linux.org/ignition/network-configuration/

