### PR TITLE
Fix firmware for armv7l

### DIFF
--- a/libvirt/domain_def.go
+++ b/libvirt/domain_def.go
@@ -122,7 +122,7 @@ func newDomainDefForConnection(virConn *libvirt.Libvirt, rd *schema.ResourceData
 		d.OS.Type.Arch = arch
 	}
 
-	if d.OS.Type.Arch == "aarch64" {
+	if d.OS.Type.Arch == "aarch64" || d.OS.Type.Arch == "armv7l" {
 		// for aarch64 speciffying this will automatically select the firmware and NVRAM file
 		// reference: https://libvirt.org/formatdomain.html#bios-bootloader
 		d.OS.Firmware = "efi"


### PR DESCRIPTION
armv7l needs the same firmware as aarch64:

From a vanilla arm libvirt config:
```xml
<domain type="qemu">
  <os firmware="efi">
    <type arch="armv7l" machine="virt-7.2">hvm</type>
    <boot dev="hd"/>
  </os>
```