### PR TITLE
Enhancement: Add domain title property

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -48,6 +48,11 @@ func resourceLibvirtDomain() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"title": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -494,6 +499,13 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 		domainDef.Name = name.(string)
 	}
 
+	if title, ok := d.GetOk("title"); ok {
+		if strings.Contains(title.(string), "\n") {
+			return diag.Errorf("title attribute should not contain newline characters")
+		}
+		domainDef.Title = title.(string)
+	}
+
 	if cpuMode, ok := d.GetOk("cpu.0.mode"); ok {
 		domainDef.CPU = &libvirtxml.DomainCPU{
 			Mode: cpuMode.(string),
@@ -807,6 +819,7 @@ func resourceLibvirtDomainRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set("name", domainDef.Name)
+	d.Set("title", domainDef.Title)
 	d.Set("description", domainDef.Description)
 	d.Set("vcpu", domainDef.VCPU.Value)
 

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -73,6 +73,33 @@ func TestAccLibvirtDomain_Description(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtDomain_Title(t *testing.T) {
+	var domain libvirt.Domain
+	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_domain" "%s" {
+					name = "%s"
+                    title = "unit test title"
+				}`, randomResourceName, randomDomainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomResourceName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomResourceName, "name", randomDomainName),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomResourceName, "title", "unit test title"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtDomain_Detailed(t *testing.T) {
 	var domain libvirt.Domain
 	randomResourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)


### PR DESCRIPTION
Related to https://github.com/dmacvicar/terraform-provider-libvirt/issues/1041

Adds basic support for managing a libvirt domain title property.

Possible further improvements:

- [ ]  have a `CustomDiff` function that checks if a new title is valid (read: contains no newline characters) BEFORE  attempting to replace a domain. Right now **when the new title contains newlines** the user can still attempt a replacement, the previous domain is destroyed and the new one fails to be created because the title is invalid.
No bueno.

- [ ] do not force a replacement when the title changes and correctly update it in place. I think libvirt API has no function to update only the title property, so this may require directly updating the domain XML configuration and redefining the domain.
