### PR TITLE
Use schema.TypeMap for metadata

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -51,7 +51,7 @@ func resourceLibvirtDomain() *schema.Resource {
 				ForceNew: true,
 			},
 			"metadata": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
 			},


### PR DESCRIPTION
I'm currently using the metadata field in ```openstack_compute_instance_v2```  from the  ```terraform-provider-openstack/openstack``` provider to set the metadata I need to use an instance together with  Ansible.

```
  metadata = {
     group = "ansiblegroup"
     ansible_user = "debian"
   }
```

I would like to do the same with ```dmacvicar/terraform-provider-libvirt```. But unfortunately the metadata type in ```dmacvicar/terraform-provider-libvirt``` is currently set to ```TypeString```. This PR changes the type to ```TypeMap``` to make terraform deployments between openstack and libvirt behave consistently regarding metadata.  
