### PR TITLE
Certificate-based SSH authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,4 @@ require (
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 
-replace golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce => github.com/dmacvicar/golang-x-crypto v0.0.0-20220126233154-a96af8f07497
-
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
+golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -62,7 +62,31 @@ func (u *ConnectionURI) parseAuthMethods() []ssh.AuthMethod {
 			if err != nil {
 				log.Printf("[ERROR] Failed to parse ssh key: %v", err)
 			}
-			result = append(result, ssh.PublicKeys(signer))
+
+			// Use SSH certificate if any
+			sshCertPath := sshKeyPath + "-cert.pub"
+			sshCert, err := ioutil.ReadFile(os.ExpandEnv(sshCertPath))
+			if err != nil {
+				// Log and ignore error if no certificate is found: we just continue using private key only
+				log.Printf("[ERROR] Failed to read ssh certificate: %v", err)
+				result = append(result, ssh.PublicKeys(signer))
+				continue
+			} else {
+				publiKeyCert, _, _, _, err := ssh.ParseAuthorizedKey(sshCert)
+				if err != nil {
+					// Log and ignore error, if not a parseable certificate: we just continue using private key only
+					log.Printf("[ERROR] Failed to parse ssh certificate: %v", err)
+					result = append(result, ssh.PublicKeys(signer))
+					continue
+				} else {
+					certSigner, err := ssh.NewCertSigner(publiKeyCert.(*ssh.Certificate), signer)
+					if err != nil {
+						log.Printf("[ERROR] Failed to use ssh certificate: %v", err)
+					} else {
+						result = append(result, ssh.PublicKeys(certSigner))
+					}
+				}
+			}
 		case "ssh-password":
 			if sshPassword, ok := u.User.Password(); ok {
 				result = append(result, ssh.Password(sshPassword))


### PR DESCRIPTION
## Content
This PR intends to close https://github.com/dmacvicar/terraform-provider-libvirt/issues/957

It adds support for certificate-based SSH authentication, when a certificate is present. Certificate name is built according to SSH following convention:

|Private key file name| Certificate file name|
--- | ---
|id_rsa|id_rsa-cert.pub|


## Notes
- Certificate-based authentication takes precedence over traditional pubkey only authentication: a conforming SSH-certificate will be used.
- To work properly, this feature uses the upstream golang.org/x/crypto/ssh. Build should not fail against github.com/dmacvicar/golang-x-crypto, but PR will not work properly.