### PR TITLE
Fix/qemuagent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/digitalocean/go-libvirt v0.0.0-20210615174804-eaff166426e3
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/uuid v1.1.2
+	github.com/hashicorp/go-getter v1.4.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.9.0
 	github.com/hooklift/assert v0.0.0-20170704181755-9d1defd6d214 // indirect
 	github.com/hooklift/iso9660 v1.0.0

--- a/libvirt/testdata/.gitignore
+++ b/libvirt/testdata/.gitignore
@@ -1,0 +1,1 @@
+alpine-qemu-agent-static-ip.qcow2


### PR DESCRIPTION

### Reimplements **qemu-guest-agent** interface query using go-libvirt interface.

Needed to query dhcp allocated IPs on bridged networks. 

### Testcase
I wanted to produce a decent reproducible test case so I generated an VM image (using alpine scripts) that runs qemu-guest-agent and configures a static IP that can be queried. See **TestAccLibvirtDomain_NetworkInterfaceQemuGuestAgentStaticIP**.

The VM test image in https://github.com/maseman/testvm-tflibvirt is generated with a workflow as a release asset. At ~100MB I thought it best NOT to add the file to terraform-provider-libvirt /testdata and instead setup a download in the testcase.

Alpine VMs like this (and with small overlay configurations) might be useful for other more complex test scenarios in the future. 