### PR TITLE
make network dns enabled by default

### DIFF
--- a/libvirt/network_dns.go
+++ b/libvirt/network_dns.go
@@ -200,18 +200,6 @@ func getDNSForwardersFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkD
 	return dnsForwarders, nil
 }
 
-// getDNSEnableFromResource returns string to enable ("yes") or disable ("no") dns
-// in the network definition.
-func getDNSEnableFromResource(d *schema.ResourceData) string {
-	if dnsEnabled, ok := d.GetOk(dnsPrefix + ".enabled"); ok {
-		if dnsEnabled.(bool) {
-			return "yes" // this "boolean" must be "yes"|"no"
-		}
-		return "no"
-	}
-	return "no"
-}
-
 // getDNSSRVFromResource returns a list of libvirt's DNS SRVs
 // in the network definition.
 func getDNSSRVFromResource(d *schema.ResourceData) ([]libvirtxml.NetworkDNSSRV, error) {

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -40,9 +40,9 @@ resource "libvirt_network" "kube_network" {
 
   # (Optional) DNS configuration
   dns {
-    # (Optional, default false)
-    # Set to true, if no other option is specified and you still want to 
-    # enable dns.
+    # (Optional, default true)
+    # If disabled, no dns will be setup for this network and dns configuration
+	# will be ignored.
     enabled = true
     # (Optional, default false)
     # true: DNS requests under this domain will only be resolved by the


### PR DESCRIPTION
https://libvirt.org/formatnetwork.html#addressing specifies dns is disabled only if enable="no", but if omitted, it is enabled by default.

However, it claims if disabled, it would ignore the dns entries, but in reality it fails with "error: XML error: Extra data in disabled network".

terraform-provider-libvirt defaults to enabled=false, and it seems it was accidentally introduced with #969 

This change makes:

- if enabled is omitted, we use the libvirt default
- we only add dns information to the xml if enabled


This also fixes the testacc testsuite, which was failing due to this "error: XML error: Extra data in disabled network" problem.

Fixes #1079 