### PR TITLE
Fix malformed connection remote name when using ssh remote uri.

### DIFF
--- a/libvirt/uri/connection_uri.go
+++ b/libvirt/uri/connection_uri.go
@@ -39,6 +39,7 @@ func (u *ConnectionURI) RemoteName() string {
 
 	newURI := *u
 	newURI.Scheme = u.driver()
+	newURI.User = nil
 	newURI.Host = ""
 	newURI.RawQuery = ""
 

--- a/libvirt/uri/connection_uri_test.go
+++ b/libvirt/uri/connection_uri_test.go
@@ -19,6 +19,7 @@ func TestURI(t *testing.T) {
 		{"xxx+tcp:///", "xxx", "tcp", "xxx:///"},
 		{"xxx+unix:///", "xxx", "unix", "xxx:///"},
 		{"xxx+tls://servername/?foo=bar&name=dong:///ding", "xxx", "tls", "dong:///ding"},
+		{"xxx+ssh://username@hostname:2222/path?foo=bar&bar=foo", "xxx", "ssh", "xxx:///path"},
 	}
 
 	for _, fixture := range fixtures {


### PR DESCRIPTION
Fixes an issue where the remote uri qemu+ssh://username@hostname:2222/system?foo=bar&bar=foo does not resolve to qemu:///system as remote name