### PR TITLE
utils_xslt: display xsltproc stderr when it fails

### DIFF
--- a/libvirt/utils_xslt.go
+++ b/libvirt/utils_xslt.go
@@ -1,6 +1,7 @@
 package libvirt
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"os/exec"
@@ -87,11 +88,16 @@ func transformXML(xmlS string, xsltS string) (string, error) {
 		"--nowrite",
 		xsltFile.Name(),
 		xmlFile.Name())
-	transformedXML, err := cmd.Output()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 	if err != nil {
 		log.Printf("[ERROR] Failed to run xsltproc (is it installed?)")
+		log.Printf("[ERROR] Error: %s", stderr)
 		return xmlS, err
 	}
+	transformedXML := string(stdout.Bytes())
 	log.Printf("[DEBUG] Transformed XML with user specified XSLT:\n%s", transformedXML)
 
 	return string(transformedXML), err


### PR DESCRIPTION
It's easy to have xsltproc failing to process the XML from a libvirt terraform configuration. Indeed, syntax error will trigger such failure, and a bad terraform configuration where xslt= property is confused as file path instead of content would likely generate syntax errors:

    resource "libvirt_domain" "example" {
      # ...
      xml {
        xslt = "${path.module}/transform.xslt"
      }
    }

Currently, when xsltproc fails, with TF_LOG=1, the following is displayed:

    2023-02-21T14:00:35.620+0100 [INFO]  provider.terraform-provider-libvirt: 2023/02/21 14:00:35 [ERROR] Failed to run xsltproc (is it installed?): timestamp=2023-02-21T14:00:35.620+0100

Which is confusing when xsltproc is available. With this patch and TF_LOG=1, the following would be displayed:

    2023-02-21T14:00:35.620+0100 [INFO]  provider.terraform-provider-libvirt: 2023/02/21 14:00:35 [ERROR] Failed to run xsltproc (is it installed?): timestamp=2023-02-21T14:00:35.620+0100
    2023-02-21T14:00:35.620+0100 [INFO]  provider.terraform-provider-libvirt: 2023/02/21 14:00:35 [ERROR] Error: {/tmp/terraform-provider-libvirt-xslt1179436507:1: parser error : Start tag expected, '<' not found
    transform.xslt
    ^

Refs #999


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
