### PR TITLE
TPM active PCR banks & domain firmware type

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -391,6 +391,10 @@ func setFirmware(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 			}
 		}
 	}
+
+	if firmware, ok := d.GetOk("firmware_type"); ok {
+		domainDef.OS.Firmware = firmware.(string)
+	}
 }
 
 func setBootDevices(d *schema.ResourceData, domainDef *libvirtxml.Domain) {

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -844,6 +844,30 @@ func setTPMs(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 			if backendPersistentState, ok := d.GetOk(prefix + ".backend_persistent_state"); ok {
 				tpm.Backend.Emulator.PersistentState = formatBoolYesNo(backendPersistentState.(bool))
 			}
+
+			if _, ok := d.GetOk(prefix + ".backend_active_pcr_banks"); ok {
+				tpm.Backend.Emulator.ActivePCRBanks = &libvirtxml.DomainTPMBackendPCRBanks{}
+				if sha1Active, ok := d.GetOk(prefix + ".backend_active_pcr_banks.0.sha1"); ok {
+					if sha1Active.(bool) {
+						tpm.Backend.Emulator.ActivePCRBanks.SHA1 = &libvirtxml.DomainTPMBackendPCRBank{}
+					}
+				}
+				if sha256Active, ok := d.GetOk(prefix + ".backend_active_pcr_banks.0.sha256"); ok {
+					if sha256Active.(bool) {
+						tpm.Backend.Emulator.ActivePCRBanks.SHA256 = &libvirtxml.DomainTPMBackendPCRBank{}
+					}
+				}
+				if sha384Active, ok := d.GetOk(prefix + ".backend_active_pcr_banks.0.sha384"); ok {
+					if sha384Active.(bool) {
+						tpm.Backend.Emulator.ActivePCRBanks.SHA384 = &libvirtxml.DomainTPMBackendPCRBank{}
+					}
+				}
+				if sha512Active, ok := d.GetOk(prefix + ".backend_active_pcr_banks.0.sha512"); ok {
+					if sha512Active.(bool) {
+						tpm.Backend.Emulator.ActivePCRBanks.SHA512 = &libvirtxml.DomainTPMBackendPCRBank{}
+					}
+				}
+			}
 		}
 		domainDef.Devices.TPMs = append(domainDef.Devices.TPMs, tpm)
 	}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -72,6 +72,11 @@ func resourceLibvirtDomain() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"firmware_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"nvram": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -858,6 +863,7 @@ func resourceLibvirtDomainRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("vcpu", domainDef.VCPU)
 	d.Set("memory", domainDef.Memory)
 	d.Set("firmware", domainDef.OS.Loader)
+	d.Set("firmware_type", domainDef.OS.Firmware)
 	d.Set("nvram", domainDef.OS.NVRam)
 	d.Set("cpu", domainDef.CPU)
 	d.Set("arch", domainDef.OS.Type.Arch)

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -442,6 +442,36 @@ func resourceLibvirtDomain() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"backend_active_pcr_banks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"sha1": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+									"sha256": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+									"sha384": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+									"sha512": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This PR comes in 2 parts

1. Allow setting the active PCR banks of a domain's TPM
   This setting is currently missing from the TPM definition and causes some issues when using the TPM attestation functionality.
   This PR expands the TPM definition to allow users the choice of which PCR banks to set active.


2. Allow choosing a domain's firmware type
  To make proper use of the TPM, e.g. measured-boot/secure-boot,  we need EFI firmware.
  Correctly setting up EFI is currently a bit messy using the terraform provider since simply setting `OS.Firmware` is not supported.
  Using libvirt directly, one would simply define the following to achieve a functional efi setup:
    ```xml
    <os firmware='efi'>
       ...
    </os>
    ```
    See [the libvirt bootloader XML definition](https://libvirt.org/formatdomain.html#operating-system-booting) for more details.

    With this PR users can set a new option, `firmware_type`, to `efi` to achieve the same behavior.

   Personally, I would prefer renaming the current `firmware` option to the more appropriate `loader`, so we can simply name the new `firmware_type` option `firmware`.
   But I am not sure if such a  thing should be done in this PR as this will likely break existing configurations relying on it.

I am also open to splitting this PR in two parts if so desired.

Example definition:

```terraform
resource "libvirt_domain" "example" {
  count   = 1
  memory  = 2048
  vcpu    = 2
  machine = "q35"
  fimrware_type = "efi"
  tpm {
    backend_type    = "emulator"
    backend_version = "2.0"
    backend_active_pcr_banks {
      sha1   = true
      sha256 = true
      sha384 = true
      sha512 = true
    }
  }
}
```

For reference, this is the xslt I am currently using as a workaround to achieve the functionality of this PR.
```xslt
<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
  <xsl:output omit-xml-declaration="yes" indent="yes"/>
    <xsl:template match="node()|@*">
        <xsl:copy>
            <xsl:apply-templates select="node()|@*"/>
        </xsl:copy>
    </xsl:template>
    <xsl:template match="os">
        <os firmware="efi">
            <xsl:apply-templates select="@*|node()"/>
        </os>
    </xsl:template>
    <xsl:template match="/domain/devices/tpm/backend">
    <xsl:copy>
        <xsl:apply-templates select="node()|@*"/>
        <xsl:element name ="active_pcr_banks">
            <xsl:element name="sha1"></xsl:element>
            <xsl:element name="sha256"></xsl:element>
            <xsl:element name="sha384"></xsl:element>
            <xsl:element name="sha512"></xsl:element>
        </xsl:element>
    </xsl:copy>
  </xsl:template>
</xsl:stylesheet>
```