### PR TITLE
Support dnsmasq options

### DIFF
--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -74,3 +74,26 @@ func TestAccLibvirtNetworkDataSource_DNSSRVTemplate(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLibvirtNetworkDataSource_DNSDnsmasqTemplate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+
+			{
+				Config: `data "libvirt_network_dnsmasq_options_template" "options" {
+  count = 2
+  option_name = "address"
+  option_value = "/.apps.tt${count.index}.testing/1.1.1.${count.index+1}"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.0", "option_name", "address"),
+					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.0", "option_value", "/.apps.tt0.testing/1.1.1.1"),
+					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.1", "option_name", "address"),
+					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.1", "option_value", "/.apps.tt1.testing/1.1.1.2"),
+				),
+			},
+		},
+	})
+}

--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -337,3 +337,35 @@ func testAccCheckLibvirtNetworkDNSEnableOrDisable(name string, expectDNS bool) r
 		return nil
 	}
 }
+
+// testAccCheckDnsmasqOptions checks the expected Dnsmasq options in a network
+func testAccCheckDnsmasqOptions(name string, expected []libvirtxml.NetworkDnsmasqOption) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		virConn := testAccProvider.Meta().(*Client).libvirt
+		networkDef, err := getNetworkDef(s, name, *virConn)
+		if err != nil {
+			return err
+		}
+		if networkDef.DnsmasqOptions == nil {
+			return fmt.Errorf("DnsmasqOptions block not found in networkDef")
+		}
+		actual := networkDef.DnsmasqOptions.Option
+		if len(expected) != len(actual) {
+			return fmt.Errorf("len(expected): %d != len(actual): %d", len(expected), len(actual))
+		}
+		for _, e := range expected {
+			found := false
+			for _, a := range actual {
+				if reflect.DeepEqual(a.Value, e.Value) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("Unable to find:%v in: %v", e, actual)
+			}
+		}
+		return nil
+	}
+}

--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -174,3 +174,23 @@ func getMTUFromResource(d *schema.ResourceData) *libvirtxml.NetworkMTU {
 
 	return nil
 }
+
+// getDNSMasqOptionFromResource returns a list of dnsmasq options
+// from the network definition
+func getDNSMasqOptionFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkDnsmasqOption, error) {
+	var dnsmasqOption []libvirtxml.NetworkDnsmasqOption
+	dnsmasqOptionPrefix := "dnsmasq_options.0"
+	if dnsmasqOptionCount, ok := d.GetOk(dnsmasqOptionPrefix + ".options.#"); ok {
+		for i := 0; i < dnsmasqOptionCount.(int); i++ {
+			dnsmasqOptionsPrefix := fmt.Sprintf(dnsmasqOptionPrefix+".options.%d", i)
+
+			optionName := d.Get(dnsmasqOptionsPrefix + ".option_name").(string)
+			optionValue := d.Get(dnsmasqOptionsPrefix + ".option_value").(string)
+			dnsmasqOption = append(dnsmasqOption, libvirtxml.NetworkDnsmasqOption{
+				Value: optionName + "=" + optionValue,
+			})
+		}
+	}
+
+	return dnsmasqOption, nil
+}

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -29,8 +29,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"libvirt_network_dns_host_template": datasourceLibvirtNetworkDNSHostTemplate(),
-			"libvirt_network_dns_srv_template":  datasourceLibvirtNetworkDNSSRVTemplate(),
+			"libvirt_network_dns_host_template":        datasourceLibvirtNetworkDNSHostTemplate(),
+			"libvirt_network_dns_srv_template":         datasourceLibvirtNetworkDNSSRVTemplate(),
+			"libvirt_network_dnsmasq_options_template": datasourceLibvirtNetworkDnsmasqOptionsTemplate(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -239,6 +239,38 @@ func resourceLibvirtNetwork() *schema.Resource {
 					},
 				},
 			},
+			"dnsmasq_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: false,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"option_name": {
+										Type: schema.TypeString,
+										// This should be required, but Terraform does validation too early
+										// and therefore doesn't recognize that this is set when assigning from
+										// a rendered dnsmasq_options template.
+										Optional: true,
+									},
+									"option_value": {
+										Type: schema.TypeString,
+										// This should be required, but Terraform does validation too early
+										// and therefore doesn't recognize that this is set when assigning from
+										// a rendered dnsmasq_options template.
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"xml": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -421,6 +453,15 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	} else {
 		return fmt.Errorf("unsupported network mode '%s'", networkDef.Forward.Mode)
 	}
+
+	dnsmasqOption, err := getDNSMasqOptionFromResource(d)
+	if err != nil {
+		return err
+	}
+	dnsMasqOptions := libvirtxml.NetworkDnsmasqOptions{
+		Option: dnsmasqOption,
+	}
+	networkDef.DnsmasqOptions = &dnsMasqOptions
 
 	// parse any static routes
 	routes, err := getRoutesFromResource(d)

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -79,6 +79,22 @@ resource "libvirt_network" "kube_network" {
     #     gateway = "10.18.0.2"
     #   }
   }
+
+  # (Optional) Dnsmasq options configuration
+  dnsmasq_options {
+    # (Optional) one or more option entries.  Both of
+    # "option_name" and "option_value" must be specified.  The format is:
+    # options  {
+    #     option_name = "server"
+    #     option_value = "/base.domain/my.ip.address.1"
+    #   }
+    # options {
+    #     option_name = "address"
+    #     ip = "/.api.base.domain/my.ip.address.2"
+    #   }
+    #
+  }
+
 }
 ```
 
@@ -182,6 +198,30 @@ resource "libvirt_network" "k8snet" {
 					dhcp {
 						enabled = true
 					}
+```
+
+* `dnsmasq_options` - (Optional) configuration of Dnsmasq options for the network
+  You need to provide a list of option name and value pairs.
+
+  * `options` - (Optional) a Dnsmasq option entry block. You can have one or more of these
+   blocks in your definition. You must specify both `option_name` and `option_value`.
+
+  An example of setting Dnsmasq options (using Dnsmasq option templates) follows:
+
+```hcl
+        resource "libvirt_network" "my_network" {
+          ...
+          dnsmasq_options {
+            options { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }
+          }
+          ...
+        }
+
+        data "libvirt_network_dnsmasq_options_template" "options" {
+          count = length(var.libvirt_dnsmasq_options)
+          option_name = keys(var.libvirt_dnsmasq_options)[count.index]
+          option_value = values(var.libvirt_dnsmasq_options)[count.index]
+        }
 ```
 
 ### Altering libvirt's generated network XML definition


### PR DESCRIPTION
So this is implementing #642 using datasource as suggested in the issue. The issue was closed at that time because
of a workaround using xslt. But now we are seeing that this is needed for our Openshift CI for non-x86 arches which
runs on libvirt. This would enable us to automate this option through the openshift installer byproviding it through
the install-config at installation time.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
