### PR TITLE
Set firmware attribute to efi for aarch64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/hooklift/assert v0.0.0-20170704181755-9d1defd6d214 // indirect
 	github.com/hooklift/iso9660 v1.0.0
-	github.com/libvirt/libvirt-go v5.0.0+incompatible
-	github.com/libvirt/libvirt-go-xml v5.0.0+incompatible
+	github.com/libvirt/libvirt-go v5.10.0+incompatible
+	github.com/libvirt/libvirt-go-xml v5.10.0+incompatible
 	github.com/mattn/goveralls v0.0.2
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -178,10 +178,10 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3v
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/libvirt/libvirt-go v5.0.0+incompatible h1:IUbnpRXdveEHGNqZrckQAihg65OuHYb/b90yV89c6yQ=
-github.com/libvirt/libvirt-go v5.0.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=
-github.com/libvirt/libvirt-go-xml v5.0.0+incompatible h1:zSZ7uRWGGgvyzDHPrA+3sYrTf+Jtx4izPWYQhHfAOqc=
-github.com/libvirt/libvirt-go-xml v5.0.0+incompatible/go.mod h1:oBlgD3xOA01ihiK5stbhFzvieyW+jVS6kbbsMVF623A=
+github.com/libvirt/libvirt-go v5.10.0+incompatible h1:01fwkdUHH2hk4YyFNCr48OvSGqXYLzp9cofUpeyeLNc=
+github.com/libvirt/libvirt-go v5.10.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=
+github.com/libvirt/libvirt-go-xml v5.10.0+incompatible h1:kcgVynR4a9cuh/kc7Ywl8XRBUxbqe05seR2qgN+yTno=
+github.com/libvirt/libvirt-go-xml v5.10.0+incompatible/go.mod h1:oBlgD3xOA01ihiK5stbhFzvieyW+jVS6kbbsMVF623A=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -117,6 +117,12 @@ func newDomainDefForConnection(virConn *libvirt.Connect, rd *schema.ResourceData
 		d.OS.Type.Arch = arch
 	}
 
+	if d.OS.Type.Arch == "aarch64" {
+		// for aarch64 speciffying this will automatically select the firmware and NVRAM file
+		// reference: https://libvirt.org/formatdomain.html#bios-bootloader
+		d.OS.Firmware = "efi"
+	}
+
 	caps, err := getHostCapabilities(virConn)
 	if err != nil {
 		return d, err


### PR DESCRIPTION
This new firmare attribute was added to newer versions of libvirt-go-xml. This enables to specify the firmware as
'bios' or 'efi' and automatically fills in the loader and NVRAM elements without having to specify them manually.
Refer to https://libvirt.org/formatdomain.html#bios-bootloader for this. As part of this change, libvirt-go and
libvirt-go-xml needs to be updated. The old functionality of specifying the loader and NVRAM is also left as such
so those can continue to be specified if we do not want automatic selection

Setting this automatically for aarch64 as it is a EFI architecture by default.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
