### PR TITLE
fix: get ssh username from ~/.ssh/config, if not specified in uri

### DIFF
--- a/libvirt/uri/ssh.go
+++ b/libvirt/uri/ssh.go
@@ -118,7 +118,7 @@ func (u *ConnectionURI) parseAuthMethods(target string, sshcfg *ssh_config.Confi
 // construct the whole ssh connection, which can consist of multiple hops if using proxy jumps,
 // the ssh configuration file is loaded once and passed along to each host connection.
 func (u *ConnectionURI) dialSSH() (net.Conn, error) {
-	var sshcfg* ssh_config.Config = nil
+	var sshcfg *ssh_config.Config = nil
 
 	sshConfigFile, err := os.Open(os.ExpandEnv(defaultSSHConfigFile))
 	if err != nil {
@@ -277,12 +277,13 @@ func (u *ConnectionURI) dialHost(target string, sshcfg *ssh_config.Config, depth
 	// cfg.User value defaults to u.User.Username()
 	if sshcfg != nil {
 		sshu, err := sshcfg.Get(target, "User")
-		if err != nil {
-			log.Printf("[DEBUG] ssh user for target '%v' is overridden to '%v'", target, sshu)
+		if err == nil && sshu != "" && cfg.User == "" {
+			// get username from ~/.ssh/config
+			// if uri doesn't contains username
+			log.Printf("[DEBUG] ssh user for target '%v' is set to '%v'", target, sshu)
 			cfg.User = sshu
 		}
 	}
-
 
 	cfg.Auth = u.parseAuthMethods(target, sshcfg)
 	if len(cfg.Auth) < 1 {


### PR DESCRIPTION
Fix allows to use

```
provider "libvirt" {
 uri ="qemu+ssh://mn0/system?no_verify=1&sshauth=privkey"
}
```

in addition to:
```
provider "libvirt" {
 uri = "qemu+ssh://p.safonov@mn0/system?no_verify=1&sshauth=privkey"
}
```
Then username is specified in ~/.ssh/config:
```
Host micronode0 mn0
    User p.safonov # read this string
    Port 22
    HostName 10.128.4.38
    IdentityFile /home/pavel/.ssh/server/pp/pp_mn0
    IdentitiesOnly yes
```

