### PR TITLE
LVM storage pool implementation

### DIFF
--- a/libvirt/pool.go
+++ b/libvirt/pool.go
@@ -101,9 +101,17 @@ func deletePool(client *Client, uuid string) error {
 		}
 	}
 
-	err = pool.Delete(0)
+	poolDef, err := newDefPoolFromLibvirt(pool)
 	if err != nil {
-		return fmt.Errorf("error deleting storage pool: %s", err)
+		return err
+	}
+
+	// if the logical pool has no source device then the volume group existed before we created the pool, so we don't delete it
+	if poolDef.Type == "dir" || (poolDef.Type == "logical" && poolDef.Source != nil && poolDef.Source.Device != nil) {
+		err = pool.Delete(0)
+		if err != nil {
+			return fmt.Errorf("error deleting storage pool: %s", err)
+		}
 	}
 
 	err = pool.Undefine()

--- a/libvirt/pool_def.go
+++ b/libvirt/pool_def.go
@@ -1,0 +1,33 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+	libvirt "github.com/libvirt/libvirt-go"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
+)
+
+func newDefPoolFromLibvirt(pool *libvirt.StoragePool) (libvirtxml.StoragePool, error) {
+	name, err := pool.GetName()
+	if err != nil {
+		return libvirtxml.StoragePool{}, fmt.Errorf("could not get name for pool: %s", err)
+	}
+	poolDefXML, err := pool.GetXMLDesc(0)
+	if err != nil {
+		return libvirtxml.StoragePool{}, fmt.Errorf("could not get XML description for pool %s: %s", name, err)
+	}
+	poolDef, err := newDefPoolFromXML(poolDefXML)
+	if err != nil {
+		return libvirtxml.StoragePool{}, fmt.Errorf("could not get a pool definition from XML for %s: %s", name, err)
+	}
+	return poolDef, nil
+}
+
+func newDefPoolFromXML(s string) (libvirtxml.StoragePool, error) {
+	var poolDef libvirtxml.StoragePool
+	err := xml.Unmarshal([]byte(s), &poolDef)
+	if err != nil {
+		return libvirtxml.StoragePool{}, err
+	}
+	return poolDef, nil
+}


### PR DESCRIPTION
Logical storage pool implementation.

Our team needed the lvm storage pool, so I implemented it. We tested, it seems fine.
What do you think  @dmacvicar ?
If you say it's ok, then I write acceptance tests, and add the documentation.

If everything is fine, I think we should discuss about this:
The volumes created in logical storage pool, don't preserve de volume `format`. See: [pool](https://libvirt.org/storage.html#StorageBackendLogical) and [volume](https://libvirt.org/formatstorage.html#StorageVol). It's a problem when you try to determine the disk driver based on volume format during the domain creation here:https://github.com/dmacvicar/terraform-provider-libvirt/blob/30595333cabd9d1651449c18acfaa2f99aaef928/libvirt/domain.go#L513
So right now we can only use the default disk driver, which is raw, so e.g. cqow2 cannot be used.
I see two options:
1. The more elegant: extend the `disk` resource with a `driver` attribute. If it's provided, we use it, otherwise we should use the current logic.
2. Use the volume name to figure out the driver (as you do with files and url-s) e.g. if it ends with `.raw` or `.qcow2`, use them.
