### PR TITLE
Bugfix: ssh port override for #1116

### DIFF
--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -169,12 +169,14 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 			configuredPort, err := sshcfg.Get(target, "Port")
 			if err == nil && configuredPort != "" {
 				port = configuredPort
+				log.Printf("[DEBUG] using ssh port from ssh_config: '%s'", port)
 			}
 		}
 
 	} else {
-		log.Printf("[DEBUG] ssh Port is overridden to: '%s'", port)
+		log.Printf("[DEBUG] using ssh port from querystring: '%s'", port)
 	}
+	log.Printf("[DEBUG] port for ssh connection is: '%s'", port)
 
 	hostName := target
 	if sshcfg != nil {

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -168,9 +168,21 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 	//  3. defaultSSHPort
 	port := ""
 
-	if sshcfg != nil && (configuredPort, err := sshcfg.Get(target, "Port")); err == nil && configuredPort != "" {
+	if sshcfg != nil {
+		configuredPort, err := sshcfg.Get(target, "Port")
+		if err != nil {
+			log.Printf("[WARN] error reading Port attribute from ssh_config for target '%v'", target)
+		} else {
+			port = configuredPort
 
-		port = configuredPort
+			if port == "" {
+				log.Printf("[DEBUG] port for target '%v' in ssh_config is empty", target)
+			}
+		}
+	}
+
+	if port != "" {
+
 		log.Printf("[DEBUG] using ssh port from ssh_config: '%s'", port)
 
 	} else if u.Port() != "" {

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -132,7 +132,7 @@ func (u *ConnectionURI) dialSSH() (net.Conn, error) {
 	}
 
 	// configuration loaded, build tunnel
-	sshClient, err := u.dialHost(u.Host, sshcfg, 0)
+	sshClient, err := u.dialHost(u.Hostname(), sshcfg, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -165,6 +165,13 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 	port := u.Port()
 	if port == "" {
 		port = defaultSSHPort
+		if sshcfg != nil {
+			configuredPort, err := sshcfg.Get(target, "Port")
+			if err == nil && configuredPort != "" {
+				port = configuredPort
+			}
+		}
+
 	} else {
 		log.Printf("[DEBUG] ssh Port is overridden to: '%s'", port)
 	}


### PR DESCRIPTION
This issue fixes #1116.

It is a direct fix that maintains backward compatibility, however it introduces an outcome that breaks the principle of least astonishment: the port specified in the query string will take precedence over the port specified in *any* configured targets along the way (e.g. client -> bastion1 -> bastion2 -> host).

My opinion is that config should have priority over query string, however, this behaviour is not backwards compatible.

@dmacvicar : will need your input on this.
