### PR TITLE
Feat: Allow increasing a storage volume size

### DIFF
--- a/libvirt/resource_libvirt_volume_test.go
+++ b/libvirt/resource_libvirt_volume_test.go
@@ -188,7 +188,7 @@ func TestAccLibvirtVolume_BackingStoreTestByName(t *testing.T) {
 					name = "%s"
                     base_volume_name = "${libvirt_volume.backing-%s.name}"
                     pool = "${libvirt_pool.%s.name}"
-			        }
+				}
 				`, random, random, randomPoolPath, random, random, random, random, random, random, random),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtVolumeExists("libvirt_volume.backing-"+random, &volume),
@@ -483,6 +483,134 @@ func TestAccLibvirtVolume_Import(t *testing.T) {
 						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
 					resource.TestCheckResourceAttr(
 						"libvirt_volume."+randomVolumeResource, "size", "10737"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtVolume_ResizeShrink(t *testing.T) {
+	var volume libvirt.StorageVol
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolPath := "/tmp/terraform-provider-libvirt-pool-" + randomPoolName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+                    resource "libvirt_pool" "%s" {
+                            name = "%s"
+                            type = "dir"
+                            path = "%s"
+                    }
+
+					resource "libvirt_volume" "%s" {
+							name   = "%s"
+							format = "raw"
+							size   =  1024 * 1024
+                            pool = "${libvirt_pool.%s.name}"
+					}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeResource, randomVolumeName, randomPoolName,
+				),
+				ResourceName: "libvirt_volume." + randomVolumeResource,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "size", "1048576"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+                    resource "libvirt_pool" "%s" {
+                            name = "%s"
+                            type = "dir"
+                            path = "%s"
+                    }
+
+					resource "libvirt_volume" "%s" {
+							name   = "%s"
+							format = "raw"
+							size   =  1024
+                            pool = "${libvirt_pool.%s.name}"
+					}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeResource, randomVolumeName, randomPoolName,
+				),
+				ResourceName: "libvirt_volume." + randomVolumeResource,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "size", "1024"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibvirtVolume_ResizeExpand(t *testing.T) {
+	var volume libvirt.StorageVol
+	randomVolumeResource := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomVolumeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomPoolPath := "/tmp/terraform-provider-libvirt-pool-" + randomPoolName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+                    resource "libvirt_pool" "%s" {
+                            name = "%s"
+                            type = "dir"
+                            path = "%s"
+                    }
+
+					resource "libvirt_volume" "%s" {
+							name   = "%s"
+							format = "raw"
+							size   =  1024 * 1024
+                            pool = "${libvirt_pool.%s.name}"
+					}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeResource, randomVolumeName, randomPoolName,
+				),
+				ResourceName: "libvirt_volume." + randomVolumeResource,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "size", "1048576"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+                    resource "libvirt_pool" "%s" {
+                            name = "%s"
+                            type = "dir"
+                            path = "%s"
+                    }
+
+					resource "libvirt_volume" "%s" {
+							name   = "%s"
+							format = "raw"
+							size   =  1024 * 1024 * 10
+                            pool = "${libvirt_pool.%s.name}"
+					}`, randomPoolName, randomPoolName, randomPoolPath, randomVolumeResource, randomVolumeName, randomPoolName,
+				),
+				ResourceName: "libvirt_volume." + randomVolumeResource,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtVolumeExists("libvirt_volume."+randomVolumeResource, &volume),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "name", randomVolumeName),
+					resource.TestCheckResourceAttr(
+						"libvirt_volume."+randomVolumeResource, "size", "10485760"),
 				),
 			},
 		},

--- a/libvirt/volume.go
+++ b/libvirt/volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	libvirt "github.com/digitalocean/go-libvirt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -12,6 +13,9 @@ import (
 const (
 	volumeStateConfNotExists = resourceStateConfNotExists
 	volumeStateConfExists    = resourceStateConfExists
+	volumeStateConfError     = resourceStateConfError
+	volumeStateConfPending   = resourceStateConfPending
+	volumeStateConfDone      = resourceStateConfDone
 )
 
 func volumeExistsStateRefreshFunc(virConn *libvirt.Libvirt, key string) retry.StateRefreshFunc {
@@ -27,6 +31,20 @@ func volumeExistsStateRefreshFunc(virConn *libvirt.Libvirt, key string) retry.St
 	}
 }
 
