### PR TITLE
Fix copy of the URL in RemoteName

### DIFF
--- a/libvirt/uri/connection_uri.go
+++ b/libvirt/uri/connection_uri.go
@@ -31,13 +31,13 @@ func Parse(uriStr string) (*ConnectionURI, error) {
 // The name passed to the remote virConnectOpen function is formed by removing
 // transport, hostname, port number, username and extra parameters from the remote URI
 // unless the name option is specified.
-func (u *ConnectionURI) RemoteName() string {
+func (u ConnectionURI) RemoteName() string {
 	q := u.Query()
 	if name := q.Get("name"); name != "" {
 		return name
 	}
 
-	newURI := *u
+	newURI := *u.URL
 	newURI.Scheme = u.driver()
 	newURI.User = nil
 	newURI.Host = ""


### PR DESCRIPTION
Fixes #1040

The copy performed in RemoteName was shallow and this corrupted the original URI that is used during the Dial() call made by the go-libvirt library.

The issue always existed but did not manifest when libvirt.New(conn) was used because the connection was established before the call to RemoteName. The problem manifested when the switch to libvirt.NewWithDialer was made, because the dialing is now made during the call to ConnectToURI, which receives as paramater the result of the call to RemoteName.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
