### PR TITLE
adds wait_for_shutoff to resource_libvirt_domain

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -871,3 +871,16 @@ func destroyDomainByUserRequest(virConn *libvirt.Libvirt, d *schema.ResourceData
 
 	return nil
 }
+
+func waitForDomainShutoff(virConn *libvirt.Libvirt, domain libvirt.Domain) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		state, _, err := virConn.DomainGetState(domain, 0)
+		if err != nil {
+			return nil, "", err
+		}
+		if libvirt.DomainState(state) == libvirt.DomainShutoff {
+			return domain, "SHUTOFF", nil
+		}
+		return domain, "NOT-SHUTOFF", err
+	}
+}

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
   will be created.
 * `memory` - (Optional) The amount of memory in MiB. If not specified the domain
   will be created with 512 MiB of memory be used.
+* `wait_for_shutoff` - (Optional) Use `true` to shutoff instance before destroying. Allows guest VM to shutdown gracefully. If not specified `false` is assumed.
 * `running` - (Optional) Use `false` to turn off the instance. If not specified,
   true is assumed and the instance, if stopped, will be started at next apply.
 * `disk` - (Optional) An array of one or more disks to attach to the domain. The


### PR DESCRIPTION
Open to feedback, there is likely a better way to implement this. I took a first swing at the docs, but I wasn't sure where to start on testing this change.

Tested with Terraform version 1.7.0.

```

Fixes: #356, #1060
