### PR TITLE
tls: fix typo, use clientCertSearchPath for clientcert.pem

### DIFF
--- a/libvirt/uri/tls.go
+++ b/libvirt/uri/tls.go
@@ -81,7 +81,7 @@ func (u *ConnectionURI) tlsConfig() (*tls.Config, error) {
 		// non-root also looks in $HOME/.pki first
 		if !root {
 			caCertSearchPath = append([]string{os.ExpandEnv(defaultUserPKIPath)}, caCertSearchPath...)
-			clientCertSearchPath = append([]string{os.ExpandEnv(defaultUserPKIPath)}, clientKeySearchPath...)
+			clientCertSearchPath = append([]string{os.ExpandEnv(defaultUserPKIPath)}, clientCertSearchPath...)
 			clientKeySearchPath = append([]string{os.ExpandEnv(defaultUserPKIPath)}, clientKeySearchPath...)
 		}
 	}


### PR DESCRIPTION
`clientcert.pem` is located in `/etc/pki/libvirt/clientcert.pem` as per
https://www.libvirt.org/tlscerts.html

Fixes

```go
level=error msg="Error: failed to dial libvirt: can't locate resource 'clientcert.pem' in [/home/kni/.pki/libvirt /etc/pki/libvirt/private]: file does not exist"
```
