### PR TITLE
support more than 6 scsi devices on a single domain

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -476,6 +476,14 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 		if d.Get(prefix + ".scsi").(bool) {
 			disk.Target.Bus = "scsi"
 			scsiDisk = true
+			tmpInt := uint(0)
+			tmpIdx := uint(i)
+			disk.Address = &libvirtxml.DomainAddress{Drive: &libvirtxml.DomainAddressDrive{
+				Controller: &tmpInt,
+				Bus:        &tmpInt,
+				Target:     &tmpInt,
+				Unit:       &tmpIdx,
+			}}
 			if wwn, ok := d.GetOk(prefix + ".wwn"); ok {
 				disk.WWN = wwn.(string)
 			} else {
@@ -611,8 +619,10 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 
 	log.Printf("[DEBUG] scsiDisk: %t", scsiDisk)
 	if scsiDisk {
+		tmpIdx := uint(0)
 		domainDef.Devices.Controllers = append(domainDef.Devices.Controllers,
 			libvirtxml.DomainController{
+				Index: &tmpIdx,
 				Type:  "scsi",
 				Model: "virtio-scsi",
 			})


### PR DESCRIPTION
this commit forces all scsi devices of a certain domain
to be attached to a single virtio scsi controller.
this eliminates the limit of 6 scsi devices per domain.
upper limit for this implementation is 256 scsi devices per domain.

some background information:
https://bugzilla.redhat.com/show_bug.cgi?id=1269577


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
