### PR TITLE
Remove SchemaConfigModeAttr mode in disk block

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -147,7 +147,6 @@ func resourceLibvirtDomain() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				ForceNew:   true,
-				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"volume_id": {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -281,43 +281,6 @@ resource "libvirt_domain" "domain1" {
 }
 ```
 
-Also note that the `disk` block is actually a list of maps, so it is possible to
-declare several of them by using either the literal list and map syntax as in
-the following examples:
-
-```hcl
-resource "libvirt_domain" "my_machine" {
-  ...
-  disk {
-    volume_id = libvirt_volume.volume1.id
-  }
-  disk {
-    volume_id = libvirt_volume.volume2.id
-  }
-}
-```
-
-```hcl
-resource "libvirt_domain" "my_machine" {
-  ...
-  disk = [
-    {
-      volume_id = libvirt_volume.volume1.id
-    },
-    {
-      volume_id = libvirt_volume.volume2.id
-    }
-  ]
-}
-```
-
-```hcl
-resource "libvirt_domain" "my_machine" {
-  ...
-  disk = [var.disk_map_list]
-}
-```
-
 ### Handling network interfaces
 
 The `network_interface` specifies a network interface that can be connected


### PR DESCRIPTION
Fix #728 

**This is a breaking change.** 

With `schema.SchemaConfigModeAttr`, user can use the list syntax for `disk` attribute but I think it creates more problems than what it solves.  There is an alternative syntax that's available in README to replacing this behavior. More importantly, turn this on will break json syntax as reported in #728 and potentially break CDKTF (https://www.terraform.io/cdktf) as well.
