### PR TITLE
Remove mention of CentOS packages from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ What is *NOT* in scope:
   
 ## Downloading
 
-Builds for openSUSE, CentOS, Ubuntu, Fedora are created with openSUSE's [OBS](https://build.opensuse.org). The build definitions are available for both the [stable](https://build.opensuse.org/package/show/systemsmanagement:terraform/terraform-provider-libvirt) and [master](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) branches.
+Builds for openSUSE, Ubuntu, and Fedora are created with openSUSE's [OBS](https://build.opensuse.org). The build definitions are available for both the [stable](https://build.opensuse.org/package/show/systemsmanagement:terraform/terraform-provider-libvirt) and [master](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) branches.
 
 ## Using published binaries/builds
 


### PR DESCRIPTION
Unfortunately CentOS packages no longer seem to be provided, so this removes the mention of them from the README.md.