### PR TITLE
Fix network host entry for IPv6 addresses

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -758,7 +758,7 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 						}
 
 						log.Printf("[INFO] Adding IP/MAC/host=%s/%s/%s to %s", ip.String(), mac, hostname, network.Name)
-						if err := updateOrAddHost(virConn, network, ip.String(), mac, hostname); err != nil {
+						if err := updateOrAddHost(virConn, network, ip, mac, hostname); err != nil {
 							return err
 						}
 					}

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -3,6 +3,7 @@ package libvirt
 import (
 	"bytes"
 	"encoding/xml"
+	"net"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -129,7 +130,7 @@ func TestGetHostXMLDesc(t *testing.T) {
 	mac := "XX:YY:ZZ"
 	name := "localhost"
 
-	data := getHostXMLDesc(ip, mac, name)
+	data := getHostXMLDesc(net.ParseIP(ip), mac, name)
 
 	dd := libvirtxml.NetworkDHCPHost{}
 	err := xml.Unmarshal([]byte(data), &dd)
@@ -211,9 +212,9 @@ func TestGetNetworkIdx(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			net, _ := newDefNetworkFromXML(tc.networkXML)
+			network, _ := newDefNetworkFromXML(tc.networkXML)
 
-			idx, _ := getNetworkIdx(&net, tc.ipAddress)
+			idx, _ := getNetworkIdx(&network, net.ParseIP(tc.ipAddress))
 			if idx != tc.expectedIdx {
 				t.Logf("expected network idx: %d, got %d\n", tc.expectedIdx, idx)
 				t.Fail()

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -658,7 +658,13 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 				address := addressI.(string)
 				log.Printf("[INFO] Finally adding IP/MAC/host=%s/%s/%s", address, mac, pending.hostname)
 
-				err = updateOrAddHost(virConn, network, address, mac, pending.hostname)
+				var err error
+				ip := net.ParseIP(address)
+				if ip == nil {
+					err = fmt.Errorf("not an IP address: %s", address)
+				} else {
+					err = updateOrAddHost(virConn, network, ip, mac, pending.hostname)
+				}
 				if err != nil {
 					log.Printf("Could not add IP/MAC/host=%s/%s/%s: %s", address, mac, pending.hostname, err)
 				}
@@ -770,7 +776,7 @@ func resourceLibvirtDomainUpdate(d *schema.ResourceData, meta interface{}) error
 
 				log.Printf("[INFO] Updating IP/MAC/host=%s/%s/%s in '%s' network", ip.String(), mac, hostname, network.Name)
 
-				if err := updateOrAddHost(virConn, network, ip.String(), mac, hostname); err != nil {
+				if err := updateOrAddHost(virConn, network, ip, mac, hostname); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
https://gitlab.com/libvirt/libvirt/-/blob/v8.1.0/src/conf/network_conf.c#L516-L522
https://libvirt.org/formatnetwork.html#elementsAddress

The IPv6 host element differs slightly from that for IPv4: there is no mac attribute since a MAC address has no defined meaning in IPv6.