### PR TITLE
Datasource libvirt volume

### DIFF
--- a/libvirt/data_source_libvirt_volume.go
+++ b/libvirt/data_source_libvirt_volume.go
@@ -58,7 +58,8 @@ func datasourceLibvirtVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"xslt": {
-							Type: schema.TypeString,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},

--- a/libvirt/data_source_libvirt_volume.go
+++ b/libvirt/data_source_libvirt_volume.go
@@ -1,0 +1,71 @@
+package libvirt
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+// a libvirt volume datasource.
+//
+// Datasource example:
+//
+// data "libvirt_volume" "cloudimg" {
+//    pool = "image_pool"
+//	  name = "ubuntu-22.04-server-cloudimg.img"
+// }
+
+func datasourceLibvirtVolume() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceLibvirtVolumeRead,
+		Exists: resourceLibvirtVolumeExists,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"format": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"base_volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"base_volume_pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+			},
+			"base_volume_name": {
+				Type:     schema.TypeString,
+				Optional: false,
+				Required: true,
+			},
+			"xml": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"xslt": {
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}

--- a/libvirt/data_source_libvirt_volume_test.go
+++ b/libvirt/data_source_libvirt_volume_test.go
@@ -1,0 +1,59 @@
+package libvirt
+
+import (
+	"fmt"
+	libvirt "github.com/digitalocean/go-libvirt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccLibvirtVolumeDatasource(t *testing.T) {
+	var volume libvirt.StorageVol
+
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolPath := "/tmp/terraform-provider-libvirt-pool-" + randomPoolName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_pool" "%s" {
+					name = "%s"
+					type = "dir"
+					path = "%s"
+				}
+
+				resource "libvirt_volume" "%s" {
+					name = "%s"
+					size = 1073741824
+					pool = "%s"
+				}
+
+				data "libvirt_volume" "%s" {
+					name = "%s"
+					pool = "%s"
+				}
+				"`, randomPoolName,
+					randomPoolName,
+					randomPoolPath,
+					randomVolumeResource,
+					randomVolumeName,
+					randomPoolName,
+					randomVolumeResource,
+					randomVolumeName,
+					randomPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("data.libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr("data.libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					resource.TestCheckResourceAttr("data.libvirt_volume."+randomVolumeResource, "pool", randomPoolName),
+				),
+			},
+		},
+	})
+}

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -28,6 +28,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"libvirt_volume":                           datasourceLibvirtVolume(),
 			"libvirt_network_dns_host_template":        datasourceLibvirtNetworkDNSHostTemplate(),
 			"libvirt_network_dns_srv_template":         datasourceLibvirtNetworkDNSSRVTemplate(),
 			"libvirt_network_dnsmasq_options_template": datasourceLibvirtNetworkDnsmasqOptionsTemplate(),


### PR DESCRIPTION

Goal here is pretty simple: enable a volume in a specific pool to be used as a backing volume without having to use a resource.

Code is mostly lifted from `volume.go`. It doesn't yet work, but does compile...