### PR TITLE
Force removal of domains with snapshots or checkpoints

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -1073,7 +1073,7 @@ func resourceLibvirtDomainDelete(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := virConn.DomainUndefineFlags(domain, libvirt.DomainUndefineNvram); err != nil {
+	if err := virConn.DomainUndefineFlags(domain, libvirt.DomainUndefineNvram|libvirt.DomainUndefineSnapshotsMetadata|libvirt.DomainUndefineManagedSave|libvirt.DomainUndefineCheckpointsMetadata); err != nil {
 		if e := err.(libvirt.Error); e.Code == uint32(libvirt.ErrNoSupport) || e.Code == uint32(libvirt.ErrInvalidArg) {
 			log.Printf("libvirt does not support undefine flags: will try again without flags")
 			if err := virConn.DomainUndefine(domain); err != nil {


### PR DESCRIPTION
Libvirt needs special flags to actually delete a virtual machine if
that one has a snapshot or a checkpoint.

Use these flags when removing the domain resource to avoid any error
if the VM has snapshots or checkpoints even added manually by the user.