+func volumeResizeDoneStateRefreshFunc(virConn *libvirt.Libvirt, volume libvirt.StorageVol, targetSize uint64) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		_, capacity, _, err := virConn.StorageVolGetInfo(volume)
+		if err != nil {
+			return virConn, resourceStateConfError, fmt.Errorf("failed to query volume '%s' info: %w", volume.Name, err)
+		}
+
+		if capacity != targetSize {
+			return virConn, resourceStateConfPending, nil
+		}
+		return virConn, resourceStateConfDone, nil
+	}
+}
+
 func waitForStateVolumeExists(ctx context.Context, virConn *libvirt.Libvirt, key string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{volumeStateConfNotExists},
@@ -34,6 +52,21 @@ func waitForStateVolumeExists(ctx context.Context, virConn *libvirt.Libvirt, key
 		Refresh:    volumeExistsStateRefreshFunc(virConn, key),
 		Timeout:    resourceStateTimeout,
 		MinTimeout: resourceStateMinTimeout,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForStateVolumeResizeDone(ctx context.Context, virConn *libvirt.Libvirt, volume libvirt.StorageVol, targetSize uint64) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{volumeStateConfPending},
+		Target:     []string{volumeStateConfDone},
+		Refresh:    volumeResizeDoneStateRefreshFunc(virConn, volume, targetSize),
+		Timeout:    resourceStateTimeout,
+		MinTimeout: 1 * time.Second,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -109,5 +142,68 @@ func volumeDelete(ctx context.Context, client *Client, key string) error {
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return err
 	}
+	return nil
+}
+
+// volumeResizeCheck checks whether it is possible to increase the size of the provided volume by the given amount
+func volumeResizeCheck(client *Client, volume libvirt.StorageVol, pool libvirt.StoragePool, sizeIncrease uint64) error {
+	virConn := client.libvirt
+
+	state, _, _, poolAvailable, err := virConn.StoragePoolGetInfo(pool)
+	if err != nil {
+		return fmt.Errorf("error retrieving info for storage pool '%s' : %w", pool.Name, err)
+	}
+	// Check if the pool is in the running state (2)
+	if state != 2 {
+		return fmt.Errorf("the storage pool '%s' is in an invalid state (%d) for resizing", pool.Name, state)
+	}
+
+	_, volumeCapacity, volumeAllocated, err := virConn.StorageVolGetInfo(volume)
+	if err != nil {
+		return fmt.Errorf("error retrieving info for volume '%s': %w", volume.Name, err)
+	}
+	log.Printf(
+		"[DEBUG] '%s' volume capacity=%d allocated=%d - %s pool available=%d - requested size increase=%d",
+		volume.Name, volumeCapacity, volumeAllocated, pool.Name, poolAvailable, sizeIncrease,
+	)
+
+	if sizeIncrease > poolAvailable {
+		return fmt.Errorf("not enough available space for storage pool '%s' to resize volume %s", pool.Name, volume.Name)
+	}
+
+	return nil
+}
+
+// volumeResize increases the size of the volume identified by `key' from the old to the new provided size
+func volumeResize(ctx context.Context, client *Client, key string, oldSize, newSize uint64) error {
+	virConn := client.libvirt
+
+	volume, err := virConn.StorageVolLookupByKey(key)
+	if err != nil {
+		return fmt.Errorf("volumeResize: Can't retrieve volume with key %s: %w", key, err)
+	}
+
+	pool, err := virConn.StoragePoolLookupByName(volume.Pool)
+	if err != nil {
+		return fmt.Errorf("volumeResize: Failed to retrieve volume's storage pool %s: %w", volume.Pool, err)
+	}
+
+	client.poolMutexKV.Lock(pool.Name)
+	defer client.poolMutexKV.Unlock(pool.Name)
+
+	sizeDelta := newSize - oldSize
+	if err := volumeResizeCheck(client, volume, pool, sizeDelta); err != nil {
+		return fmt.Errorf("volumeResize: Failed while determining if the volume %s can be resized: %w", volume.Name, err)
+	}
+
+	if err := virConn.StorageVolResize(volume, sizeDelta, libvirt.StorageVolResizeDelta); err != nil {
+		return fmt.Errorf("volumeResize: Failed to resize volume %s: %w", volume.Name, err)
+	}
+
+	if err := waitForStateVolumeResizeDone(ctx, virConn, volume, newSize); err != nil {
+		return err
+	}
+	log.Printf("[INFO] The volume %s has been resized. Filesystem expansion might be necessary", volume.Name)
+
 	return nil
 }


### PR DESCRIPTION
Related to https://github.com/dmacvicar/terraform-provider-libvirt/issues/952 and https://github.com/dmacvicar/terraform-provider-libvirt/issues/1017

This PR adds support for a non-destructive resize when a storage volume size is increased.
Shrinking a storage volume will still ultimately result in destroying the existing one and recreating it.

It would have been possible to handle both cases, shrinking and expanding, in the `UpdateContext `function, but having a `CustomizeDiff` function allows to correctly differentiate between a resource update  and a destroy + add, notifying it to the user.
