### PR TITLE
Fix domain running status fails when shutdown expected (#622)

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -101,6 +101,20 @@ func resourceLibvirtDomain() *schema.Resource {
 				ForceNew: false,
 				Required: false,
 			},
+			"shutdown_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  10,
+				ForceNew: false,
+				Required: false,
+			},
+			"shutdown_force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: false,
+				Required: false,
+			},
 			"cloudinit": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -670,7 +684,7 @@ func resourceLibvirtDomainUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("error retrieving libvirt domain by update: %s", err)
 	}
 
-	err = updateRunningStatus(virConn, d, domain)
+	err = updateRunningStatus(ctx, virConn, d, domain)
 
 	if err != nil {
 		return diag.Errorf("error while updating running status: %s", err)

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -1534,6 +1534,8 @@ func TestAccLibvirtDomain_UpdateDomainRunning(t *testing.T) {
 					name = "%s"
 					vcpu = 1
 					running = true
+					shutdown_timeout = 5
+					shutdown_force = true
 				}`, randomResourceName, randomDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainStateEqual("libvirt_domain."+randomResourceName, &domain, "running"),
@@ -1545,6 +1547,8 @@ func TestAccLibvirtDomain_UpdateDomainRunning(t *testing.T) {
 					name = "%s"
 					vcpu = 1
 					running = false
+					shutdown_timeout = 5
+					shutdown_force = true
 			 	}`, randomResourceName, randomDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainStateEqual("libvirt_domain."+randomResourceName, &domain, "shutoff"),

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
   will be created with 512 MiB of memory be used.
 * `running` - (Optional) Use `false` to turn off the instance. If not specified,
   true is assumed and the instance, if stopped, will be started at next apply.
+* `shutdown_timeout` - (Optional) Duration in seconds to wait for domain shutdown when updating `running` from `true` to `false`. Fails after timeout. Default is `10`.
+* `shutdown_force` - (Optional) Force shutdown after `shutdown_timeout`. May cause data loss. Fails after second timeout. Default is `false`.
 * `disk` - (Optional) An array of one or more disks to attach to the domain. The
   `disk` object structure is documented [below](#handling-disks).
 * `network_interface` - (Optional) An array of one or more network interfaces to


### PR DESCRIPTION
This PR fixes the issue of the guest not being shutdown when updating `running` to `false` (#622).

```
$ vim main.tf
```

```hcl
terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
      version = ">= 0.7.1"
    }
  }
}

provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_domain" "myvm" {
  name   = "myvm"
  vcpu   = 1
  running = true
}
```

```
$ terraform init
$ terraform apply
$ virsh list --all
 Id    Name   State
-----------------------
 140   myvm   running
```

```
$ vim main.tf
```

```hcl
terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
      version = ">= 0.7.1"
    }
  }
}

provider "libvirt" {
  uri = "qemu:///system"
}

resource "libvirt_domain" "myvm" {
  name   = "myvm"
  vcpu   = 1
  running = false  # I changed this!
}
```

```
$ terraform apply
$ virsh list --all
 Id    Name   State
-----------------------
 140   myvm   running
```

The expected state is `shut off`.
