### PR TITLE
ssh improvements

### DIFF
--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -145,7 +145,7 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 		port = defaultSSHPort
 	}
 
-	sshClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", u.Hostname(), port), &cfg)
+	sshClient, err := ssh.Dial("tcp", net.JoinHostPort(hostname, port), &cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -133,6 +133,11 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 		username = sshu
 	}
 
+	hostname, err := sshcfg.Get(u.Hostname(), "HostName")
+	if err != nil {
+		hostname = u.Hostname()
+	}
+
 	cfg := ssh.ClientConfig{
 		User:            username,
 		HostKeyCallback: hostKeyCallback,
@@ -142,7 +147,10 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 
 	port := u.Port()
 	if port == "" {
-		port = defaultSSHPort
+		port, err = sshcfg.Get(u.Host, "Port")
+		if err != nil {
+			port = defaultSSHPort
+		}
 	}
 
 	sshClient, err := ssh.Dial("tcp", net.JoinHostPort(hostname, port), &cfg)


### PR DESCRIPTION
* fix ipv6 handling for non-default ports
* add ssh config support for the following:
  * hostname
    * if user-specified uri points to ssh config entry with hostname setting, use that
  * port
    * user-specified port > config-specified port > default port