### PR TITLE
fix(domain): restore error handling for network operations

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	libvirt "github.com/digitalocean/go-libvirt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -194,10 +193,19 @@ func domainGetIfacesInfo(virConn *libvirt.Libvirt, domain libvirt.Domain, rd *sc
 	var interfaces []libvirt.DomainInterface
 	interfaces, err = virConn.DomainInterfaceAddresses(domain, addrsrc, 0)
 	if err != nil {
-		return interfaces, fmt.Errorf("error retrieving interface addresses: %w", err)
+		switch virErr := err.(type) {
+		case libvirt.Error:
+			// Agent can be unresponsive if being installed/setup
+			if addrsrc == uint32(libvirt.DomainInterfaceAddressesSrcLease) && virErr.Code != uint32(libvirt.ErrOperationInvalid) ||
+				addrsrc == uint32(libvirt.DomainInterfaceAddressesSrcAgent) && virErr.Code != uint32(libvirt.ErrAgentUnresponsive) {
+				return interfaces, fmt.Errorf("error retrieving interface addresses: %w", err)
+			}
+			// If it is ErrAgentUnresponsive, continue trying
+			return interfaces, nil
+		default:
+			return interfaces, fmt.Errorf("error retrieving interface addresses: %w", virErr)
+		}
 	}
-	log.Printf("[DEBUG] Interfaces info obtained with libvirt API:\n%s\n", spew.Sdump(interfaces))
-
 	return interfaces, nil
 }
 

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -193,8 +193,8 @@ func domainGetIfacesInfo(virConn *libvirt.Libvirt, domain libvirt.Domain, rd *sc
 	var interfaces []libvirt.DomainInterface
 	interfaces, err = virConn.DomainInterfaceAddresses(domain, addrsrc, 0)
 	if err != nil {
-		switch virErr := err.(type) {
-		case libvirt.Error:
+		var virErr libvirt.Error
+		if errors.As(err, &virErr) {
 			// Agent can be unresponsive if being installed/setup
 			if addrsrc == uint32(libvirt.DomainInterfaceAddressesSrcLease) && virErr.Code != uint32(libvirt.ErrOperationInvalid) ||
 				addrsrc == uint32(libvirt.DomainInterfaceAddressesSrcAgent) && virErr.Code != uint32(libvirt.ErrAgentUnresponsive) {
@@ -202,9 +202,8 @@ func domainGetIfacesInfo(virConn *libvirt.Libvirt, domain libvirt.Domain, rd *sc
 			}
 			// If it is ErrAgentUnresponsive, continue trying
 			return interfaces, nil
-		default:
-			return interfaces, fmt.Errorf("error retrieving interface addresses: %w", virErr)
 		}
+		return interfaces, fmt.Errorf("error retrieving interface addresses: %w", err)
 	}
 	return interfaces, nil
 }


### PR DESCRIPTION
Restore critical error checks for network
These checks are necessary to ensure proper error propagation when network operations fail.

Fixes #1091


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for retrieving network interface addresses, resulting in improved system resilience.
  - Adjusted the response to specific non-critical issues, allowing the process to continue smoothly under certain error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->