### PR TITLE
 Add multi-hosts support.

### DIFF
--- a/libvirt/config.go
+++ b/libvirt/config.go
@@ -3,6 +3,7 @@ package libvirt
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"sync"
 
 	libvirt "github.com/digitalocean/go-libvirt"
@@ -10,13 +11,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 )
 
+// ConfigHost struct for the libvirt-provider
+type ConfigHost struct {
+	Region string
+	AZ     string
+	URI    string
+}
+
 // Config struct for the libvirt-provider
 type Config struct {
-	URI string
+	URI   string
+	Hosts []ConfigHost
 }
 
 // Client libvirt
 type Client struct {
+	Region      string
+	AZ          string
 	libvirt     *libvirt.Libvirt
 	poolMutexKV *mutexkv.MutexKV
 	// define only one network at a time
@@ -24,10 +35,10 @@ type Client struct {
 	networkMutex sync.Mutex
 }
 
-// Client libvirt, generate libvirt client given URI
-func (c *Config) Client() (*Client, error) {
+// NewClient libvirt, generate libvirt client given URI
+func NewClient(url, region, az string) (*Client, error) {
 
-	u, err := uri.Parse(c.URI)
+	u, err := uri.Parse(url)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +61,83 @@ func (c *Config) Client() (*Client, error) {
 	log.Printf("[INFO] libvirt client libvirt version: %v\n", v)
 
 	client := &Client{
+		Region:      region,
+		AZ:          az,
 		libvirt:     l,
 		poolMutexKV: mutexkv.NewMutexKV(),
+	}
+
+	return client, nil
+}
+
+// Clients libvirt
+type Clients struct {
+	Clients []*Client
+}
+
+// Clients libvirt, generate libvirt clients list
+func (c *Config) Clients() (*Clients, error) {
+
+	clients := &Clients{}
+
+	if c.URI != "" {
+		if _, ok := globalClientMap[c.URI]; ok {
+			log.Printf("[DEBUG] Reusing client for uri: '%s'", c.URI)
+		} else {
+			log.Printf("[DEBUG] Configuring provider for '%s'", c.URI)
+			client, err := NewClient(c.URI, "default", "default")
+			if err != nil {
+				return clients, err
+			}
+			clients.Clients = append(clients.Clients, client)
+			globalClientMap[c.URI] = client
+		}
+	}
+
+	for _, h := range c.Hosts {
+		if _, ok := globalClientMap[h.URI]; ok {
+			log.Printf("[DEBUG] Reusing client for uri: '%s'", h.URI)
+		} else {
+			log.Printf("[DEBUG] Configuring provider for '%s'", h.URI)
+			client, err := NewClient(h.URI, h.Region, h.AZ)
+			if err != nil {
+				return clients, err
+			}
+			clients.Clients = append(clients.Clients, client)
+			globalClientMap[c.URI] = client
+		}
+	}
+
+	return clients, nil
+}
+
+// Find libvirt client, find the appropriate endpoint
+func (clients *Clients) Find(region, az string) (*Client, error) {
+
+	var client *Client
+	var compatibleClients []*Client
+
+	// filter all known clients which map the requested region and AZ
+	for _, c := range clients.Clients {
+		if c.Region == region && c.AZ == az {
+			compatibleClients = append(compatibleClients, c)
+		}
+	}
+
+	if len(compatibleClients) == 0 {
+		return nil, fmt.Errorf("no provider seems to be avaiable for the requested Region/AZ tuple: (%s/%s)", region, az)
+	}
+
+	// if only one matches, go for it
+	if len(compatibleClients) == 1 {
+		client = compatibleClients[0]
+	} else {
+		// otherwise, pick and choose a random host matching requested criterias
+		rd := rand.Intn(len(compatibleClients) - 1)
+		if rd < 0 {
+			rd = 0
+		}
+		client = compatibleClients[rd]
 	}
 
 	return client, nil

--- a/libvirt/network_dns.go
+++ b/libvirt/network_dns.go
@@ -15,8 +15,8 @@ import (
 
 // updateDNSHosts detects changes in the DNS hosts entries
 // updating the network definition accordingly
-func updateDNSHosts(d *schema.ResourceData, meta interface{}, network libvirt.Network) error {
-	virConn := meta.(*Client).libvirt
+func updateDNSHosts(d *schema.ResourceData, client *Client, network libvirt.Network) error {
+	virConn := client.libvirt
 
 	hostsKey := dnsPrefix + ".hosts"
 	if d.HasChange(hostsKey) {

--- a/libvirt/resource_libvirt_cloud_init.go
+++ b/libvirt/resource_libvirt_cloud_init.go
@@ -14,6 +14,18 @@ func resourceCloudInitDisk() *schema.Resource {
 		Delete: resourceCloudInitDiskDelete,
 		Exists: resourceCloudInitDiskExists,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"az": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -46,7 +58,10 @@ func resourceCloudInitDisk() *schema.Resource {
 
 func resourceCloudInitDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] creating cloudinit")
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
@@ -81,7 +96,11 @@ func resourceCloudInitDiskCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceCloudInitDiskRead(d *schema.ResourceData, meta interface{}) error {
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -99,7 +118,10 @@ func resourceCloudInitDiskRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCloudInitDiskDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -114,7 +136,10 @@ func resourceCloudInitDiskDelete(d *schema.ResourceData, meta interface{}) error
 
 func resourceCloudInitDiskExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	log.Printf("[DEBUG] Check if resource libvirt_cloudinit_disk exists")
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return false, err
+	}
 	if client.libvirt == nil {
 		return false, fmt.Errorf(LibVirtConIsNil)
 	}

--- a/libvirt/resource_libvirt_coreos_ignition.go
+++ b/libvirt/resource_libvirt_coreos_ignition.go
@@ -13,6 +13,18 @@ func resourceIgnition() *schema.Resource {
 		Read:   resourceIgnitionRead,
 		Delete: resourceIgnitionDelete,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"az": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -35,7 +47,10 @@ func resourceIgnition() *schema.Resource {
 
 func resourceIgnitionCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] creating ignition file")
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -65,7 +80,11 @@ func resourceIgnitionCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIgnitionRead(d *schema.ResourceData, meta interface{}) error {
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -82,7 +101,10 @@ func resourceIgnitionRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIgnitionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -40,6 +40,18 @@ func resourceLibvirtDomain() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"az": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -466,7 +478,11 @@ func resourceLibvirtDomain() *schema.Resource {
 func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	log.Printf("[DEBUG] Check if resource libvirt_domain exists")
 
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return false, err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return false, fmt.Errorf(LibVirtConIsNil)
 	}
@@ -485,7 +501,11 @@ func resourceLibvirtDomainExists(d *schema.ResourceData, meta interface{}) (bool
 func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create resource libvirt_domain")
 
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -673,7 +693,11 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Update resource libvirt_domain")
 
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -784,7 +808,11 @@ func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Read resource libvirt_domain")
 
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -1033,7 +1061,11 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 func resourceLibvirtDomainDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete resource libvirt_domain")
 
-	virConn := meta.(*Client).libvirt
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}

--- a/libvirt/resource_libvirt_pool.go
+++ b/libvirt/resource_libvirt_pool.go
@@ -17,6 +17,18 @@ func resourceLibvirtPool() *schema.Resource {
 		Delete: resourceLibvirtPoolDelete,
 		Exists: resourceLibvirtPoolExists,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"az": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -75,7 +87,10 @@ func resourceLibvirtPool() *schema.Resource {
 }
 
 func resourceLibvirtPoolCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
@@ -169,7 +184,10 @@ func resourceLibvirtPoolCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLibvirtPoolRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
@@ -231,7 +249,10 @@ func resourceLibvirtPoolRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLibvirtPoolDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -241,13 +262,16 @@ func resourceLibvirtPoolDelete(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLibvirtPoolExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	log.Printf("[DEBUG] Check if resource (id : %s) libvirt_pool exists", d.Id())
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return false, err
+	}
 	virConn := client.libvirt
 	if virConn == nil {
 		return false, fmt.Errorf(LibVirtConIsNil)
 	}
 
-	_, err := virConn.StoragePoolLookupByUUID(parseUUID(d.Id()))
+	_, err = virConn.StoragePoolLookupByUUID(parseUUID(d.Id()))
 	if err != nil {
 		virErr := err.(libvirt.Error)
 		if virErr.Code != uint32(libvirt.ErrNoStoragePool) {

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -15,6 +15,18 @@ func resourceLibvirtVolume() *schema.Resource {
 		Delete: resourceLibvirtVolumeDelete,
 		Exists: resourceLibvirtVolumeExists,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
+			"az": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -81,11 +93,14 @@ func resourceLibvirtVolume() *schema.Resource {
 }
 
 func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
-	virConn := meta.(*Client).libvirt
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -280,11 +295,14 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 
 // resourceLibvirtVolumeRead returns the current state for a volume resource
 func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
-	virConn := meta.(*Client).libvirt
+	virConn := client.libvirt
 	if virConn == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -345,7 +363,10 @@ func resourceLibvirtVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 // resourceLibvirtVolumeDelete removed a volume resource
 func resourceLibvirtVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return err
+	}
 	if client.libvirt == nil {
 		return fmt.Errorf(LibVirtConIsNil)
 	}
@@ -356,7 +377,10 @@ func resourceLibvirtVolumeDelete(d *schema.ResourceData, meta interface{}) error
 // resourceLibvirtVolumeExists returns True if the volume resource exists
 func resourceLibvirtVolumeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	log.Printf("[DEBUG] Check if resource libvirt_volume exists")
-	client := meta.(*Client)
+	client, err := resourceGetClient(d, meta)
+	if err != nil {
+		return false, err
+	}
 
 	volPoolName := d.Get("pool").(string)
 	volume, err := volumeLookupReallyHard(client, volPoolName, d.Id())

--- a/libvirt/utils.go
+++ b/libvirt/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 var diskLetters = []rune("abcdefghijklmnopqrstuvwxyz")
@@ -69,4 +70,21 @@ func formatBoolYesNo(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+// resourceGetClient provides associated client based on resource requested region/az parameters
+func resourceGetClient(d *schema.ResourceData, meta interface{}) (*Client, error) {
+	clients := meta.(*Clients)
+
+	region := "default"
+	if _, ok := d.GetOk("region"); ok {
+		region = d.Get("region").(string)
+	}
+
+	az := "default"
+	if _, ok := d.GetOk("az"); ok {
+		az = d.Get("az").(string)
+	}
+
+	return clients.Find(region, az)
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,8 +51,53 @@ resource "libvirt_domain" "test1" {
 
 The following keys can be used to configure the provider.
 
-* `uri` - (Required) The [connection URI](https://libvirt.org/uri.html) used
+* `uri` - (Optional) The [connection URI](https://libvirt.org/uri.html) used
   to connect to the libvirt host.
+* `host` - (Optional) An element describing a libvirt host. One may add a list of `host` to describe a full cluster.
+
+At least one `uri` or a `host` element is required.
+
+When using a `host`, users can specify:
+
+* `region` - (Optional) The region the libvirt instance is associated to.
+* `az` - (Optional) The availability-zone the libvirt instance is associated to.
+* `uri` - (Optional) The [connection URI](https://libvirt.org/uri.html) used
+  to connect to the libvirt host.
+
+# Multiple Hosts Configuration
+
+As Terraform is not able to iterate over providers, one can specify multiple hosts with associated
+regions and availability zones to allow resources to interate over those and use the correct libvirt connection.
+
+```hcl
+# Configure the Libvirt provider with multiple hosts
+provider "libvirt" {
+  host {
+    region = "us-west"
+    az     = "1"
+    uri    = "qemu+tcp://libvirt-us-west-1.acme.com/system"
+  }
+  host {
+    region = "us-east"
+    az     = "1"
+    uri    = "qemu+tcp://libvirt-us-east-1.acme.com/system"
+  }
+}
+
+locals {
+  instances = {
+    "1" = { region = "us-west", az = "1" },
+    "2" = { region = "us-east", az = "2" },
+  }
+}
+
+# Create a new domain with the same configuration on all regions
+resource "libvirt_domain" "test" {
+  for_each = local.instances
+  region = each.value.region
+  ...
+}
+```
 
 ## Environment variables
 

--- a/website/docs/r/cloudinit.html.markdown
+++ b/website/docs/r/cloudinit.html.markdown
@@ -43,6 +43,8 @@ Take also insipiration from ubuntu.tf https://github.com/dmacvicar/terraform-pro
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `pool` - (Optional) The pool where the resource will be created.
   If not given, the `default` pool will be used.
   For user_data, network_config and meta_data parameters have a look at upstream doc:

--- a/website/docs/r/coreos_ignition.html.markdown
+++ b/website/docs/r/coreos_ignition.html.markdown
@@ -35,6 +35,8 @@ resource "libvirt_ignition" "ignition" {
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `pool` - (Optional) The pool where the resource will be created.
   If not given, the `default` pool will be used.
 * `content` - (Required) This points to the source of the Ignition configuration

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -25,6 +25,8 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `description` - (Optional) The description for domain.
   Changing this forces a new resource to be created.
   This data is not used by libvirt in any way, it can contain any information the user wants.

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -104,6 +104,8 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `domain` - (Optional) The domain used by the DNS server.
 * `addresses` - (Optional) A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in
   CIDR notation.  This defines the subnets associated to that network.

--- a/website/docs/r/pool.html.markdown
+++ b/website/docs/r/pool.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
 * `type` - (Required) The type of the pool. Currently, only "dir" supported.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `path` - (Optional) The directory where the pool will keep all its volumes. This is only relevant to (and required by)
                       the "dir" type pools.
 

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by libvirt.
   Changing this forces a new resource to be created.
+* `region` - (Optional) The libvirt client region to create the resource to.
+* `az` - (Optional) The libvirt client availability-zone to create the resource to.
 * `pool` - (Optional) The storage pool where the resource will be created.
   If not given, the `default` storage pool will be used.
 * `source` - (Optional) If specified, the image will be uploaded into libvirt


### PR DESCRIPTION
This allows specifying multiple hosts (and so associated libvirt connections) to the same provider and tagging them by region and/or availability zones.
This way, it becomes possible to iterate resources over multiple libvirt instances as Terraform does not yet support iteration over providers.