### PR TITLE
Add "port" parameter to the "graphics" schema

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -365,6 +365,16 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 				listener,
 			}
 
+			// Handle port parameter for VNC
+			if port, ok := d.GetOk(prefix + ".port"); ok && port.(string) != "" {
+				// Port is specified, set it and ensure autoport is false
+				domainDef.Devices.Graphics[0].VNC.Port = port.(string)
+				domainDef.Devices.Graphics[0].VNC.AutoPort = "no"
+			} else {
+				// Port not specified, set to -1 (default)
+				domainDef.Devices.Graphics[0].VNC.Port = "-1"
+			}
+
 			if websocket, ok := d.GetOk(prefix + ".websocket"); ok {
 				domainDef.Devices.Graphics[0].VNC.WebSocket = websocket.(int)
 			}

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -367,12 +367,14 @@ func setGraphics(d *schema.ResourceData, domainDef *libvirtxml.Domain, arch stri
 
 			// Handle port parameter for VNC
 			if port, ok := d.GetOk(prefix + ".port"); ok && port.(string) != "" {
-				// Port is specified, set it and ensure autoport is false
-				domainDef.Devices.Graphics[0].VNC.Port = port.(string)
-				domainDef.Devices.Graphics[0].VNC.AutoPort = "no"
+				// Port is specified, convert to int and set it
+				if portNum, err := strconv.Atoi(port.(string)); err == nil {
+					domainDef.Devices.Graphics[0].VNC.Port = portNum
+					domainDef.Devices.Graphics[0].VNC.AutoPort = "no"
+				}
 			} else {
 				// Port not specified, set to -1 (default)
-				domainDef.Devices.Graphics[0].VNC.Port = "-1"
+				domainDef.Devices.Graphics[0].VNC.Port = -1
 			}
 
 			if websocket, ok := d.GetOk(prefix + ".websocket"); ok {


### PR DESCRIPTION
## Summary

Add support for custom port configuration in VNC graphics for libvirt domains. This feature allows users to specify a fixed port number for VNC connections instead of relying on automatic port assignment.

## Changes

- **Add `port` parameter to graphics schema**: Optional string parameter with numeric validation
- **Implement validation constraints**: Port parameter can only be used with VNC graphics type and requires `autoport = false`
- **Update domain XML generation**: Properly handles port configuration in libvirt XML, defaults to -1 when not specified
- **Add comprehensive tests**: Covers both successful configuration and validation error cases

## Usage Example

```hcl
resource "libvirt_domain" "example" {
  name = "example-domain"
  graphics {
    type     = "vnc"
    autoport = false
    port     = "5900"
  }
}
```

Validation Rules

- Port parameter is only valid when type = "vnc"
- When port is specified, autoport must be false
- Port value must be a valid numeric string
- Configuration errors provide clear validation messages

Test Coverage

- TestAccLibvirtDomain_GraphicsVNCPort: Tests successful VNC port configuration
- TestAccLibvirtDomain_GraphicsVNCPortValidation: Tests validation scenarios including invalid type, autoport conflicts, and non-numeric values

Backward Compatibility

This change is fully backward compatible. Existing configurations continue to work unchanged, and the new port parameter is optional.