### PR TITLE
modify the volume size type to support units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-LDFLAGS += -X main.version=$$(git describe --always --abbrev=40 --dirty)
+HOSTNAME=registry.terraform.io
+NAMESPACE=dmacvicar
+NAME=libvirt
+BINARY=terraform-provider-${NAME}
+VERSION?=$(shell git describe --tags | sed -E 's,^v,,g')
+OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
+
+LDFLAGS += -X main.version=${VERSION}
 
 # default  args for tests
 TEST_ARGS_DEF := -covermode=count -coverprofile=profile.cov
@@ -10,8 +17,12 @@ terraform-provider-libvirt:
 
 build: terraform-provider-libvirt
 
-install:
-	go install -ldflags "${LDFLAGS}"
+install: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+
+uninstall:
+	rm -rf ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}
 
 # unit tests
 # usage:

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -32,7 +32,7 @@ func resourceLibvirtVolume() *schema.Resource {
 				ForceNew: true,
 			},
 			"size": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -165,7 +165,7 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 
 		// if size is given, set it to the specified value
 		if _, ok := d.GetOk("size"); ok {
-			volumeDef.Capacity.Value = uint64(d.Get("size").(int))
+			volumeDef.Capacity.Value = sizeFromString(d.Get("size").(string))
 		}
 
 		// first handle whether it has a backing image

--- a/libvirt/utils_volume.go
+++ b/libvirt/utils_volume.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -64,4 +65,39 @@ func timeFromEpoch(str string) time.Time {
 	s, _ = strconv.Atoi(ts[0])
 
 	return time.Unix(int64(s), int64(ns))
+}
+
+func sizeFromString(str string) uint64 {
+	r := regexp.MustCompile(`^(?i)(\d+)([bkmgt]i?)?b?$`)
+	parts := r.FindStringSubmatch(str)
+	if len(parts) != 3 {
+		return 0
+	}
+	size, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	switch strings.ToLower(parts[2]) {
+	case "", "b", "bi":
+		size = size * 1
+	case "k":
+		size = size * 1000
+	case "m":
+		size = size * 1000 * 1000
+	case "g":
+		size = size * 1000 * 1000 * 1000
+	case "t":
+		size = size * 1000 * 1000 * 1000 * 1000
+	case "ki":
+		size = size * 1024
+	case "mi":
+		size = size * 1024 * 1024
+	case "gi":
+		size = size * 1024 * 1024 * 1024
+	case "ti":
+		size = size * 1024 * 1024 * 1024 * 1024
+	default:
+		return 0
+	}
+	return size
 }

--- a/libvirt/utils_volume_test.go
+++ b/libvirt/utils_volume_test.go
@@ -22,3 +22,69 @@ func TestTimeFromEpoch(t *testing.T) {
 		t.Fatalf("expected timestamp '123.456', got %v.%v", ts.Unix(), ts.Nanosecond())
 	}
 }
+
+func TestSizeFromString(t *testing.T) {
+	if size := sizeFromString(""); size != 0 {
+		t.Fatalf("expected size '0', got %v", size)
+	}
+
+	if size := sizeFromString("abc"); size != 0 {
+		t.Fatalf("expected size '0', got %v", size)
+	}
+
+	if size := sizeFromString("1"); size != 1 {
+		t.Fatalf("expected size '1', got %v", size)
+	}
+
+	if size := sizeFromString("1B"); size != 1 {
+		t.Fatalf("expected size '1', got %v", size)
+	}
+
+	if size := sizeFromString("1KB"); size != 1000 {
+		t.Fatalf("expected size '1000', got %v", size)
+	}
+
+	if size := sizeFromString("1k"); size != 1000 {
+		t.Fatalf("expected size '1000', got %v", size)
+	}
+
+	if size := sizeFromString("1m"); size != 1000000 {
+		t.Fatalf("expected size '1000000', got %v", size)
+	}
+
+	if size := sizeFromString("1g"); size != 1000000000 {
+		t.Fatalf("expected size '1000000000', got %v", size)
+	}
+
+	if size := sizeFromString("1t"); size != 1000000000000 {
+		t.Fatalf("expected size '1000000000000', got %v", size)
+	}
+
+	if size := sizeFromString("1000000000000"); size != 1000000000000 {
+		t.Fatalf("expected size '1000000000000', got %v", size)
+	}
+
+	if size := sizeFromString("1KiB"); size != 1024 {
+		t.Fatalf("expected size '1024', got %v", size)
+	}
+
+	if size := sizeFromString("1ki"); size != 1024 {
+		t.Fatalf("expected size '1024', got %v", size)
+	}
+
+	if size := sizeFromString("1mi"); size != 1048576 {
+		t.Fatalf("expected size '1048576', got %v", size)
+	}
+
+	if size := sizeFromString("1gi"); size != 1073741824 {
+		t.Fatalf("expected size '1073741824', got %v", size)
+	}
+
+	if size := sizeFromString("1ti"); size != 1099511627776 {
+		t.Fatalf("expected size '1099511627776', got %v", size)
+	}
+
+	if size := sizeFromString("1099511627776"); size != 1099511627776 {
+		t.Fatalf("expected size '1099511627776', got %v", size)
+	}
+}


### PR DESCRIPTION
This allows us to specify the volume size as:

```hcl
resource "libvirt_volume" "example_root" {
  size = "123GiB"
}
```

Currently, the units are case-insensitive, should they be case-sensitive?

Maybe also expand this to the other size/capacity properties like the memory size?

Please note that this is still missing the documentation.