### PR TITLE
add libvirt nodeinfo datasource

### DIFF
--- a/libvirt/data_source_libvirt_nodeinfo.go
+++ b/libvirt/data_source_libvirt_nodeinfo.go
@@ -1,0 +1,252 @@
+package libvirt
+
+import (
+	"log"
+	"encoding/xml"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// a libvirt based host capability data source
+//
+// Example usage:
+//
+//	data "libvirt_nodeinfo" "host_machine" {
+//        uri = "qemu+ssh://target-machine/system?"
+//	}
+//
+//      locals {
+//      	arch = data.external.native_machine_details.result["arch"]
+//      	images = {
+//      		"debian-x86_64" = "/srv/images/debian-12-backports-generic-amd64.qcow2",
+//    			"debian-aarch64"  = "/srv/images/debian-12-backports-generic-arm64.qcow2",
+//      	}
+//      image_path = local.images["debian-${local.arch}"]
+//      }
+
+func datasourceLibvirtNodeInfo() *schema.Resource {
+	return &schema.Resource{
+		Read: resourceLibvirtNodeInfoRead,
+		Schema: map[string]*schema.Schema{
+			"live_migration_support" : {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"live_migration_transports" : {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{ Type: schema.TypeString, },
+				Computed: true,
+			},
+			"arch" : {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"model" : {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vendor" : {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sockets" : {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dies" : {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cores" : {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"threads" : {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"features": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"topology" : {
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Optional: true, // or Required: true, based on your use case
+						},
+						"memory": {
+							Type:     schema.TypeInt,
+							Optional: true, // or Required: true, based on your use case
+						},
+						"cpu": {
+							Type:     schema.TypeList,
+							Optional: true, // or Required: true, based on your use case
+							Elem:     &schema.Schema{
+								Type: schema.TypeMap,
+								Elem: schema.TypeInt,
+
+							},
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+type Host struct {
+	XMLName  xml.Name `xml:"host"`
+	UUID     string   `xml:"uuid"`
+	CPU      CPU      `xml:"cpu"`
+	Migration MigrationFeatures `xml:"migration_features"`
+	Topology Topology `xml:"topology"`
+}
+
+type CPU struct {
+	Arch      string       `xml:"arch"`
+	Model     string       `xml:"model"`
+	Vendor    string       `xml:"vendor"`
+	Topology  CPUtopology  `xml:"topology"`
+	Features  []struct{
+		Name string `xml:"name,attr"`
+	}    `xml:"feature"`
+}
+
+type MigrationFeatures struct {
+	XMLName    xml.Name `xml:"migration_features"`
+	Live       *bool `xml:"live"`
+	Transports []string `xml:"uri_transports>uri_transport"`
+}
+
+type CPUtopology struct {
+	Sockets int `xml:"sockets,attr"`
+	Dies    int `xml:"dies,attr"`
+	Cores   int `xml:"cores,attr"`
+	Threads int `xml:"threads,attr"`
+}
+
+type Topology struct {
+	Cells []Cell `xml:"cells>cell"`
+}
+
+type Cell struct {
+	ID     int `xml:"id,attr"`
+	Memory Memory `xml:"memory"`
+	CPUs   CPUs   `xml:"cpus"`
+}
+
+type Memory struct {
+	Unit  string `xml:"unit,attr"`
+	Value int    `xml:",chardata"`
+}
+
+type CPUs struct {
+	Num  string `xml:"num,attr"`
+	CPU  []CPUInfo `xml:"cpu"`
+}
+
+type CPUInfo struct {
+	ID        string `xml:"id,attr"`
+	SocketID  string `xml:"socket_id,attr"`
+	DieID     string `xml:"die_id,attr"`
+	CoreID    string `xml:"core_id,attr"`
+	Siblings  string `xml:"siblings,attr"`
+}
+
+// Data represents the top-level structure of the XML that includes the <host> node
+type Capabilities struct {
+	Host Host `xml:"host"`
+}
+
+func convertUnit( unit string ) (int){
+	switch unit {
+	case "KiB":
+		return 1024
+	case "MiB":
+		return 1024*1024
+	default:
+		return 1
+	}
+}
+
+func resourceLibvirtNodeInfoRead(d *schema.ResourceData, meta interface{}) error {
+	virtConn := meta.(*Client).libvirt
+	caps, err := virtConn.ConnectGetCapabilities()
+	if err != nil {
+		log.Fatalf("Failed to get node capabilities: %v", err)
+		return nil
+	}
+
+	log.Printf("full caps: %v", caps)
+	var capabilities Capabilities
+	err = xml.Unmarshal([]byte(caps), &capabilities)
+	if err != nil {
+		log.Fatalf("Error unmarshalling XML: %v", err)
+	}
+
+	d.SetId(capabilities.Host.UUID)
+
+	d.Set("arch", capabilities.Host.CPU.Arch)
+	d.Set("model", capabilities.Host.CPU.Model)
+	d.Set("vendor", capabilities.Host.CPU.Vendor)
+	d.Set("sockets", capabilities.Host.CPU.Topology.Sockets)
+	d.Set("dies", capabilities.Host.CPU.Topology.Dies)
+	d.Set("cores", capabilities.Host.CPU.Topology.Cores)
+	d.Set("threads", capabilities.Host.CPU.Topology.Threads)
+
+	d.Set("live_migration_support", capabilities.Host.Migration.Live != nil)
+	if err := d.Set("live_migration_transports", capabilities.Host.Migration.Transports); err != nil {
+		log.Fatalf("error setting features: %s", err)
+		return nil
+	}
+
+	features := []string{}
+	// Iterate over the cpu.Features slice
+	for _, feature := range capabilities.Host.CPU.Features {
+		// Append the 'Name' field of each 'Feature' struct to the slice
+		features = append(features, feature.Name)
+	}
+
+	if err := d.Set("features", features); err != nil {
+		log.Fatalf("error setting features: %s", err)
+		return nil
+	}
+
+	// topology := make([]map[string]interface{}, 0)
+	// for _, t := range capabilities.Host.Topology {
+	// 	topologyItem := make(map[string]interface{})
+	// 	if t.ID != nil { // Assuming `ID`, `Memory`, and `CPU` are fields in your topology data structure
+	// 		topologyItem["id"] = *t.ID
+	// 	}
+	// 	if t.Memory != nil {
+	// 		topologyItem["memory"] = *t.Memory
+	// 	}
+	// 	if t.CPU != nil {
+	// 		cpuList := make([]map[string]int, 0)
+	// 		for _, cpu := range *t.CPU { // Assuming `CPU` is a slice of maps or similar structure
+	// 			cpuItem := make(map[string]int)
+	// 			for key, value := range cpu {
+	// 				cpuItem[key] = value
+	// 			}
+	// 			cpuList = append(cpuList, cpuItem)
+	// 		}
+	// 		topologyItem["cpu"] = cpuList
+	// 	}
+	// 	topology = append(topology, topologyItem)
+	// }
+
+	d.Set("topology", nil)
+	log.Printf("[DEBUG] Host topology not yet implemented")
+
+	return nil
+
+}
+
+
+

--- a/libvirt/data_source_libvirt_nodeinfo_test.go
+++ b/libvirt/data_source_libvirt_nodeinfo_test.go
@@ -1,0 +1,107 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// MockClient represents a mock client for testing.
+type MockClient struct {
+	caps string // XML capabilities data
+}
+
+// ConnectGetCapabilities returns mock capabilities data.
+func (c *MockClient) ConnectGetCapabilities() (string, error) {
+	return c.caps, nil
+}
+
+// mockCapabilitiesXML provides a sample XML for libvirt capabilities.
+const mockCapabilitiesXML = `
+<capabilities>
+	<host>
+		<uuid>test-uuid</uuid>
+		<cpu>
+			<arch>x86_64</arch>
+			<model>model-name</model>
+			<vendor>vendor-name</vendor>
+			<topology sockets="2" dies="1" cores="4" threads="2"/>
+			<feature name="feature1"/>
+			<feature name="feature2"/>
+			<feature name="feature3"/>
+		</cpu>
+		<migration_features>
+			<live />
+			<uri_transports>
+				<uri_transport>transport#1</uri_transport>
+				<uri_transport>transport#2</uri_transport>
+				<uri_transport>transport#3</uri_transport>
+			</uri_transports>
+		</migration_features>
+	</host>
+</capabilities>
+`
+
+func Test_resourceLibvirtNodeInfoRead(t *testing.T) {
+	// Set up mock client with predefined capabilities XML
+	mockClient := &MockClient{caps: mockCapabilitiesXML}
+
+	// Initialize a Terraform resource data schema
+	d := schema.TestResourceDataRaw(t, datasourceLibvirtNodeInfo().Schema, map[string]interface{}{})
+
+	// Call the function under test
+	err := resourceLibvirtNodeInfoRead(d, mockClient)
+	if err != nil {
+		t.Fatalf("resourceLibvirtNodeInfoRead() error = %v", err)
+	}
+
+	// Define expected values based on mockCapabilitiesXML
+	expectedUUID := "test-uuid"
+	expectedArch := "x86_64"
+	expectedModel := "model-name"
+	expectedVendor := "vendor-name"
+	expectedSockets := 2
+	expectedDies := 1
+	expectedCores := 4
+	expectedThreads := 2
+	expectedLiveMigrationSupport := true
+	expectedLiveMigrationTransports := []interface{}{"transport#1", "transport#2", "transport#3"}
+	expectedFeatures := []interface{}{"feature1", "feature2", "feature3"}
+
+	// Assert that the resource data is set correctly
+	if got := d.Get("arch"); got != expectedArch {
+		t.Errorf("resourceLibvirtNodeInfoRead() arch = %v, want %v", got, expectedArch)
+	}
+	if got := d.Get("model"); got != expectedModel {
+		t.Errorf("resourceLibvirtNodeInfoRead() model = %v, want %v", got, expectedModel)
+	}
+	if got := d.Get("vendor"); got != expectedVendor {
+		t.Errorf("resourceLibvirtNodeInfoRead() vendor = %v, want %v", got, expectedVendor)
+	}
+	if got := d.Get("sockets"); got != expectedSockets {
+		t.Errorf("resourceLibvirtNodeInfoRead() sockets = %v, want %v", got, expectedSockets)
+	}
+	if got := d.Get("dies"); got != expectedDies {
+		t.Errorf("resourceLibvirtNodeInfoRead() dies = %v, want %v", got, expectedDies)
+	}
+	if got := d.Get("cores"); got != expectedCores {
+		t.Errorf("resourceLibvirtNodeInfoRead() cores = %v, want %v", got, expectedCores)
+	}
+	if got := d.Get("threads"); got != expectedThreads {
+		t.Errorf("resourceLibvirtNodeInfoRead() threads = %v, want %v", got, expectedThreads)
+	}
+	if got := d.Get("live_migration_support"); got != expectedLiveMigrationSupport {
+		t.Errorf("resourceLibvirtNodeInfoRead() live_migration_support = %v, want %v", got, expectedLiveMigrationSupport)
+	}
+	if got := d.Get("live_migration_transports"); !reflect.DeepEqual(got, expectedLiveMigrationTransports) {
+		t.Errorf("resourceLibvirtNodeInfoRead() live_migration_transports = %v, want %v", got, expectedLiveMigrationTransports)
+	}
+	if got := d.Get("features"); !reflect.DeepEqual(got, expectedFeatures) {
+		t.Errorf("resourceLibvirtNodeInfoRead() features = %v, want %v", got, expectedFeatures)
+	}
+	if got := d.Id(); got != expectedUUID {
+		t.Errorf("resourceLibvirtNodeInfoRead() UUID = %v, want %v", got, expectedUUID)
+	}
+}

--- a/libvirt/provider.go
+++ b/libvirt/provider.go
@@ -28,6 +28,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"libvirt_nodeinfo":                         datasourceLibvirtNodeInfo(),
 			"libvirt_network_dns_host_template":        datasourceLibvirtNetworkDNSHostTemplate(),
 			"libvirt_network_dns_srv_template":         datasourceLibvirtNetworkDNSSRVTemplate(),
 			"libvirt_network_dnsmasq_options_template": datasourceLibvirtNetworkDnsmasqOptionsTemplate(),


### PR DESCRIPTION
This feature allows querying the host machine's nodeinfo through the libvirt protocol.

This is useful for, among other things, obtaining the target machine's architecture to select a guest image.

```hcl
// main.tf
provider "libvirt" {
  uri = "qemu+ssh://${var.target}/system?sshauth=privkey&no_verify"
}

data "libvirt_nodeinfo" "host" {}

locals {
  arch = data.libvirt_nodeinfo.host.arch
  images = {
    "debian-x86_64" = "/srv/images/debian-12-backports-generic-amd64.qcow2",
    "debian-aarch64"  = "/srv/images/debian-12-backports-generic-arm64.qcow2",
  }
  image_path = local.images["debian-${local.arch}"]
}

output image_path {
  value = local.image_path
}
```


Which will create the following output:

```bash
$~/terraform-provider-libvirt/testing$ TF_VAR_target=chromium terraform apply 
data.libvirt_nodeinfo.host: Reading...
data.libvirt_nodeinfo.host: Read complete after 1s [id=d4e1bf70-6374-45b7-a970-fb584a1b4062]

Changes to Outputs:
  + image_path = "/srv/images/debian-12-backports-generic-arm64.qcow2"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

image_path = "/srv/images/debian-12-backports-generic-arm64.qcow2"
$~/terraform-provider-libvirt/testing$ terraform show 
# data.libvirt_nodeinfo.host:
data "libvirt_nodeinfo" "host" {
    arch                      = "aarch64"
    cores                     = 2
    dies                      = 1
    features                  = [
        "fp",
        "asimd",
        "evtstrm",
        "aes",
        "pmull",
        "sha1",
        "sha2",
        "crc32",
        "cpuid",
    ]
    host                      = "qemu+ssh://chromium/system?sshauth=privkey&no_verify=true"
    id                        = "d4e1bf70-6374-45b7-a970-fb584a1b4062"
    live_migration_support    = true
    live_migration_transports = [
        "tcp",
        "rdma",
    ]
    model                     = "cortex-a72"
    sockets                   = 1
    threads                   = 1
    topology                  = []
    vendor                    = "ARM"
}


Outputs:

image_path = "/srv/images/debian-12-backports-generic-arm64.qcow2"
```
