### PR TITLE
Fixing issue #811

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -593,7 +593,9 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 				numOfISOs++
 			}
 
-			if !strings.HasSuffix(file.(string), ".qcow2") {
+			if strings.HasSuffix(file.(string), ".qcow2") {
+				disk.Driver.Type = "qcow2"
+			} else {
 				disk.Driver.Type = "raw"
 			}
 		} else if blockDev, ok := d.GetOk(prefix + ".block_device"); ok {


### PR DESCRIPTION
Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.

Fixing https://github.com/dmacvicar/terraform-provider-libvirt/issues/811

For some reason disk.Driver.Type ends up with value 'raw', even when file name of the disk drive has a ".qcow2" suffix.
Is seems like checking that the suffix is there and then apply qcow2 as the driver type is not done explicitely, so raw is choosen in this case.

This fix proposal fixed the workflow (described in issue 811) on my environment, tests are passing successfully. I propose you this fix and hope it is useful. Feel free to slap my fingers if I missed something in the contribution process or assumed something wrong or anything :)

Thank you for your great work ! I use the provider a lot and love it.