### PR TITLE
Add hypervisor `type` argument to `libvirt_domain` resource

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -85,12 +85,6 @@ func newDomainDef() libvirtxml.Domain {
 		},
 	}
 
-	if v := os.Getenv("TERRAFORM_LIBVIRT_TEST_DOMAIN_TYPE"); v != "" {
-		domainDef.Type = v
-	} else {
-		domainDef.Type = "kvm"
-	}
-
 	// FIXME: We should allow setting this from configuration as well.
 	rngDev := os.Getenv("TF_LIBVIRT_RNG_DEV")
 	if rngDev == "" {

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -73,6 +74,12 @@ func resourceLibvirtDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "kvm",
 			},
 			"nvram": {
 				Type:     schema.TypeList,
@@ -507,6 +514,12 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 
 	domainDef.OS.Type.Machine = d.Get("machine").(string)
 	domainDef.Devices.Emulator = d.Get("emulator").(string)
+
+	if v := os.Getenv("TERRAFORM_LIBVIRT_TEST_DOMAIN_TYPE"); v != "" {
+		domainDef.Type = v
+	} else {
+		domainDef.Type = d.Get("type").(string)
+	}
 
 	arch, err := getHostArchitecture(virConn)
 	if err != nil {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `emulator` - (Optional) The path of the emulator to use
 * `qemu_agent` (Optional) By default is disabled, set to true for enabling it. More info [qemu-agent](https://wiki.libvirt.org/page/Qemu_guest_agent).
 * `tpm` (Optional) TPM device to attach to the domain. The `tpm` object structure is documented [below](#tpm-device).
+* `type` (Optional) The type of hypervisor to use for the domain.  Defaults to `kvm`, other values can be found [here](https://libvirt.org/formatdomain.html#id1)
 ### Kernel and boot arguments
 
 * `kernel` - (Optional) The path of the kernel to boot


### PR DESCRIPTION
Fixes #738 