### PR TITLE
Parametrize cloud-init bus type

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -179,7 +179,7 @@ func domainGetIfacesInfo(virConn *libvirt.Libvirt, domain libvirt.Domain, rd *sc
 	return interfaces, nil
 }
 
-func newDiskForCloudInit(virConn *libvirt.Libvirt, volumeKey string) (libvirtxml.DomainDisk, error) {
+func newDiskForCloudInit(virConn *libvirt.Libvirt, volumeKey string, bus string) (libvirtxml.DomainDisk, error) {
 	disk := libvirtxml.DomainDisk{
 		// HACK mark the disk as belonging to the cloudinit
 		// resource so we can ignore it
@@ -188,7 +188,7 @@ func newDiskForCloudInit(virConn *libvirt.Libvirt, volumeKey string) (libvirtxml
 		Target: &libvirtxml.DomainDiskTarget{
 			// Last device letter possible with a single IDE controller on i440FX
 			Dev: "hdd",
-			Bus: "ide",
+			Bus: bus,
 		},
 		Driver: &libvirtxml.DomainDiskDriver{
 			Name: "qemu",
@@ -648,7 +648,10 @@ func setCloudinit(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn 
 		if err != nil {
 			return err
 		}
-		disk, err := newDiskForCloudInit(virConn, cloudinitID)
+
+		cloudinitBus := d.Get("cloudinit_bus").(string)
+
+		disk, err := newDiskForCloudInit(virConn, cloudinitID, cloudinitBus)
 		if err != nil {
 			return err
 		}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -106,6 +106,13 @@ func resourceLibvirtDomain() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+			"cloudinit_bus": {
+				Type: schema.TypeString,
+				Optional: true,
+				Default: "ide",
+				ForceNew: true,
+				Required: false,
+			},
 			"coreos_ignition": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -688,7 +695,9 @@ func resourceLibvirtDomainUpdate(ctx context.Context, d *schema.ResourceData, me
 			return diag.FromErr(err)
 		}
 
-		disk, err := newDiskForCloudInit(virConn, cloudinitID)
+		cloudinitBus := d.Get("cloudinit_bus").(string)
+
+		disk, err := newDiskForCloudInit(virConn, cloudinitID, cloudinitBus)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -40,6 +40,8 @@ func TestAccLibvirtDomain_Basic(t *testing.T) {
 						"libvirt_domain."+randomResourceName, "memory", "512"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomResourceName, "vcpu", "1"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomResourceName, "cloudinit_bus", "ide"),
 				),
 			},
 		},
@@ -983,6 +985,46 @@ func TestAccLibvirtDomain_Filesystems(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "filesystem.0.readonly", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtDomain_CloudinitBus(t *testing.T) {
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	var initialConfig = fmt.Sprintf(`
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		
+		cloudinit_bus = "ide"
+	}`, randomDomainName, randomDomainName)
+
+	var updatedConfig = fmt.Sprintf(`
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+
+		cloudinit_bus = "sata"
+	}`, randomDomainName, randomDomainName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain." + randomDomainName, "cloudinit_bus", "ide"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.TestCheckResourceAttr(
+					"libvirt_domain." + randomDomainName, "cloudinit_bus", "sata"),
 			},
 		},
 	})

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
   the domain. This is going to be attached as a CDROM ISO. Changing the
   cloud-init won't cause the domain to be recreated, however the change will
   have effect on the next reboot.
+* `cloudinit_bus` - (Optional, default: `ide`) The bus type which will be used for
+  the cloud-init disk. This is mainly to allow the use of cloud-init with Q35 machines.
 * `autostart` - (Optional) Set to `true` to start the domain on host boot up.
   If not specified `false` is assumed.
 * `filesystem` - (Optional) An array of one or more host filesystems to attach to


### PR DESCRIPTION
Hello,
I really like this provider and I appreciate the work you've done.

I've had issues with cloud-init and Q35 machines in the past, gave up on libvirt with Terraform for some time and then I've stumbled upon this issue: https://github.com/dmacvicar/terraform-provider-libvirt/issues/1018

I've decided to make the changes mentioned by issue creator in my fork and it seemed to solve my issue.

I didn't want to blindly make it hard-coded for SATA though, that's why I'm proposing a parameter.

Basically, I think the most backwards compatible approach is to add a new field to the ``libvirt_domain`` resource, called ``cloudinit_bus``. By default it will be set to ``"ide"``, but can be changed to ``"sata"`` for Q35 machines (for example).

I've added some basic acceptance tests, but I'm not proud of them - let's say that they are just to cover the lines.
I wanted to add some test that will verify that the VM will be recreated when the bus type is changed, but this project is not using the ``terraform-plugin-test`` module and I didn't want to bring it in immediately.

If you think I should make some higher quality tests then let me know and maybe give me some tips - I'm fairly new to Go and especially to testing it, not even mentioning developing Terraform plugins.