### PR TITLE
Support specifying websocket port for VNC

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -341,6 +341,10 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 			domainDef.Devices.Graphics[0].VNC.Listeners = []libvirtxml.DomainGraphicListener{
 				listener,
 			}
+
+			if websocket, ok := d.GetOk(prefix + ".websocket"); ok {
+				domainDef.Devices.Graphics[0].VNC.WebSocket = websocket.(int)
+			}
 		default:
 			return fmt.Errorf("This provider only supports vnc/spice as graphics type. Provided: '%s'", graphicsType)
 		}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -260,6 +260,10 @@ func resourceLibvirtDomain() *schema.Resource {
 							Optional: true,
 							Default:  "127.0.0.1",
 						},
+						"websocket": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -404,6 +404,7 @@ The block supports:
 * `listen_type` - "listen type", defaults to "none"
 * `listen_address` - (Optional) IP Address where the VNC listener should be started if
 `listen_type` is set to `address`. Defaults to 127.0.0.1
+* `websocket` - (Optional) Port to listen on for VNC WebSocket functionality (-1 meaning auto-allocation)
 
 On occasion we have found it necessary to set a `type` of `vnc` and a
 `listen_type` of `address` with certain builds of QEMU.


### PR DESCRIPTION
Installing a VNC client isn't always a option. In these cases VNC can be
accessed over WebSocket with noVNC[1] in the browser.

[1] https://novnc.com

