### PR TITLE
Fix permissions on lv to run vm

### DIFF
--- a/libvirt/volume_def.go
+++ b/libvirt/volume_def.go
@@ -15,7 +15,7 @@ func newDefVolume() libvirtxml.StorageVolume {
 				Type: "qcow2",
 			},
 			Permissions: &libvirtxml.StorageVolumeTargetPermissions{
-				Mode: "644",
+				Mode: "660",
 			},
 		},
 		Capacity: &libvirtxml.StorageVolumeSize{


### PR DESCRIPTION
By default, logical volumes are created with chmod 660 permissions. You cannot start a virtual machine on an LV provisioned by terraform-provider-libvirt (cannot open disk device with only 640)