### PR TITLE
Improve SSH authentication

### DIFF
--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -95,7 +95,7 @@ func (curi *ConnectionURI) dialSSH() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		username = u.Name
+		username = u.Username
 	}
 
 	cfg := ssh.ClientConfig{


### PR DESCRIPTION
This adds support for using the SSH agent when using the ssh transport to libvirt. Tested locally that using a key file still works

Fixes #864 

Other methods can be added, but since they're mostly interactive, they don't make much sense for Terraform.

There are also commits for that add support for disabling SSH host key verification and fixes a minor bug with automatic user name selection.