### PR TITLE
Support specifying "open" forward mode

### DIFF
--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -55,7 +55,7 @@ func getIPsFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkIP, error) 
 	// check if DHCP must be enabled by default
 	var dhcpEnabled bool
 	netMode := getNetModeFromResource(d)
-	if netMode == netModeIsolated || netMode == netModeNat || netMode == netModeRoute {
+	if netMode == netModeIsolated || netMode == netModeNat || netMode == netModeRoute || netMode == netModeOpen {
 		dhcpEnabled = true
 	}
 

--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -13,7 +13,7 @@ import (
 // HasDHCP checks if the network has a DHCP server managed by libvirt
 func HasDHCP(net libvirtxml.Network) bool {
 	if net.Forward != nil {
-		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "" {
+		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "open" || net.Forward.Mode == "" {
 			return true
 		}
 	} else {

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -115,7 +115,7 @@ func TestHasDHCPForwardSet(t *testing.T) {
 		}
 	}
 
-	for _, mode := range []string{"nat", "route", ""} {
+	for _, mode := range []string{"nat", "route", "open", ""} {
 		net := createNet(mode)
 		if !HasDHCP(net) {
 			t.Errorf(

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -17,6 +17,7 @@ const (
 	netModeIsolated = "none"
 	netModeNat      = "nat"
 	netModeRoute    = "route"
+	netModeOpen     = "open"
 	netModeBridge   = "bridge"
 	dnsPrefix       = "dns.0"
 )
@@ -60,7 +61,7 @@ func resourceLibvirtNetwork() *schema.Resource {
 				// libvirt cannot update it so force new
 				ForceNew: true,
 			},
-			"mode": { // can be "none", "nat" (default), "route", "bridge"
+			"mode": { // can be "none", "nat" (default), "route", "open", "bridge"
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -377,13 +378,13 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	networkDef.Forward = &libvirtxml.NetworkForward{
 		Mode: getNetModeFromResource(d),
 	}
-	if networkDef.Forward.Mode == netModeIsolated || networkDef.Forward.Mode == netModeNat || networkDef.Forward.Mode == netModeRoute {
+	if networkDef.Forward.Mode == netModeIsolated || networkDef.Forward.Mode == netModeNat || networkDef.Forward.Mode == netModeRoute || networkDef.Forward.Mode == netModeOpen {
 
 		if networkDef.Forward.Mode == netModeIsolated {
 			// there is no forwarding when using an isolated network
 			networkDef.Forward = nil
-		} else if networkDef.Forward.Mode == netModeRoute {
-			// there is no NAT when using a routed network
+		} else if networkDef.Forward.Mode == netModeRoute || networkDef.Forward.Mode == netModeOpen {
+			// there is no NAT when using a routed or open network
 			networkDef.Forward.NAT = nil
 		}
 

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -18,7 +18,7 @@ resource "libvirt_network" "kube_network" {
   # the name used by libvirt
   name = "k8snet"
 
-  # mode can be: "nat" (default), "none", "route", "bridge"
+  # mode can be: "nat" (default), "none", "route", "open", "bridge"
   mode = "nat"
 
   #  the domain used by the DNS server in this network
@@ -123,6 +123,7 @@ The following arguments are supported:
     the virtual network to the LAN **without applying any NAT**. It requires that
     the IP address range be pre-configured in the routing tables of the router
     on the host network.
+    - `open`: similar to `route`, but no firewall rules are added.
     - `bridge`: use a pre-existing host bridge. The guests will effectively be
     directly connected to the physical network (i.e. their IP addresses will
     all be on the subnet of the physical network, and there will be no
@@ -130,7 +131,7 @@ The following arguments are supported:
     attribute is mandatory in this case.
 * `bridge` - (Optional) The bridge device defines the name of a bridge
    device which will be used to construct the virtual network (when not provided,
-   it will be automatically obtained by libvirt in `none`, `nat` and `route` modes).
+   it will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes).
 * `mtu` - (Optional) The MTU to set for the underlying network interfaces. When
    not supplied, libvirt will use the default for the interface, usually 1500.
    Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.


### PR DESCRIPTION
"The new forward mode 'open' is just like mode='route', except that no
firewall rules are added to assure that any traffic does or doesn't
pass. It is assumed that either they aren't necessary, or they will be
setup outside the scope of libvirt."[1]

[1] https://github.com/libvirt/libvirt/commit/25e8112d7c32ab271b9cae28f3ccbf5835206693

---

This is a useful mode if you want libvirt to manage the ip address and DHCP/DNS server, but want to manage the firewall rules yourself (ex: if the firewall rules are too restrictive).