### PR TITLE
Make 'option_value' for dnsmasq  optional

### DIFF
--- a/libvirt/data_source_libvirt_network.go
+++ b/libvirt/data_source_libvirt_network.go
@@ -185,7 +185,7 @@ func datasourceLibvirtNetworkDnsmasqOptionsTemplate() *schema.Resource {
 			},
 			"option_value": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"rendered": {
 				Type: schema.TypeMap,

--- a/libvirt/data_source_libvirt_network_test.go
+++ b/libvirt/data_source_libvirt_network_test.go
@@ -80,7 +80,6 @@ func TestAccLibvirtNetworkDataSource_DNSDnsmasqTemplate(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-
 			{
 				Config: `data "libvirt_network_dnsmasq_options_template" "options" {
   count = 2
@@ -92,6 +91,14 @@ func TestAccLibvirtNetworkDataSource_DNSDnsmasqTemplate(t *testing.T) {
 					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.0", "option_value", "/.apps.tt0.testing/1.1.1.1"),
 					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.1", "option_name", "address"),
 					checkTemplate("data.libvirt_network_dnsmasq_options_template.options.1", "option_value", "/.apps.tt1.testing/1.1.1.2"),
+				),
+			},
+			{
+				Config: `data "libvirt_network_dnsmasq_options_template" "noval_options" {
+   option_name = "no-hosts"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					checkTemplate("data.libvirt_network_dnsmasq_options_template.noval_options", "option_name", "no-hosts"),
 				),
 			},
 		},

--- a/libvirt/network.go
+++ b/libvirt/network.go
@@ -184,12 +184,18 @@ func getDNSMasqOptionFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkD
 	dnsmasqOptionPrefix := "dnsmasq_options.0"
 	if dnsmasqOptionCount, ok := d.GetOk(dnsmasqOptionPrefix + ".options.#"); ok {
 		for i := 0; i < dnsmasqOptionCount.(int); i++ {
+			var optionString string
 			dnsmasqOptionsPrefix := fmt.Sprintf(dnsmasqOptionPrefix+".options.%d", i)
 
 			optionName := d.Get(dnsmasqOptionsPrefix + ".option_name").(string)
-			optionValue := d.Get(dnsmasqOptionsPrefix + ".option_value").(string)
+			optionValue, ok := d.GetOk(dnsmasqOptionsPrefix + ".option_value")
+			if ok {
+			   optionString = optionName + "=" + optionValue.(string)
+			} else {
+			   optionString = optionName
+			}
 			dnsmasqOption = append(dnsmasqOption, libvirtxml.NetworkDnsmasqOption{
-				Value: optionName + "=" + optionValue,
+				Value: optionString,
 			})
 		}
 	}

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -653,6 +653,9 @@ func TestAccLibvirtNetwork_DnsmasqOptions(t *testing.T) {
 							option_name = "address"
 							option_value = "/.apps.tt.testing/1.1.1.2"
 						}
+						options {
+							option_name = "no-hosts"
+						}
 					}
 				}`, randomNetworkResource, randomNetworkName),
 				Check: resource.ComposeTestCheckFunc(
@@ -660,9 +663,11 @@ func TestAccLibvirtNetwork_DnsmasqOptions(t *testing.T) {
 					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dnsmasq_options.0.options.0.option_value", "/tt.testing/1.1.1.1"),
 					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dnsmasq_options.0.options.1.option_name", "address"),
 					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dnsmasq_options.0.options.1.option_value", "/.apps.tt.testing/1.1.1.2"),
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dnsmasq_options.0.options.2.option_name", "no-hosts"),
 					testAccCheckDnsmasqOptions("libvirt_network."+randomNetworkResource, []libvirtxml.NetworkDnsmasqOption{
 						{Value: "server=/tt.testing/1.1.1.1"},
 						{Value: "address=/.apps.tt.testing/1.1.1.2"},
+						{Value: "no-hosts"},
 					}),
 				),
 			},

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -82,11 +82,15 @@ resource "libvirt_network" "kube_network" {
 
   # (Optional) Dnsmasq options configuration
   dnsmasq_options {
-    # (Optional) one or more option entries.  Both of
-    # "option_name" and "option_value" must be specified.  The format is:
+    # (Optional) one or more option entries.
+    # "option_name" muast be specified while "option_value" is
+	# optional to also support value-less options.  The format is:
     # options  {
     #     option_name = "server"
     #     option_value = "/base.domain/my.ip.address.1"
+    #   }
+    # options  {
+    #     option_name = "no-hosts"
     #   }
     # options {
     #     option_name = "address"
@@ -205,7 +209,8 @@ resource "libvirt_network" "k8snet" {
   You need to provide a list of option name and value pairs.
 
   * `options` - (Optional) a Dnsmasq option entry block. You can have one or more of these
-   blocks in your definition. You must specify both `option_name` and `option_value`.
+   blocks in your definition. You must specify `option_name` while `option_value` is
+   optional to support value-less options.
 
   An example of setting Dnsmasq options (using Dnsmasq option templates) follows:
 


### PR DESCRIPTION
To support value-less dnsmasq options ('no-hosts') this change set makes `option_value` optional in which case `option_name` is inserted in the dnsmasq.conf without traling '='. 
While this change invalidates the separation into 'name' and 'value' to some extend, it retains compatibility.
An update to the documentation and test cases are also included. 