### PR TITLE
Update libvirt-go to 7.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/hooklift/assert v0.0.0-20170704181755-9d1defd6d214 // indirect
 	github.com/hooklift/iso9660 v1.0.0
-	github.com/libvirt/libvirt-go v5.10.0+incompatible
-	github.com/libvirt/libvirt-go-xml v5.10.0+incompatible
+	github.com/libvirt/libvirt-go v7.0.0+incompatible
+	github.com/libvirt/libvirt-go-xml v7.0.0+incompatible
 	github.com/mattn/goveralls v0.0.2
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -178,10 +178,10 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3v
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/libvirt/libvirt-go v5.10.0+incompatible h1:01fwkdUHH2hk4YyFNCr48OvSGqXYLzp9cofUpeyeLNc=
-github.com/libvirt/libvirt-go v5.10.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=
-github.com/libvirt/libvirt-go-xml v5.10.0+incompatible h1:kcgVynR4a9cuh/kc7Ywl8XRBUxbqe05seR2qgN+yTno=
-github.com/libvirt/libvirt-go-xml v5.10.0+incompatible/go.mod h1:oBlgD3xOA01ihiK5stbhFzvieyW+jVS6kbbsMVF623A=
+github.com/libvirt/libvirt-go v7.0.0+incompatible h1:twXBsJe7klsz2Zogxm4GJF5aBRPmdY72RX8nDumB86A=
+github.com/libvirt/libvirt-go v7.0.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=
+github.com/libvirt/libvirt-go-xml v7.0.0+incompatible h1:zY4SWe4hqy9c1XekUWeVS6ThYDbnK1YnIaq7kgMM8iE=
+github.com/libvirt/libvirt-go-xml v7.0.0+incompatible/go.mod h1:oBlgD3xOA01ihiK5stbhFzvieyW+jVS6kbbsMVF623A=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/libvirt/qemu_agent.go
+++ b/libvirt/qemu_agent.go
@@ -82,10 +82,10 @@ func qemuAgentInterfacesRefreshFunc(domain Domain, wait4ipv4 bool) resource.Stat
 
 				switch strings.ToLower(addr.Type) {
 				case "ipv4":
-					libVirtAddr.Type = int(libvirt.IP_ADDR_TYPE_IPV4)
+					libVirtAddr.Type = libvirt.IP_ADDR_TYPE_IPV4
 					ipv4Assigned = true
 				case "ipv6":
-					libVirtAddr.Type = int(libvirt.IP_ADDR_TYPE_IPV6)
+					libVirtAddr.Type = libvirt.IP_ADDR_TYPE_IPV6
 				default:
 					log.Printf("[ERROR] Cannot handle unknown address type %s", addr.Type)
 					continue

--- a/libvirt/qemu_agent_test.go
+++ b/libvirt/qemu_agent_test.go
@@ -183,7 +183,7 @@ func TestGetDomainInterfacesViaQemuAgent(t *testing.T) {
 	for _, addr := range interfaces[0].Addrs {
 		var expected string
 
-		if addr.Type == int(libvirt.IP_ADDR_TYPE_IPV4) {
+		if addr.Type == libvirt.IP_ADDR_TYPE_IPV4 {
 			expected = ipv4Addr
 		} else {
 			expected = ipv6Addr

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -460,7 +460,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		Unit:  "MiB",
 	}
 	domainDef.VCPU = &libvirtxml.DomainVCPU{
-		Value: d.Get("vcpu").(int),
+		Value: uint(d.Get("vcpu").(int)),
 	}
 	domainDef.Description = d.Get("description").(string)
 


### PR DESCRIPTION
The current version (5.1.0) does not compile on 32-bit architectures
such as the Raspberry Pi. Updating the dependency to the latest
version and tweaking build errors allows the unit tests to pass.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
