### PR TITLE
Connection port parsing

### DIFF
--- a/libvirt/uri/connection_uri_test.go
+++ b/libvirt/uri/connection_uri_test.go
@@ -12,15 +12,17 @@ func TestURI(t *testing.T) {
 		Driver     string
 		Transport  string
 		RemoteName string
+		HostName   string
+		Port       string
 	}{
-		{"xxx://servername/", "xxx", "tls", "xxx:///"},
-		{"xxx+tls://servername/", "xxx", "tls", "xxx:///"},
-		{"xxx+tls:///", "xxx", "tls", "xxx:///"},
-		{"xxx+tcp://servername/", "xxx", "tcp", "xxx:///"},
-		{"xxx+tcp:///", "xxx", "tcp", "xxx:///"},
-		{"xxx+unix:///", "xxx", "unix", "xxx:///"},
-		{"xxx+tls://servername/?foo=bar&name=dong:///ding", "xxx", "tls", "dong:///ding"},
-		{"xxx+ssh://username@hostname:2222/path?foo=bar&bar=foo", "xxx", "ssh", "xxx:///path"},
+		{"xxx://servername/", "xxx", "tls", "xxx:///", "servername", ""},
+		{"xxx+tls://servername/", "xxx", "tls", "xxx:///", "servername", ""},
+		{"xxx+tls:///", "xxx", "tls", "xxx:///", "", ""},
+		{"xxx+tcp://servername/", "xxx", "tcp", "xxx:///", "servername", ""},
+		{"xxx+tcp:///", "xxx", "tcp", "xxx:///", "", ""},
+		{"xxx+unix:///", "xxx", "unix", "xxx:///", "", ""},
+		{"xxx+tls://servername/?foo=bar&name=dong:///ding", "xxx", "tls", "dong:///ding", "servername", ""},
+		{"xxx+ssh://username@hostname:2222/path?foo=bar&bar=foo", "xxx", "ssh", "xxx:///path", "hostname", "2222"},
 	}
 
 	for _, fixture := range fixtures {
@@ -29,5 +31,7 @@ func TestURI(t *testing.T) {
 		assert.Equal(t, fixture.Transport, u.transport())
 		assert.Equal(t, fixture.Driver, u.driver())
 		assert.Equal(t, fixture.RemoteName, u.RemoteName())
+		assert.Equal(t, fixture.HostName, u.Host)
+		assert.Equal(t, fixture.Port, u.Port())
 	}
 }

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -169,12 +169,14 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 			configuredPort, err := sshcfg.Get(target, "Port")
 			if err == nil && configuredPort != "" {
 				port = configuredPort
+				log.Printf("[DEBUG] using ssh port from ssh_config: '%s'", port)
 			}
 		}
 
 	} else {
-		log.Printf("[DEBUG] ssh Port is overridden to: '%s'", port)
+		log.Printf("[DEBUG] using ssh port from querystring: '%s'", port)
 	}
+	log.Printf("[DEBUG] port for ssh connection is: '%s'", port)
 
 	hostName := target
 	if sshcfg != nil {

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -168,9 +168,21 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 	//  3. defaultSSHPort
 	port := ""
 
-	if sshcfg != nil && (configuredPort, err := sshcfg.Get(target, "Port")); err == nil && configuredPort != "" {
+	if sshcfg != nil {
+		configuredPort, err := sshcfg.Get(target, "Port")
+		if err != nil {
+			log.Printf("[WARN] error reading Port attribute from ssh_config for target '%v'", target)
+		} else {
+			port = configuredPort
 
-		port = configuredPort
+			if port == "" {
+				log.Printf("[DEBUG] port for target '%v' in ssh_config is empty", target)
+			}
+		}
+	}
+
+	if port != "" {
+
 		log.Printf("[DEBUG] using ssh port from ssh_config: '%s'", port)
 
 	} else if u.Port() != "" {

--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -165,6 +165,13 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 	port := u.Port()
 	if port == "" {
 		port = defaultSSHPort
+		if sshcfg != nil {
+			configuredPort, err := sshcfg.Get(target, "Port")
+			if err == nil && configuredPort != "" {
+				port = configuredPort
+			}
+		}
+
 	} else {
 		log.Printf("[DEBUG] ssh Port is overridden to: '%s'", port)
 	}


### PR DESCRIPTION
This issue is meant to address #1124 

This is a subtle bug because it has practically no impact on the libvirt code base. It only affects libvirt [here](https://github.com/dmacvicar/terraform-provider-libvirt/blob/main/libvirt/config.go#L36):

```golang
	if err := l.ConnectToURI(libvirt.ConnectURI(u.RemoteName())); err != nil {
```

Outside of this location, this bug only affects ssh_config settings by incorrectly passing the target as "hostname:portname" instead of "hostname" [here](https://github.com/dmacvicar/terraform-provider-libvirt/blob/main/libvirt/uri/ssh.go#L135):

```

	// configuration loaded, build tunnel
	sshClient, err := u.dialHost(u.Host, sshcfg, 0)
	if err != nil {
		return nil, err
	}
```

However, when a port override is specified in the ConnectionString, u.Host will contain the hostname.