### PR TITLE
fix issue where domain creates static host DHCP when DHCP is disabled

### DIFF
--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -13,13 +13,21 @@ import (
 // HasDHCP checks if the network has a DHCP server managed by libvirt.
 func HasDHCP(net libvirtxml.Network) bool {
 	if net.Forward != nil {
-		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "open" || net.Forward.Mode == "" {
+		if net.Forward.Mode == "bridge" {
+			return false
+		}
+	}
+
+	for _, family := range net.IPs {
+
+		if family.DHCP == nil {
+			continue
+		}
+		if len(family.DHCP.Ranges) >= 1 {
 			return true
 		}
-	} else {
-		// isolated network
-		return true
 	}
+
 	return false
 }
 

--- a/libvirt/network_def_test.go
+++ b/libvirt/network_def_test.go
@@ -100,14 +100,6 @@ func TestBrokenNetworkDefUnmarshall(t *testing.T) {
 	}
 }
 
-func TestHasDHCPNoForwardSet(t *testing.T) {
-	net := libvirtxml.Network{}
-
-	if !HasDHCP(net) {
-		t.Error("Expected to have DHCP")
-	}
-}
-
 func TestHasDHCPForwardSet(t *testing.T) {
 	createNet := func(mode string) libvirtxml.Network {
 		return libvirtxml.Network{
@@ -116,15 +108,32 @@ func TestHasDHCPForwardSet(t *testing.T) {
 			},
 		}
 	}
-
+	mode := "bridge"
+	if HasDHCP(createNet(mode)) {
+		t.Errorf(
+			"Expected not have DHCP running in mode: '%s'",
+			mode)
+	}
 	for _, mode := range []string{"nat", "route", "open", ""} {
-		net := createNet(mode)
-		if !HasDHCP(net) {
+		testNetwork := createNet(mode)
+		if HasDHCP(testNetwork) {
 			t.Errorf(
-				"Expected to have forward enabled with forward set to be '%s'",
-				mode)
+				"Expected network to have not have dhcp: %v",
+				testNetwork.IPs)
 		}
 	}
+
+	testNetwork := createNet("nat")
+	ipv4Range := libvirtxml.NetworkIP{DHCP: &libvirtxml.NetworkDHCP{Ranges: []libvirtxml.NetworkDHCPRange{libvirtxml.NetworkDHCPRange{
+		Start: "192.168.1.1",
+		End:   "192.168.1.3",
+	}}}}
+
+	testNetwork.IPs = append(testNetwork.IPs, ipv4Range)
+	if !HasDHCP(testNetwork) {
+		t.Errorf("Expected to have IPv4 DHCP enable in network %v", testNetwork.IPs[0].DHCP.Ranges)
+	}
+
 }
 
 func TestGetHostXMLDesc(t *testing.T) {


### PR DESCRIPTION
When you disable the DHCP service, The Domain creates static host records which enables the DHCP only for those static hosts.

The issue is found in the check `HasDHCP`  which only checks for the mode and not if there is a DHCP configured.  This issue cannot be patched via XSLT because it's running in the domain level (post network)

In this fix 
- we will ignore `bridge` networks
- check if there is a range configured for each family network 
