### PR TITLE
RBD volume support

### DIFF
--- a/examples/v0.13/rbd/ubuntu-rbd-example.tf
+++ b/examples/v0.13/rbd/ubuntu-rbd-example.tf
@@ -1,0 +1,57 @@
+terraform {
+ required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "gxben/libvirt"
+      version = "0.6.11"
+    }
+  }
+}
+
+# instance the provider
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+# We previously added an Ubuntu QCOW2 cloud-image to Ceph, that will be used as a reference template.
+# $ wget http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64-disk-kvm.img
+# $ qemu-img convert -p -f qcow2 -O rbd ubuntu-20.04-server-cloudimg-amd64-disk-kvm.img rbd:rbd_pool/ubuntu-cloudimg-20.04
+
+# For convenience, it is easier to configure the RBD pool at libvirt system level rather than Terraform level.
+# This can be done once through:
+# $ virsh pool-define pool.xml
+# $ virsh pool-start rbd_pool
+# where pool.xml can be inspired from the following (where ceph.acme.com is the Ceph monitor host):
+# <pool type="rbd">
+#   <name>rbd_pool</name>
+#   <source>
+#     <name>rbd_pool</name>
+#     <host name='ceph.acme.com' port='3300'/>
+#   </source>
+# </pool>
+
+# We then ask Terraform to create a new volume on RBD by cloning the RBD reference template and resize it to 50 GB.
+resource "libvirt_volume" "os-disk" {
+  name             = "os-disk"
+  type             = "rbd"
+  pool             = "rbd_pool"
+  format           = "raw"
+  base_volume_pool = "rbd_pool"
+  base_volume_name = "ubuntu-cloudimg-20.04"
+  size             = "53687091200" # 50 GB
+}
+
+# Create the machine
+resource "libvirt_domain" "domain-ubuntu" {
+  name   = "ubuntu-terraform"
+  memory = "1024"
+  vcpu   = 1
+
+  disk {
+    rbd       = true
+    rbd_host  = "ceph.acme.com"
+    rbd_port  = "3300"
+    rbd_pool  = "rbd_pool"
+    rbd_image = "os-disk"
+  }
+}

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -20,6 +20,12 @@ func resourceLibvirtVolume() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "file",
+				ForceNew: true,
+			},
 			"pool": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -88,6 +94,14 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	virConn := meta.(*Client).libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
+	}
+
+	volumeType := "file"
+	if _, ok := d.GetOk("type"); ok {
+		volumeType = d.Get("type").(string)
+	}
+	if volumeType != "file" && volumeType != "rbd" {
+		return fmt.Errorf("Only storage volumes of type \"dir\" and \"rbd\" are supported")
 	}
 
 	poolName := "default"
@@ -197,7 +211,7 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 
 		// FIXME - confirm test behaviour accurate
 		// if baseVolume != nil {
-		if baseVolume.Name != "" {
+		if baseVolume.Name != "" && volumeType == "file" {
 			backingStoreFragmentDef, err := newDefBackingStoreFromLibvirt(virConn, baseVolume)
 			if err != nil {
 				return fmt.Errorf("Could not retrieve backing store definition: %s", err.Error())
@@ -220,6 +234,14 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 			}
 			volumeDef.BackingStore = &backingStoreFragmentDef
 		}
+
+		// Create a network RBD volume, get rid of permissions and backing store
+		// as libvirt does not support it yet
+		if volumeType == "rbd" {
+			volumeDef.Type = "network"
+			volumeDef.Target.Permissions = nil
+			volumeDef.BackingStore = nil
+		}
 	}
 
 	data, err := xmlMarshallIndented(volumeDef)
@@ -234,7 +256,25 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// create the volume
-	volume, err := virConn.StorageVolCreateXML(pool, data, 0)
+	var volume libvirt.StorageVol
+	if volumeType == "rbd" {
+		// RBD requires proper volume cloning and does not support backing store copy
+		baseVolumePoolName := d.Get("base_volume_pool").(string)
+		baseVolumePool, err := virConn.StoragePoolLookupByName(baseVolumePoolName)
+		if err != nil {
+			return fmt.Errorf("can't find storage pool '%s'", baseVolumePoolName)
+		}
+
+		baseVolumeName, _ := d.GetOk("base_volume_name")
+		baseVolume, _ := virConn.StorageVolLookupByName(baseVolumePool, baseVolumeName.(string))
+		if err != nil {
+			return fmt.Errorf("Can't retrieve base volume with name '%s': %v", baseVolumeName.(string), err)
+		}
+
+		volume, err = virConn.StorageVolCreateXMLFrom(pool, data, baseVolume, 0)
+	} else {
+		volume, err = virConn.StorageVolCreateXML(pool, data, 0)
+	}
 	if err != nil {
 		virErr := err.(libvirt.Error)
 		if virErr.Code != uint32(libvirt.ErrStorageVolExist) {
@@ -246,6 +286,14 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error looking up libvirt volume: %s", err)
 		}
 		log.Printf("[INFO] Volume about to be created was found and left as-is: %s", volumeDef.Name)
+	}
+
+	// resize RBD network volumes, if required
+	if volumeType == "rbd" && volumeDef.Capacity.Value != 0 {
+		err = virConn.StorageVolResize(volume, volumeDef.Capacity.Value, 0)
+		if err != nil {
+			return fmt.Errorf("Error trying to resize the libvirt volume: %s", err)
+		}
 	}
 
 	// we use the key as the id

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -33,6 +33,17 @@ resource "libvirt_volume" "worker" {
   base_volume_id = libvirt_volume.opensuse_leap.id
   count          = var.workers_count
 }
+
+# base RBD cloudimg template to create a new RBD volume
+resource "libvirt_volume" "os-disk" {
+  name             = "os-disk"
+  type             = "rbd"
+  pool             = "rbd_pool"
+  format           = "raw"
+  base_volume_pool = "rbd_pool"
+  base_volume_name = "ubuntu-cloudimg-20.04"
+  size             = "53687091200" # 50 GB
+}
 ```
 
 ~> **Tip:** when provisioning multiple domains using the same base image, create
@@ -46,6 +57,9 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
+* `type` - (Optional) The storage volume to be created.
+  If not given, the `file` storage volume type will be used.
+  Currently supported types are `file` and `rbd`.
 * `pool` - (Optional) The storage pool where the resource will be created.
   If not given, the `default` storage pool will be used.
 * `source` - (Optional) If specified, the image will be uploaded into libvirt


### PR DESCRIPTION
@dmacvicar This PR adds minimal changes to provide RBD volume support.
As documented, it relies on libvirt sysadmin to have provisioned template images on the Ceph/RBD pool and have the named pool defined at libvirt's level first, as to minimize configuration impact at Terraform level.

libvirt currently does not support source volume copying through backing store for anything else than directory pool type.
So when RBD volumes come into play, we use the volume clone and resize functions instead. 