### PR TITLE
Make vcpu a block property

### DIFF
--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -525,10 +525,18 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 		Value: uint(d.Get("memory").(int)),
 		Unit:  "MiB",
 	}
-	domainDef.VCPU = &libvirtxml.DomainVCPU{
-		CPUSet: d.Get("vcpu.0.cpuset").(string),
-		Placement: d.Get("vcpu.0.placement").(string),
-		Value: uint(d.Get("vcpu.0.count").(int)),
+	if vcpuCount, ok := d.GetOk("vcpu.0.count"); ok {
+		domainDef.VCPU = &libvirtxml.DomainVCPU{
+			CPUSet: d.Get("vcpu.0.cpuset").(string),
+			Placement: d.Get("vcpu.0.placement").(string),
+			Value: uint(vcpuCount.(int)),
+		}
+	} else {
+		domainDef.VCPU = &libvirtxml.DomainVCPU{
+			CPUSet: d.Get("vcpu.0.cpuset").(string),
+			Placement: d.Get("vcpu.0.placement").(string),
+			Value: 1,
+		}
 	}
 	domainDef.Description = d.Get("description").(string)
 

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -525,17 +525,10 @@ func resourceLibvirtDomainCreate(ctx context.Context, d *schema.ResourceData, me
 		Value: uint(d.Get("memory").(int)),
 		Unit:  "MiB",
 	}
-	if cpuSet, ok := d.GetOk("vcpu.0.cpuset"); ok {
-		domainDef.VCPU = &libvirtxml.DomainVCPU{
-			CPUSet: cpuSet.(string),
-			Placement: d.Get("vcpu.0.placement").(string),
-			Value: uint(d.Get("vcpu.0.count").(int)),
-		}
-	} else {
-		domainDef.VCPU = &libvirtxml.DomainVCPU{
-			Placement: d.Get("vcpu.0.placement").(string),
-			Value: uint(d.Get("vcpu.0.count").(int)),
-		}
+	domainDef.VCPU = &libvirtxml.DomainVCPU{
+		CPUSet: d.Get("vcpu.0.cpuset").(string),
+		Placement: d.Get("vcpu.0.placement").(string),
+		Value: uint(d.Get("vcpu.0.count").(int)),
 	}
 	domainDef.Description = d.Get("description").(string)
 

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -39,7 +39,7 @@ func TestAccLibvirtDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomResourceName, "memory", "512"),
 					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomResourceName, "vcpu", "1"),
+						"libvirt_domain."+randomResourceName, "vcpu.0.count", "1"),
 				),
 			},
 		},
@@ -87,7 +87,9 @@ func TestAccLibvirtDomain_Detailed(t *testing.T) {
 				resource "libvirt_domain" "%s" {
 					name   = "%s"
 					memory = 384
-					vcpu   = 2
+					vcpu {
+					  count = 2
+					}
 				}`, randomResourceName, randomDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLibvirtDomainExists("libvirt_domain."+randomResourceName, &domain),
@@ -96,7 +98,7 @@ func TestAccLibvirtDomain_Detailed(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_domain."+randomResourceName, "memory", "384"),
 					resource.TestCheckResourceAttr(
-						"libvirt_domain."+randomResourceName, "vcpu", "2"),
+						"libvirt_domain."+randomResourceName, "vcpu.0.count", "2"),
 				),
 			},
 		},
@@ -1431,12 +1433,16 @@ func TestAccLibvirtDomain_ShutoffMultiDomainsRunning(t *testing.T) {
 				Config: `
    				resource "libvirt_domain" "domainoff" {
 					name = "domainfalse"
-					vcpu = 1
+					vcpu {
+					  count = 1
+					}
 					running = false
 				}
 				resource "libvirt_domain" "domainok" {
 					name = "domaintrue"
-					vcpu = 1
+					vcpu {
+					  count = 1
+					}
 					running = true
 				}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -1526,7 +1532,9 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 				resource "libvirt_domain" "%s" {
 					name   = "%s"
 					memory = 384
-					vcpu   = 2
+					vcpu {
+					  count = 2
+					}
 				}`, randomDomainName, randomDomainName),
 			},
 			{
@@ -1539,7 +1547,7 @@ func TestAccLibvirtDomain_Import(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"libvirt_domain.%s-2", "memory", "384"),
 					resource.TestCheckResourceAttr(
-						"libvirt_domain.%s-2", "vcpu", "2"),
+						"libvirt_domain.%s-2", "vcpu.0.count", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
This pull requests is intended to close #1140
libvirt_domain vcpu field is made into block, where count is old vcpu count and placement and cpusets are also configured. As a result, specifying the latter fields allow to run libvirt domains on aarch64 SoCs with different cores via this provider. Further testing is required, however, to check other platforms still work as intended.
Note: i cannot confirm that acceptance tests are working. On aarch64 they also fail for me in current main branch.
I'll update documentation to this PR once the schema and functionality are confirmed and approved by maintainers.
