### PR TITLE
Fix cloud-init on aarch64

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -465,7 +465,7 @@ func setConsoles(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 	}
 }
 
-func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Libvirt) error {
+func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Libvirt, arch string) error {
 	var scsiDisk = false
 	var numOfISOs = 0
 
@@ -600,7 +600,9 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 	}
 
 	log.Printf("[DEBUG] scsiDisk: %t", scsiDisk)
-	if scsiDisk {
+	// always add an scsi controller on aarch64, otherwise
+	// the machine cannot access cdrom
+	if scsiDisk || arch == "aarch64" {
 		domainDef.Devices.Controllers = append(domainDef.Devices.Controllers,
 			libvirtxml.DomainController{
 				Type:  "scsi",

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -541,7 +541,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	if err := setDisks(d, &domainDef, virConn); err != nil {
+	if err := setDisks(d, &domainDef, virConn, arch); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I played with this provider on aarch64 and I found out that cloud-init doesn't work there. Two fixes are needed:
- the cloud-init cdrom must be connected using scsi (AFAIK ide isn't an option on aarch64)
- since we are now using scsi, we also need to make sure to add the SCSI controller on aarch64

I successfully tested this change with the following terraform file:

```hcl
terraform {
  required_providers {
    libvirt = {
      source = "terraform.budai.cz/dmacvicar/libvirt"
    }
  }
}


provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_pool" "cluster" {
  name = "terraform"
  type = "dir"
  path = "/var/lib/libvirt/terraform"
}


resource "libvirt_volume" "fedora34-qcow2" {
  name   = "fedora34.qcow2"
  pool   = libvirt_pool.cluster.name
  source = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/aarch64/images/Fedora-Cloud-Base-34-1.2.aarch64.qcow2"
  format = "qcow2"
}

data "template_file" "user_data" {
  template = file("${path.module}/cloud_init.cfg")
}

resource "libvirt_cloudinit_disk" "commoninit" {
  name      = "commoninit.iso"
  user_data = data.template_file.user_data.rendered
  pool      = libvirt_pool.cluster.name
}

resource "libvirt_domain" "test" {
  name   = "fedora34"
  memory = 1024
  arch = "aarch64"
  machine = "virt-5.2"
  cpu {
    mode = "host-passthrough"
  }

  cloudinit = libvirt_cloudinit_disk.commoninit.id

  network_interface {
    network_name = "default"
  }

  disk {
    volume_id = libvirt_volume.fedora34-qcow2.id
  }
}
```

If you are looking for a quick workaround for this issue, you can also use this following xslt (also tested):

```xslt
<?xml version="1.0" ?>
<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
    <xsl:output omit-xml-declaration="yes" indent="yes"/>

    <!-- copy the whole xml doc to start with -->
    <xsl:template match="node()|@*">
        <xsl:copy>
            <xsl:apply-templates select="node()|@*"/>
        </xsl:copy>
    </xsl:template>

    <!-- replace <target dev='hdd'...> with <target dev='sda'...>  -->
    <xsl:template match="/domain/devices/disk[@device='cdrom']/target/@dev">
        <xsl:attribute name="dev">
            <xsl:value-of select="'sda'"/>
        </xsl:attribute>
    </xsl:template>

    <!-- replace <target bus='ide'...> with <target bus='scsi'...>  -->
    <xsl:template match="/domain/devices/disk[@device='cdrom']/target/@bus">
        <xsl:attribute name="bus">
            <xsl:value-of select="'scsi'"/>
        </xsl:attribute>
    </xsl:template>
    <xsl:template match="/domain/devices">
        <devices>
            <xsl:apply-templates/>
            <controller type='scsi' index='0' model='virtio-scsi'>
                <alias name='scsi0'/>
                <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
            </controller>
        </devices>
    </xsl:template>

</xsl:stylesheet>
```