### PR TITLE
Fix/pool type

### DIFF
--- a/libvirt/resource_libvirt_pool.go
+++ b/libvirt/resource_libvirt_pool.go
@@ -221,9 +221,9 @@ func resourceLibvirtPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	poolType := poolDef.Type
 	if poolType == "" {
-		log.Printf("Pool %s has no type specified", poolName)
+		log.Printf("Pool %s has no type specified", pool.Name)
 	} else {
-		log.Printf("[DEBUG] Pool %s type: %s", poolName, poolType)
+		log.Printf("[DEBUG] Pool %s type: %s", pool.Name, poolType)
 		d.Set("type", poolType)
 	}
 

--- a/libvirt/resource_libvirt_pool.go
+++ b/libvirt/resource_libvirt_pool.go
@@ -219,6 +219,14 @@ func resourceLibvirtPoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("path", poolPath)
 	}
 
+	poolType := poolDef.Type
+	if poolType == "" {
+		log.Printf("Pool %s has no type specified", poolName)
+	} else {
+		log.Printf("[DEBUG] Pool %s type: %s", poolName, poolType)
+		d.Set("type", poolType)
+	}
+
 	return nil
 }
 
@@ -232,7 +240,7 @@ func resourceLibvirtPoolDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLibvirtPoolExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	log.Printf("[DEBUG] Check if resource libvirt_pool exists")
+	log.Printf("[DEBUG] Check if resource (id : %s) libvirt_pool exists", d.Id())
 	client := meta.(*Client)
 	virConn := client.libvirt
 	if virConn == nil {


### PR DESCRIPTION
Hello,

Little fix when import existing pool resource ` type: dir` is not set which cause a pool resource recreation on following terraform apply/plan. 
I am not sure if it is a good practice to add type definition into schema resource read operation maybe it could be set into Importer operation. But due to actual use of  `schema.ImportStatePassthrough` it seem more simple.

tfstate content after `terraform import` : 

```{
  "version": 4,
  "terraform_version": "0.13.5",
  "serial": 14,
  "lineage": "d1b8ac6d-ba5b-fbd6-8ced-f714bb8a21df",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "libvirt_pool",
      "name": "test",
      "provider": "provider[\"registry.terraform.io/dmacvicar/libvirt\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "allocation": 79629910016,
            "available": null,
            "capacity": 86946873344,
            "id": "e2e4ad32-7b14-4b4f-95e7-b5b7327acfe7",
            "name": "test",
            "path": "<path>",
            "type": null,                              // <=== here is wrongly null value
            "xml": []
          },
          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    }
  ]
}
```

Step to reproduce :

```
terraform init
virsh pool-define-as --name test --type dir --target <path>
virsh pool-start test --build
virsh pool-uuid --pool test
terraform import libvirt_pool.test <previous-uuid>

// ask for recreate
terraform plan
```

My tf file configuration applied after `terraform import`

```
terraform {
  required_version = ">= 0.13"
  required_providers {
    libvirt = {
      source  = "dmacvicar/libvirt"
      version = ">= 0.6.3"
    }
  }
  backend "etcdv3" {
   ...
  }
}

provider "libvirt" {
  uri = "qemu+tcp://<endpoint>"
}

resource "libvirt_pool" "test" {
  name = "test"
  type = "dir"
  path = "<path>"
}
```

Thanks for your reviews.
