### PR TITLE
SSH config support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hooklift/iso9660 v1.0.0
+	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351
 	github.com/mattn/goveralls v0.0.11
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.14.0

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -126,7 +126,7 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 			log.Printf("[DEBUG] ssh user: system username")
 			u, err := user.Current()
 			if err != nil {
-				return nil, fmt.Errorf("unable to get username: %v", err)
+				return nil, fmt.Errorf("unable to get username: %w", err)
 			}
 			sshu = u.Username
 		}

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"strings"
 
+	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -17,6 +18,7 @@ const (
 	defaultSSHPort           = "22"
 	defaultSSHKeyPath        = "${HOME}/.ssh/id_rsa"
 	defaultSSHKnownHostsPath = "${HOME}/.ssh/known_hosts"
+	defaultSSHConfigFile     = "${HOME}/.ssh/config"
 	defaultSSHAuthMethods    = "agent,privkey"
 )
 
@@ -78,6 +80,17 @@ func (u *ConnectionURI) parseAuthMethods() []ssh.AuthMethod {
 }
 
 func (u *ConnectionURI) dialSSH() (net.Conn, error) {
+
+	sshConfigFile, err := os.Open(os.ExpandEnv(defaultSSHConfigFile))
+	if err != nil {
+		log.Printf("[WARN] Failed to open ssh config file: %v", err)
+	}
+
+	sshcfg, err := ssh_config.Decode(sshConfigFile)
+	if err != nil {
+		log.Printf("[WARN] Failed to parse ssh config file: %v", err)
+	}
+
 	authMethods := u.parseAuthMethods()
 	if len(authMethods) < 1 {
 		return nil, fmt.Errorf("could not configure SSH authentication methods")
@@ -107,11 +120,17 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 
 	username := u.User.Username()
 	if username == "" {
-		u, err := user.Current()
+		sshu, err := sshcfg.Get(u.Host, "User")
+		log.Printf("[DEBUG] SSH User: %v", sshu)
 		if err != nil {
-			return nil, err
+			log.Printf("[DEBUG] ssh user: system username")
+			u, err := user.Current()
+			if err != nil {
+				return nil, fmt.Errorf("unable to get username: %v", err)
+			}
+			sshu = u.Username
 		}
-		username = u.Username
+		username = sshu
 	}
 
 	cfg := ssh.ClientConfig{


### PR DESCRIPTION
This adds native SSH configuration support, with some minor caveats:

- It's not perfect. OpenSSH and Kevin Burke's ssh_config library behave slightly differently in compiling results. OpenSSH wants least to most specific, Burke's library wants most specific to least.
- It's ugly, but it does work. The `ssh.go` dialer could use some additional love.
- It also supports alternate ports in the SSH configuration file, but not very intelligently.

This DOES allow you to recycle configurations in the provider section, without setting a static username on the URI. So, if users are managed via PAM or LDAP access to the socket, it should just work.


