### PR TITLE
Remove spice graphics device from default definition

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -58,13 +58,6 @@ func newDomainDef() libvirtxml.Domain {
 		},
 		CPU: &libvirtxml.DomainCPU{},
 		Devices: &libvirtxml.DomainDeviceList{
-			Graphics: []libvirtxml.DomainGraphic{
-				{
-					Spice: &libvirtxml.DomainGraphicSpice{
-						AutoPort: "yes",
-					},
-				},
-			},
 			Channels: []libvirtxml.DomainChannel{
 				{
 					Source: &libvirtxml.DomainChardevSource{


### PR DESCRIPTION
Before this change the device was being created regardless of any setting, even without any graphics block.
And as far as I could tell, without any possibility to remove it in the provider.

Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
