### PR TITLE
Network config in examples for openSUSE should be 1, not 2

### DIFF
--- a/examples/v0.11/leap15/network_config.cfg
+++ b/examples/v0.11/leap15/network_config.cfg
@@ -1,5 +1,5 @@
 network:
-  version: 2
+  version: 1
   config:
   - type: physical
     name: ens3

--- a/examples/v0.12/tubleweed/network_config.cfg
+++ b/examples/v0.12/tubleweed/network_config.cfg
@@ -1,5 +1,5 @@
 network:
-  version: 2
+  version: 1
   config:
   - type: physical
     name: ens3

--- a/examples/v0.13/tumbleweed/network_config.cfg
+++ b/examples/v0.13/tumbleweed/network_config.cfg
@@ -1,5 +1,5 @@
 network:
-  version: 2
+  version: 1
   config:
   - type: physical
     name: ens3


### PR DESCRIPTION
The syntax follows version 1 https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html

The issue is that, if you use version 2, you don't get the network
configured. However, this is not visible because we are running the
firstboot setup which will set the network config.

The issue is visible if you use an image without firstboot setup
enabled.

fixes #827





