### PR TITLE
fix: Network is not started if inactive #1095

### DIFF
--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -91,6 +91,13 @@ func resourceLibvirtNetwork() *schema.Resource {
 				Required: false,
 				Computed: true,
 			},
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: false,
+				Required: false,
+			},
 			"dns": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -515,6 +522,13 @@ func resourceLibvirtNetworkRead(ctx context.Context, d *schema.ResourceData, met
 		}
 		return diag.Errorf("error retrieving libvirt network %s", err)
 	}
+
+	activeInt, err := virConn.NetworkIsActive(network)
+	if err != nil {
+		return diag.Errorf("error when getting network %s status during update: %s", network.Name, err)
+	}
+
+	d.Set("active", int2bool(int(activeInt)))
 
 	networkDef, err := getXMLNetworkDefFromLibvirt(virConn, network)
 	if err != nil {


### PR DESCRIPTION
Includes network activity status in terraform state, thus allowing terraform to update network resource in case it is inactive (e.g. after hypervisor reboot or `virsh net-destroy`)

Network activity is checked in Update method, but not in Read. This makes terraform think that network should not be updated (since the state matches recorded one). Then, VM initialization fails, since it depends on an inactive network. 

First brought up in #1095.
