### PR TITLE
Add support for passwords using the SSH URI's

### DIFF
--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -59,7 +59,7 @@ func skipIfAccDisabled(t *testing.T) {
 
 func skipIfPrivilegedDisabled(t *testing.T) {
 	if os.Getenv("TF_LIBVIRT_DISABLE_PRIVILEGED_TESTS") != "" {
-		t.Skip("skipping test; Enviornemnt variable `TF_LIBVIRT_DISABLE_PRIVILEGED_TESTS` is set")
+		t.Skip("skipping test; Environment variable `TF_LIBVIRT_DISABLE_PRIVILEGED_TESTS` is set")
 	}
 }
 

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -70,7 +70,7 @@ func (curi *ConnectionURI) parseAuthMethods() []ssh.AuthMethod {
 		}
 	}
 
-	if sshPassword := q.Get("password"); sshPassword != "" {
+	if sshPassword, ok := curi.User.Password(); ok {
 		result = append(result, ssh.Password(sshPassword))
 	}
 

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -69,6 +69,11 @@ func (curi *ConnectionURI) parseAuthMethods() []ssh.AuthMethod {
 			log.Printf("[WARN] Unsupported auth method: %s", v)
 		}
 	}
+
+	if sshPassword := q.Get("password"); sshPassword != "" {
+		result = append(result, ssh.Password(sshPassword))
+	}
+
 	return result
 }
 

--- a/main.go
+++ b/main.go
@@ -29,8 +29,9 @@ func main() {
 	})
 }
 
-func printVersion(writer io.Writer) {
-	fmt.Fprintf(writer, "%s %s\n", os.Args[0], version)
+func printVersion(writer io.Writer) error {
+	_, err := fmt.Fprintf(writer, "%s %s\n", os.Args[0], version)
+	return err
 }
 
 func init() {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -29,6 +29,8 @@ The provider understands [connection URIs](https://libvirt.org/uri.html). The su
 
 Unlike the original libvirt, the `ssh` transport is not implemented using the ssh command and therefore does not require `nc` (netcat) on the server side.
 
+Additionally, the `ssh` URI supports passwords using the `driver+ssh://[username:PASSWORD@][hostname][:port]/[path][?extraparameters]` syntax.
+
 As the provider does not use libvirt on the client side, not all connection URI options are supported or apply.
 
 ## Example Usage


### PR DESCRIPTION
While a trivial addition, this allows using secret providers (e.g. Hashicorp Vault) to provide plaintext passwords instead of copying private key files around.

```
provider "vault" {
  address = "https://vault.example.com:8200"
}

data "vault_generic_secret" "admin_auth" {
  path = "op/vaults/servers/items/admin-at-kvm-server"
}

provider "libvirt" {
  uri = "qemu+ssh://admin:${data.vault_generic_secret.admin_auth.data["password"]}@kvm-server.example.com/system"
}
```
