### PR TITLE
Add none option to graphics

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -308,6 +308,12 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 			return fmt.Errorf("missing graphics type for domain")
 		}
 
+		// If graphics is explicitly disabled exit early.
+		if graphicsType == "none" {
+			domainDef.Devices.Graphics = nil
+			return nil
+		}
+
 		autoport := d.Get(prefix + ".autoport").(bool)
 		listener := libvirtxml.DomainGraphicListener{}
 
@@ -347,7 +353,7 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 				domainDef.Devices.Graphics[0].VNC.WebSocket = websocket.(int)
 			}
 		default:
-			return fmt.Errorf("this provider only supports vnc/spice as graphics type. Provided: '%s'", graphicsType)
+			return fmt.Errorf("this provider only supports vnc/spice/none as graphics type. Provided: '%s'", graphicsType)
 		}
 	}
 	return nil

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -760,6 +760,25 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 		}
 	}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeName, randomVolumeName, randomPoolName, randomDomainName, randomDomainName)
 
+	var configNone = fmt.Sprintf(`
+    resource "libvirt_pool" "%s" {
+        name = "%s"
+        type = "dir"
+        path = "%s"
+    }
+
+	resource "libvirt_volume" "%s" {
+		name = "%s"
+        pool = "${libvirt_pool.%s.name}"
+	}
+
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		graphics {
+			type        = "none"
+		}
+	}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeName, randomVolumeName, randomPoolName, randomDomainName, randomDomainName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -769,6 +788,7 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr("libvirt_domain."+randomDomainName, "graphics.#", "1"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "graphics.0.type", "spice"),
 					resource.TestCheckResourceAttr(
@@ -789,6 +809,7 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 				Config: configListenAddress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr("libvirt_domain."+randomDomainName, "graphics.#", "1"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "graphics.0.type", "spice"),
 					resource.TestCheckResourceAttr(
@@ -797,6 +818,27 @@ func TestAccLibvirtDomain_Graphics(t *testing.T) {
 						"libvirt_domain."+randomDomainName, "graphics.0.listen_type", "address"),
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomDomainName, "graphics.0.listen_address", "127.0.1.1"),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configNone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr("libvirt_domain."+randomDomainName, "graphics.#", "1"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.type", "none"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.autoport", "true"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "graphics.0.listen_type", "none"),
 				),
 			},
 		},

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -441,6 +441,9 @@ resource "libvirt_domain" "my_machine" {
 ~> **Note well:** the `graphics` block is ignored for the architectures
   `s390x` and `ppc64`.
 
+To remove the graphics entirely set `type` to `none`. 
+Consider adding a serial console for output if you enable this option.
+This can be useful for minimal server images printing only to the serial console.
 
 ### Console devices
 


### PR DESCRIPTION
Add an option to remove the graphics device from the domain definition.

Motivation:
The minimal ubuntu cloud server images do only print to serial console anyways.
To avoid confusion (the SPICE Console only shows `attempting initrdless boot` which could easily be interpreted as the OS not booting), I wanted to disable the spice console so that virt-manager always shows the serial console directly.

Considered options:

- Remove graphics in default and require user to explicitly add graphics if wanted.
- Add `none` to graphics device `type`  to disable graphics.

I chose to implement the second option because the first option would be a major breaking change.