### PR TITLE
fix: Apply some codespell[0] recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - network: add support for updating _dns.hosts_ (https://github.com/dmacvicar/terraform-provider-libvirt/pull/469)
 - network: add support for setting _SRV_ entries (https://github.com/dmacvicar/terraform-provider-libvirt/pull/460)
 - qemu-agent: do not contact the qemu agent if the domain is shutdown (https://github.com/dmacvicar/terraform-provider-libvirt/pull/474)
-- cli:  add `-version` flag (https://github.com/dmacvicar/terraform-provider-libvirt/pull/444)  
+- cli:  add `-version` flag (https://github.com/dmacvicar/terraform-provider-libvirt/pull/444)
 
 ## 0.5 (October 10, 2018)
 
@@ -39,7 +39,7 @@
 
 #### Networking
 
-* `dhcp` paramater is an optional parameter now, disabled by default. (https://github.com/dmacvicar/terraform-provider-libvirt/pull/385)
+* `dhcp` parameter is an optional parameter now, disabled by default. (https://github.com/dmacvicar/terraform-provider-libvirt/pull/385)
 * DNS forwarders were reworked. `localonly` option was added to libvirt-network (https://github.com/dmacvicar/terraform-provider-libvirt/commit/7651ee5824f77f0c7485736315d5a24762f85e60)
 * A datasource called `libvirt_network_dns_hosts_template` can be used to populate the `dns_host` attribute in `libvirt_network` resources. (https://github.com/dmacvicar/terraform-provider-libvirt/commit/a4d0ba6a319d8728cb5d6c10aae593bdd27da516)
 ___
@@ -51,7 +51,7 @@ ___
 ___
 #### Bugs
 
-* `netIface["bridge"]` now uses the correct value (https://github.com/dmacvicar/terraform-provider-libvirt/commit/2e93c78b2aea17b48639b3d613f12bfad851fd52) 
+* `netIface["bridge"]` now uses the correct value (https://github.com/dmacvicar/terraform-provider-libvirt/commit/2e93c78b2aea17b48639b3d613f12bfad851fd52)
 
 ## 0.4.3 (August 14, 2018)
 
@@ -91,5 +91,3 @@ HIGHLIGHTS:
 * The project now provides builds
 * The project now has a gitter.im channel
 * Integration tests are fixed and working again
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@
 
 - Creation and update resource. Consider to implement the `update` CRUD of terraform-libvirt  of an existing resource and also testing it in acceptance tests.
 For example if an user rerun 2 times a terraform apply with a different parameter, this call will update the existing resource with the new parameter.
-This step is not trivial and need some special care on the implementation. 
+This step is not trivial and need some special care on the implementation.
 An example of updating a resource in acceptance tests is here: https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/libvirt/resource_libvirt_cloud_init_test.go#L73
 
 ## Conventions
@@ -92,7 +92,7 @@ Then you can visualize the profile in html format:
 go tool cover -html=profile.cov
 ```
 
-The codecoverage can give you more usefull infos about were you could write a new tests for improving our acceptance tests.
+The codecoverage can give you more useful infos about were you could write a new tests for improving our acceptance tests.
 
 Feel free to read more about this on : https://blog.golang.org/cover.
 
@@ -116,4 +116,4 @@ https://godoc.org/github.com/libvirt/libvirt-go
 
 We try to keep easy issues for new contributors with label : https://github.com/dmacvicar/terraform-provider-libvirt/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22.
 
-Feel free to pick also other issues 
+Feel free to pick also other issues

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Until terraform-provider-libvirt 0.4.2, qemu-agent was used by default to get ne
 
 In current versions, we default to not to attempt connecting to it, and attempting to retrieve network interface information from the agent needs to be enabled explicitly with `qemu_agent = true`, further details [here](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/domain.html.markdown). Note that you still need to make sure the agent is running in the OS, and that is unrelated to this option.
 
-Note: when using bridge network configurations you need to enable the `qemu_agent = true`. otherwise you will not retrieve the ip adresses of domains. 
+Note: when using bridge network configurations you need to enable the `qemu_agent = true`. otherwise you will not retrieve the ip addresses of domains.
 
 Be aware that this variables may be subject to change again in future versions.
 
@@ -139,8 +139,8 @@ Be aware that this variables may be subject to change again in future versions.
 * [Openshift 4 Installer](https://github.com/openshift/installer)
   The Openshift 4 Installer uses Terraform for cluster orchestration and relies on terraform-provider-libvirt for
   libvirt platform.
-  
-* [terraform-libvirt-kubespray](https://github.com/MusicDin/terraform-kvm-kubespray) Terraform script for setting up HA kubernetes cluster using KVM/libvirt and Kubespray. 
+
+* [terraform-libvirt-kubespray](https://github.com/MusicDin/terraform-kvm-kubespray) Terraform script for setting up HA kubernetes cluster using KVM/libvirt and Kubespray.
 
 ## Authors
 

--- a/examples/v0.11/leap15/leap15.tf
+++ b/examples/v0.11/leap15/leap15.tf
@@ -3,7 +3,7 @@ provider "libvirt" {
   uri = "qemu:///system"
 }
 
-# adapt the build number 
+# adapt the build number
 resource "libvirt_volume" "leap15" {
   name   = "leap15-qcow2"
   pool   = "default"
@@ -19,7 +19,7 @@ data "template_file" "network_config" {
   template = "${file("${path.module}/network_config.cfg")}"
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field
@@ -68,4 +68,3 @@ resource "libvirt_domain" "domain-leap15" {
 }
 
 # IPs: use wait_for_lease true or after creation use terraform refresh and terraform show for the ips of domain
-

--- a/examples/v0.11/ubuntu/ubuntu-example.tf
+++ b/examples/v0.11/ubuntu/ubuntu-example.tf
@@ -25,7 +25,7 @@ data "template_file" "network_config" {
   template = "${file("${path.module}/network_config.cfg")}"
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field
@@ -75,4 +75,3 @@ resource "libvirt_domain" "domain-ubuntu" {
 }
 
 # IPs: use wait_for_lease true or after creation use terraform refresh and terraform show for the ips of domain
-

--- a/examples/v0.12/flatcar-linux/README.md
+++ b/examples/v0.12/flatcar-linux/README.md
@@ -12,7 +12,7 @@ Terraform v0.12.6
 
 ### Flatcar Linux
 
-Ths example is strongly inspired by the CoreOS [example](https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.12/coreos).
+This example is strongly inspired by the CoreOS [example](https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.12/coreos).
 
 QEMU-agent is not used, network is configured with static IP to keep things simple.
 
@@ -32,7 +32,7 @@ $ virsh net-dumpxml --network cluster-net
 
 Do not forget to download Flatcar Linux image and to add it the pool of your [choice](https://docs.flatcar-linux.org/os/booting-with-libvirt/#choosing-a-channel).
 
-You can specify the number of hosts by updating: 
+You can specify the number of hosts by updating:
 ```hcl
 variable "hosts" {
   default = 2
@@ -52,4 +52,3 @@ resource "libvirt_domain" "node" {
   ...
 }
 ```
-

--- a/examples/v0.12/tubleweed/tubleweed.tf
+++ b/examples/v0.12/tubleweed/tubleweed.tf
@@ -3,7 +3,7 @@ provider "libvirt" {
   uri = "qemu:///system"
 }
 
-# adapt the build number 
+# adapt the build number
 resource "libvirt_volume" "tubleweed" {
   name   = "tubleweed"
   pool   = "default"
@@ -19,7 +19,7 @@ data "template_file" "network_config" {
   template = file("${path.module}/network_config.cfg")
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field

--- a/examples/v0.12/ubuntu/ubuntu-example.tf
+++ b/examples/v0.12/ubuntu/ubuntu-example.tf
@@ -25,7 +25,7 @@ data "template_file" "network_config" {
   template = file("${path.module}/network_config.cfg")
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field

--- a/examples/v0.13/flatcar-linux/README.md
+++ b/examples/v0.13/flatcar-linux/README.md
@@ -12,7 +12,7 @@ Terraform v0.12.6
 
 ### Flatcar Linux
 
-Ths example is strongly inspired by the CoreOS [example](https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.12/coreos).
+This example is strongly inspired by the CoreOS [example](https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples/v0.12/coreos).
 
 QEMU-agent is not used, network is configured with static IP to keep things simple.
 
@@ -32,7 +32,7 @@ $ virsh net-dumpxml --network cluster-net
 
 Do not forget to download Flatcar Linux image and to add it the pool of your [choice](https://docs.flatcar-linux.org/os/booting-with-libvirt/#choosing-a-channel).
 
-You can specify the number of hosts by updating: 
+You can specify the number of hosts by updating:
 ```hcl
 variable "hosts" {
   default = 2
@@ -52,4 +52,3 @@ resource "libvirt_domain" "node" {
   ...
 }
 ```
-

--- a/examples/v0.13/tumbleweed/tumbleweed.tf
+++ b/examples/v0.13/tumbleweed/tumbleweed.tf
@@ -13,7 +13,7 @@ provider "libvirt" {
   uri = "qemu:///system"
 }
 
-# adapt the build number 
+# adapt the build number
 resource "libvirt_volume" "tumbleweed" {
   name   = "tumbleweed"
   pool   = "default"
@@ -29,7 +29,7 @@ data "template_file" "network_config" {
   template = file("${path.module}/network_config.cfg")
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field

--- a/examples/v0.13/ubuntu/ubuntu-example.tf
+++ b/examples/v0.13/ubuntu/ubuntu-example.tf
@@ -35,7 +35,7 @@ data "template_file" "network_config" {
   template = file("${path.module}/network_config.cfg")
 }
 
-# for more info about paramater check this out
+# for more info about parameter check this out
 # https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/r/cloudinit.html.markdown
 # Use CloudInit to add our ssh-key to the instance
 # you can add also meta_data field

--- a/libvirt/helpers_test.go
+++ b/libvirt/helpers_test.go
@@ -260,7 +260,7 @@ func testAccCheckLibvirtNetworkBridge(resourceName string, bridgeName string) re
 		}
 
 		if networkDef.Bridge.Name != bridgeName {
-			return fmt.Errorf("fail: network brigde property were not set correctly")
+			return fmt.Errorf("fail: network bridge property were not set correctly")
 		}
 
 		return nil

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -623,7 +623,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	// We save runnig state to not mix what we have and what we want
+	// We save running state to not mix what we have and what we want
 	requiredStatus := d.Get("running")
 
 	err = resourceLibvirtDomainRead(d, meta)

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -1098,7 +1098,7 @@ func testAccCheckLibvirtURLDisk(u *url.URL, domain *libvirt.Domain) resource.Tes
 		virConn := testAccProvider.Meta().(*Client).libvirt
 		domainDef, err := getXMLDomainDefFromLibvirt(virConn, *domain)
 		if err != nil {
-			return fmt.Errorf("Error getting libvirt XML defintion from existing libvirt domain: %s", err)
+			return fmt.Errorf("Error getting libvirt XML definition from existing libvirt domain: %s", err)
 		}
 
 		disks := domainDef.Devices.Disks
@@ -1129,7 +1129,7 @@ func testAccCheckLibvirtMultiISODisks(domain *libvirt.Domain) resource.TestCheck
 		virConn := testAccProvider.Meta().(*Client).libvirt
 		domainDef, err := getXMLDomainDefFromLibvirt(virConn, *domain)
 		if err != nil {
-			return fmt.Errorf("Error getting libvirt XML defintion from existing libvirt domain: %s", err)
+			return fmt.Errorf("Error getting libvirt XML definition from existing libvirt domain: %s", err)
 		}
 
 		disks := domainDef.Devices.Disks
@@ -1671,7 +1671,7 @@ EOF
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
 					testAccCheckLibvirtDomainDescription(&domain, func(domainDef libvirtxml.Domain) error {
 						if domainDef.Devices.Interfaces[0].Model.Type != "e1000" {
-							return fmt.Errorf("Expecting XSLT to tranform network model to e1000")
+							return fmt.Errorf("Expecting XSLT to transform network model to e1000")
 						}
 						return nil
 					}),
@@ -1745,7 +1745,7 @@ EOF
 }
 
 // changed whitespace in the xslt should create an empty plan
-// as the supress diff function should take care of seeing they are equivalent
+// as the suppress diff function should take care of seeing they are equivalent
 func TestAccLibvirtDomain_XSLT_Whitespace(t *testing.T) {
 	skipIfPrivilegedDisabled(t)
 
@@ -1824,7 +1824,7 @@ EOF
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
 					testAccCheckLibvirtDomainDescription(&domain, func(domainDef libvirtxml.Domain) error {
 						if domainDef.Devices.Interfaces[0].Model.Type != "e1000" {
-							return fmt.Errorf("Expecting XSLT to tranform network model to e1000")
+							return fmt.Errorf("Expecting XSLT to transform network model to e1000")
 						}
 						return nil
 					}),
@@ -1837,7 +1837,7 @@ EOF
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
 					testAccCheckLibvirtDomainDescription(&domain, func(domainDef libvirtxml.Domain) error {
 						if domainDef.Devices.Interfaces[0].Model.Type != "e1000" {
-							return fmt.Errorf("Expecting XSLT to tranform network model to e1000")
+							return fmt.Errorf("Expecting XSLT to transform network model to e1000")
 						}
 						return nil
 					}),

--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -391,7 +391,7 @@ func resourceLibvirtNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		// if addresses are given set dhcp for these
 		ips, err := getIPsFromResource(d)
 		if err != nil {
-			return fmt.Errorf("could not set DHCP from adresses '%s'", err)
+			return fmt.Errorf("could not set DHCP from addresses '%s'", err)
 		}
 		networkDef.IPs = ips
 
@@ -644,7 +644,7 @@ func resourceLibvirtNetworkDelete(d *schema.ResourceData, meta interface{}) erro
 
 	network, err := virConn.NetworkLookupByUUID(uuid)
 	if err != nil {
-		return fmt.Errorf("ehen destroying libvirt network: error retrieving %s", err)
+		return fmt.Errorf("when destroying libvirt network: error retrieving %s", err)
 	}
 
 	activeInt, err := virConn.NetworkIsActive(network)

--- a/libvirt/utils_domain_def.go
+++ b/libvirt/utils_domain_def.go
@@ -18,7 +18,7 @@ func getGuestForArchType(caps libvirtxml.Caps, arch string, virttype string) (li
 			return guest, nil
 		}
 	}
-	return libvirtxml.CapsGuest{}, fmt.Errorf("[DEBUG] Could not find any guests for architecure type %s/%s", virttype, arch)
+	return libvirtxml.CapsGuest{}, fmt.Errorf("[DEBUG] Could not find any guests for architecture type %s/%s", virttype, arch)
 }
 
 func lookupMachine(machines []libvirtxml.CapsGuestMachine, targetmachine string) string {
@@ -71,7 +71,7 @@ func getOriginalMachineName(caps libvirtxml.Caps, arch string, virttype string, 
 	return targetmachine, nil // There wasn't a canonical mapping to this
 }
 
-// as kernal args allow duplicate keys, we use a list of maps
+// as kernel args allow duplicate keys, we use a list of maps
 // we jump to a next map as soon as we find a duplicate
 // key
 func splitKernelCmdLine(cmdLine string) ([]map[string]string, error) {

--- a/libvirt/utils_domain_def_test.go
+++ b/libvirt/utils_domain_def_test.go
@@ -116,12 +116,12 @@ func TestGetHostCapabilties(t *testing.T) {
 
 	caps, err := getHostCapabilities(conn)
 	if err != nil {
-		t.Errorf("Can't get host capabilties")
+		t.Errorf("Can't get host capabilities")
 	}
 	if caps.Host.UUID == "" {
 		t.Errorf("Host has no UUID!")
 	}
 
 	elapsed := time.Since(start)
-	t.Logf("[DEBUG] Get host capabilites took %s", elapsed)
+	t.Logf("[DEBUG] Get host capabilities took %s", elapsed)
 }

--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -21,7 +21,7 @@ func newCopier(virConn *libvirt.Libvirt, volume *libvirt.StorageVol, size uint64
 			bytesCopied, err := io.CopyBuffer(w, src, buffer)
 
 			// if we get unexpected EOF this mean that connection was closed suddently from server side
-			// the problem is not on the plugin but on server hosting currupted images
+			// the problem is not on the plugin but on server hosting corrupted images
 			if err == io.ErrUnexpectedEOF {
 				return fmt.Errorf("error: transfer was unexpectedly closed from the server while downloading. Please try again later or check the server hosting sources")
 			}

--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -25,7 +25,7 @@ const (
 
 // This is the function we use to detect if the XSLT attribute itself changed
 // As we don't want to recreate resources when the XSLT is changed with whitespace,
-// we specify the diff supress function as the result of applying the identity
+// we specify the diff suppress function as the result of applying the identity
 // transform to the xslt, stripping whitespace
 // See https://www.terraform.io/docs/extend/schemas/schema-behaviors.html#diffsuppressfunc
 func xsltDiffSupressFunc(k, old, new string, d *schema.ResourceData) bool {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -239,7 +239,7 @@ The `disk` block supports:
 * `volume_id` - (Optional) The volume id to use for this disk.
 * `url` - (Optional) The http url to use as the block device for this disk (read-only)
 * `file` - (Optional) The filename to use as the block device for this disk (read-only)
-* `block_device` - (Optional) The path to the host device to use as the block device for this disk. 
+* `block_device` - (Optional) The path to the host device to use as the block device for this disk.
 
 While `volume_id`, `url`, `file` and `block_device` are optional, it is intended that you use one of them.
 
@@ -506,7 +506,7 @@ resource "libvirt_domain" "my_machine" {
 
 ### Sharing filesystem between libvirt host and guest
 
-The optional `filesystem` block allows to define one or more [filesytem](https://libvirt.org/formatdomain.html#elementsFilesystems)
+The optional `filesystem` block allows to define one or more [filesystem](https://libvirt.org/formatdomain.html#elementsFilesystems)
 entries to be added to the domain. This allows to share a directory of the libvirtd
 host with the guest.
 

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -41,7 +41,7 @@ resource "libvirt_network" "kube_network" {
   # (Optional) DNS configuration
   dns {
     # (Optional, default false)
-    # Set to true, if no other option is specified and you still want to 
+    # Set to true, if no other option is specified and you still want to
     # enable dns.
     enabled = true
     # (Optional, default false)
@@ -57,8 +57,8 @@ resource "libvirt_network" "kube_network" {
     # forwarders {
     #     address = "my address"
     #     domain = "my domain"
-    #  } 
-    # 
+    #  }
+    #
 
     # (Optional) one or more DNS host entries.  Both of
     # "ip" and "hostname" must be specified.  The format is:
@@ -70,7 +70,7 @@ resource "libvirt_network" "kube_network" {
     #     hostname = "my_hostname"
     #     ip = "my.ip.address.2"
     #   }
-    # 
+    #
 
     # (Optional) one or more static routes.
     # "cidr" and "gateway" must be specified. The format is:
@@ -187,8 +187,8 @@ resource "libvirt_network" "k8snet" {
 }
 ```
 
-* `dhcp` - (Optional) DHCP configuration. 
-   You need to use it in conjuction with the adresses variable.
+* `dhcp` - (Optional) DHCP configuration.
+   You need to use it in conjunction with the addresses variable.
   * `enabled` - (Optional) when false, disable the DHCP server
 ```hcl
 				resource "libvirt_network" "test_net" {


### PR DESCRIPTION
Fix few typos in code/documentation.

I've been using codespell[0] on some of my code that depend on your provider and found few typos so I decided to provide fix you can apply.

Thanks for the project its very useful!

[0] https://github.com/codespell-project/codespell