### PR TITLE
go.mod: update go-libvirt to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/c4milo/gotoolkit v0.0.0-20170704181456-e37eeabad07e // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/digitalocean/go-libvirt v0.0.0-20210524223541-696696fc24e0
+	github.com/digitalocean/go-libvirt v0.0.0-20210615174804-eaff166426e3
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/terraform-plugin-sdk v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/coreos/ignition v0.34.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/Pkr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/go-libvirt v0.0.0-20210524223541-696696fc24e0 h1:kMIqxaCYeoKjec6KWCocwFK3FLhtjESKJXa8uk3gOao=
-github.com/digitalocean/go-libvirt v0.0.0-20210524223541-696696fc24e0/go.mod h1:o129ljs6alsIQTc8d6eweihqpmmrbxZ2g1jhgjhPykI=
+github.com/digitalocean/go-libvirt v0.0.0-20210615174804-eaff166426e3 h1:sVa08eb+JbGVuDBkprG3CoY8k80yYsQeXmdSuZOA82g=
+github.com/digitalocean/go-libvirt v0.0.0-20210615174804-eaff166426e3/go.mod h1:o129ljs6alsIQTc8d6eweihqpmmrbxZ2g1jhgjhPykI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=


### PR DESCRIPTION
To bring back polkit authentication support.

Closes #865

You can test with https://registry.terraform.io/providers/invidian/libvirt/latest or https://github.com/invidian/terraform-provider-libvirt/releases/tag/v0.6.10-rc1.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>