### PR TITLE
Add support for additional console types (file, udp) in the Terraform libvirt provider

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -463,11 +463,33 @@ func setConsoles(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 			console.Protocol = &libvirtxml.DomainChardevProtocol{
 				Type: "telnet",
 			}
+		case "udp":
+			sourceHost := d.Get(prefix + ".source_host")
+			sourceService := d.Get(prefix + ".source_service")
+			connectHost := d.Get(prefix + ".connect_host")
+			connectService := d.Get(prefix + ".connect_service")
+			console.Source = &libvirtxml.DomainChardevSource{
+				UDP: &libvirtxml.DomainChardevSourceUDP{
+					BindHost: sourceHost.(string),
+					BindService: sourceService.(string),
+					ConnectHost: connectHost.(string),
+					ConnectService: connectService.(string),
+				},
+			}
 		case "pty":
 			if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
 				console.Source = &libvirtxml.DomainChardevSource{
 					Pty: &libvirtxml.DomainChardevSourcePty{
 						Path: sourcePath.(string),
+					},
+				}
+			}
+		case "file":
+			if sourcePath, ok := d.GetOk(prefix + ".source_path"); ok {
+				console.Source = &libvirtxml.DomainChardevSource{
+					File: &libvirtxml.DomainChardevSourceFile{
+						Path: sourcePath.(string),
+						Append: "on",
 					},
 				}
 			}

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -337,6 +337,16 @@ func resourceLibvirtDomain() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"connect_host": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"connect_service": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Changes Introduced:  
1. Extended Console Types:  
   - Added support for the following console types:
     - file  
     - udp

This pull request addresses issue #1132 by extending the supported console types in the Terraform Provider for libvirt to include options such as file, udp