### PR TITLE
Simple fix for the running attribute when switched to false from an initial state of true

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -622,7 +622,7 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	// We save runnig state to not mix what we have and what we want
+	// We save running state to not mix what we have and what we want
 	requiredStatus := d.Get("running")
 
 	if diag := resourceLibvirtDomainRead(ctx, d, meta); diag.HasError() {
@@ -691,7 +691,7 @@ func resourceLibvirtDomainUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	if !domainRunningNow {
+	if !domainRunningNow && d.Get("running").(bool) {
 		err = virConn.DomainCreate(domain)
 		if err != nil {
 			return diag.Errorf("error creating libvirt domain: %s", err)
@@ -770,6 +770,10 @@ func resourceLibvirtDomainUpdate(ctx context.Context, d *schema.ResourceData, me
 				}
 			}
 		}
+	}
+
+	if err := destroyDomainByUserRequest(virConn, d, domain); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
When the running attribute initial state is false, switching it to true works, the vm is powered on.
However, when the running attribute initial state is true, updating it to false does not shutdown the vm.
