### PR TITLE
Knownhosts tilde aware path expansion - fixes #1107

### DIFF
--- a/libvirt/util/expandenv.go
+++ b/libvirt/util/expandenv.go
@@ -1,0 +1,16 @@
+package util
+
+// ExpandEnvExt expands environment variables and resolves ~ to the home directory
+// this is a drop-in replacement for os.ExpandEnv but is additionall '~' aware
+func ExpandEnvExt(path string) string {
+	path = os.ExpandEnv(path)
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path // return path as-is if unable to resolve home directory
+		}
+		// Replace ~ with home directory
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	return path
+}

--- a/libvirt/util/expandenv.go
+++ b/libvirt/util/expandenv.go
@@ -1,11 +1,22 @@
 package util
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	userHomeDir = os.UserHomeDir
+	expandEnv   = os.ExpandEnv
+)
+
 // ExpandEnvExt expands environment variables and resolves ~ to the home directory
 // this is a drop-in replacement for os.ExpandEnv but is additionall '~' aware
 func ExpandEnvExt(path string) string {
-	path = os.ExpandEnv(path)
+	path = expandEnv(path)
 	if strings.HasPrefix(path, "~") {
-		home, err := os.UserHomeDir()
+		home, err := userHomeDir()
 		if err != nil {
 			return path // return path as-is if unable to resolve home directory
 		}

--- a/libvirt/util/expandenv_test.go
+++ b/libvirt/util/expandenv_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandEnvExt(t *testing.T) {
+	userHomeDir = func() (string, error) {
+		return "/home/mock", nil
+	}
+	expandEnv = func(s string) string {
+		return strings.Replace(s, "${HOME}", "/home/mock", 1)
+	}
+
+
+	assert.Equal(t, "foo/bar/baz", ExpandEnvExt("foo/bar/baz"))
+	assert.Equal(t, "/home/mock/foo/bar/baz", ExpandEnvExt("~/foo/bar/baz"))
+	assert.Equal(t, "/home/mock/foo/bar/baz", ExpandEnvExt("${HOME}/foo/bar/baz"))
+	assert.Equal(t, "~foo/bar/baz", ExpandEnvExt("~foo/bar/baz"))
+}


### PR DESCRIPTION
This directly addresses issue #1107 but is also a small refactor effort to move some utility code into the util package with associated unit tests.

The specific changes are to move the file path expansion code to a dedicated utility function in the util package and add an associated unit test.

As a note, issue #1107 is legacy to v0.8.x and existed before [here](https://github.com/dmacvicar/terraform-provider-libvirt/blob/v0.7.6/libvirt/uri/ssh.go#L114).

``` golang
if doVerify {
		cb, err := knownhosts.New(os.ExpandEnv(knownHostsPath)) // <- this does not expand tilde
		if err != nil {
			return nil, fmt.Errorf("failed to read ssh known hosts: %w", err)
		}
		hostKeyCallback = cb
	}
```