### PR TITLE
Fix for typo in informational message

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -593,7 +593,7 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 		err = domainWaitForLeases(ctx, virConn, domain, waitForLeases, d.Timeout(schema.TimeoutCreate), d)
 		if err != nil {
 			ipNotFoundMsg := "Please check following: \n" +
-				"1) is the domain running proplerly? \n" +
+				"1) is the domain running properly? \n" +
 				"2) has the network interface an IP address? \n" +
 				"3) Networking issues on your libvirt setup? \n " +
 				"4) is DHCP enabled on this Domain's network? \n" +


### PR DESCRIPTION
Hey folks, I found a minor typo in an informational message covering the inability to retrieve an IP address from an existing libvirt domain. This small patch fixes it.