### PR TITLE
fix issue where domain creates DHCP when DHCP is disabled

### DIFF
--- a/libvirt/network_def.go
+++ b/libvirt/network_def.go
@@ -13,13 +13,20 @@ import (
 // HasDHCP checks if the network has a DHCP server managed by libvirt.
 func HasDHCP(net libvirtxml.Network) bool {
 	if net.Forward != nil {
-		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "open" || net.Forward.Mode == "" {
+		if net.Forward.Mode == "bridge" {
+			return false
+		}
+	}
+
+	for _, family := range net.IPs {
+
+		if family.DHCP == nil {
+			continue
+		} else {
 			return true
 		}
-	} else {
-		// isolated network
-		return true
 	}
+
 	return false
 }
 


### PR DESCRIPTION
When you disable the DHCP service, The Domain creates static host records which enables the DHCP only for those static hosts.

The issue is found in the check HasDHCP which only checks for the mode and not if there is a DHCP configured. This issue cannot be patched via XSLT because it's running in the domain level (post network)

In this fix
1. we will ignore bridge networks
2. check if there is a `dhcp` field is set each family network


note: 
> you can configure  DHCP on bridge network and in some cases you will. but, this is a rare use case and can have impact on the phyiscal network.


This is an example of a network created with no DHCP and the domain adds those hosts  as a static DHCP. 

```xml
</network>
...
  <ip family='ipv4' address='192.168.127.1' prefix='24'>
    <dhcp>
      <host mac='02:00:00:46:8E:78' name='test-cluster-ccb82750-master-1' ip='192.168.127.11'/>
      <host mac='02:00:00:D1:26:11' name='test-cluster-ccb82750-master-0' ip='192.168.127.10'/>
      <host mac='02:00:00:A6:33:B3' name='test-cluster-ccb82750-master-2' ip='192.168.127.12'/>
    </dhcp>
  </ip>
</network>

```

The desired state
```xml
</network>
...
  <ip family='ipv4' address='192.168.127.1' prefix='24'>
  </ip>
</network>
```
