### PR TITLE
Update reference to Kubitect project

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Be aware that this variables may be subject to change again in future versions.
   The Openshift 4 Installer uses Terraform for cluster orchestration and relies on terraform-provider-libvirt for
   libvirt platform.
   
-* [terraform-libvirt-kubespray](https://github.com/MusicDin/terraform-kvm-kubespray) Terraform script for setting up HA kubernetes cluster using KVM/libvirt and Kubespray. 
+* [Kubitect](https://github.com/MusicDin/kubitect) - a CLI tool for deploying and managing Kubernetes clusters on libvirt platform.
 
 ## Authors
 


### PR DESCRIPTION
Hi, some time ago I added a reference to the project `terraform-kvm-kubespray` in the readme file under *Upstream projects using terraform-libvirt*.

Since the project has been renamed since then and has evolved from a plain Terraform script into a CLI tool, I would just like to update the reference so that it is not misleading.