### PR TITLE
Mark disk wwn and nvram arguments as computed

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -382,7 +382,10 @@ func setFirmware(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 		}
 
 		if _, ok := d.GetOk("nvram.0"); ok {
-			nvramFile := d.Get("nvram.0.file").(string)
+			nvramFile := ""
+			if file, ok := d.GetOk("nvram.0.file"); ok {
+				nvramFile = file.(string)
+			}
 			nvramTemplateFile := ""
 			if nvramTemplate, ok := d.GetOk("nvram.0.template"); ok {
 				nvramTemplateFile = nvramTemplate.(string)

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -85,18 +85,21 @@ func resourceLibvirtDomain() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"file": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
+							Computed: true,
 						},
 						"template": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Computed: true,
 						},
 					},
 				},
@@ -179,6 +182,7 @@ func resourceLibvirtDomain() *schema.Resource {
 						"wwn": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"block_device": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
These changes are meant to keep the libvirt provider idempotent, i.e. running terraform apply twice with no changes in between should not result in any updated resources.

The disk WWN is randomly generated if it is not specified, which means that the `disk.wwn` argument will always be different when it is regenerated. This difference causes Terraform to perform an in-place update.

When specifying the `firmware` argument, libvirt will automatically generate the corresponding NVRAM definitions. Since the generated definitions differ from the unspecified `nvram` argument in the resource and the `nvram` argument is marked as force new, Terraform will replace the entire libvirt domain.

The `nvram.file` argument was required, but this is not necessary for libvirt. Libvirt will autogenerate the location of the NVRAM variables file even if only the template is specified.
