### PR TITLE
Add ability to set mode=private to a macvlan interface. 

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -755,6 +755,13 @@ func setNetworkInterfaces(d *schema.ResourceData, domainDef *libvirtxml.Domain,
 					Mode: "vepa",
 				},
 			}
+		} else if devI, ok := d.GetOk(prefix + ".private"); ok {
+			netIface.Source = &libvirtxml.DomainInterfaceSource{
+				Direct: &libvirtxml.DomainInterfaceSourceDirect{
+					Dev:  devI.(string),
+					Mode: "private",
+				},
+			}
 		} else if devI, ok := d.GetOk(prefix + ".macvtap"); ok {
 			netIface.Source = &libvirtxml.DomainInterfaceSource{
 				Direct: &libvirtxml.DomainInterfaceSourceDirect{

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -998,7 +998,7 @@ func resourceLibvirtDomainRead(ctx context.Context, d *schema.ResourceData, meta
 			"network_name":   "",
 			"bridge":         "",
 			"vepa":           "",
-			"private":           "",
+			"private":        "",
 			"macvtap":        "",
 			"passthrough":    "",
 			"mac":            mac,

--- a/libvirt/resource_libvirt_domain.go
+++ b/libvirt/resource_libvirt_domain.go
@@ -214,6 +214,10 @@ func resourceLibvirtDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"private": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"macvtap": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -994,6 +998,7 @@ func resourceLibvirtDomainRead(ctx context.Context, d *schema.ResourceData, meta
 			"network_name":   "",
 			"bridge":         "",
 			"vepa":           "",
+			"private":           "",
 			"macvtap":        "",
 			"passthrough":    "",
 			"mac":            mac,
@@ -1045,6 +1050,8 @@ func resourceLibvirtDomainRead(ctx context.Context, d *schema.ResourceData, meta
 			switch networkInterfaceDef.Source.Direct.Mode {
 			case "vepa":
 				netIface["vepa"] = networkInterfaceDef.Source.Direct.Dev
+			case "private":
+				netIface["private"] = networkInterfaceDef.Source.Direct.Dev
 			case "bridge":
 				netIface["macvtap"] = networkInterfaceDef.Source.Direct.Dev
 			case "passthrough":

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -377,6 +377,8 @@ When connecting to a LAN, users can specify a target device with:
   sent to the VF/IF of the configured network device. Depending on the
   capabilities of the device additional prerequisites or limitations may apply;
   for example, on Linux this requires kernel 2.6.38 or newer.
+* `private` -  All packets are sent to the external bridge and will only be delivered to a target VM on the same host if they are sent through an external router or gateway and that device sends them back to the host. This procedure is followed if either the source or destination device is in private mode.
+
 
 Example of a `macvtap` interface:
 


### PR DESCRIPTION
As discussed in in open issues this is a pull-request to add mode=private to a MACVLAN interfaces, completing all current available options for this type of interface. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "private" network interface mode that enables users to configure virtual machines with private networking options.

- **Documentation**
  - Updated documentation to explain the behavior of private networking, including how packets are routed through external bridges and routers under this mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->