### PR TITLE
Default machine

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -139,8 +139,11 @@ func newDomainDefForConnection(virConn *libvirt.Libvirt, rd *schema.ResourceData
 
 	if machine, ok := rd.GetOk("machine"); ok {
 		d.OS.Type.Machine = machine.(string)
-	} else if len(guest.Arch.Machines) > 0 {
-		d.OS.Type.Machine = guest.Arch.Machines[0].Name
+	} else {
+		d.OS.Type.Machine, err = getMachineTypeForArch(caps, d.OS.Type.Arch, d.OS.Type.Type)
+		if err != nil {
+			return d, err
+		}
 	}
 
 	canonicalmachine, err := getCanonicalMachineName(caps, d.OS.Type.Arch, d.OS.Type.Type, d.OS.Type.Machine)

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -516,7 +516,6 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 	domainDef.OS.Initrd = d.Get("initrd").(string)
 	domainDef.OS.Type.Arch = d.Get("arch").(string)
 
-	domainDef.OS.Type.Machine = d.Get("machine").(string)
 	domainDef.Devices.Emulator = d.Get("emulator").(string)
 
 	if v := os.Getenv("TERRAFORM_LIBVIRT_TEST_DOMAIN_TYPE"); v != "" {

--- a/libvirt/utils_domain_def_test.go
+++ b/libvirt/utils_domain_def_test.go
@@ -102,6 +102,29 @@ func TestGetOriginalMachineName(t *testing.T) {
 	t.Logf("Reverse canonical lookup for %s is %s which matches %s", canonname, reversename, machine)
 }
 
+func TestGetMachineTypeForArch(t *testing.T) {
+	skipIfAccDisabled(t)
+	conn := testAccProvider.Meta().(*Client).libvirt
+	caps, err := getHostCapabilities(conn)
+	if err != nil {
+	       t.Error(err)
+	}
+
+	arch := "x86_64"
+	targettype := "hvm"
+	machine := "pc"
+
+	m, err := getMachineTypeForArch(caps, arch, targettype)
+	if err != nil {
+		t.Error(err)
+	}
+	if m != machine {
+		t.Errorf("Machine found for arch %s, targettype %s is %s expected %s", arch, targettype, m, machine)
+	}
+
+	t.Logf("Machine for arch %s, targettype %s is %s which matches %s", arch, targettype, m, machine)
+}
+
 func TestGetHostCapabilties(t *testing.T) {
 	skipIfAccDisabled(t)
 	conn := testAccProvider.Meta().(*Client).libvirt


### PR DESCRIPTION
The default machine types picked by libvirt on non-x86* architectures are often quite limited and not very useful. For compatibility reasons libvirt picks the machine type that was the first one support for this architecture. virt-installer therefore maintains its own settings.
This patchset implements the same setting for libvirt if the user does not explicitly specify a machine type.

@dmacvicar - could you have a look?