### PR TITLE
Fix read TPM from state

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -853,7 +853,7 @@ func setTPMs(d *schema.ResourceData, domainDef *libvirtxml.Domain) {
 	prefix := "tpm.0"
 	if _, ok := d.GetOk(prefix); ok {
 		tpm := libvirtxml.DomainTPM{}
-		if model, ok := d.GetOk(".model"); ok {
+		if model, ok := d.GetOk(prefix + ".model"); ok {
 			tpm.Model = model.(string)
 		}
 

--- a/libvirt/resource_libvirt_domain_test.go
+++ b/libvirt/resource_libvirt_domain_test.go
@@ -875,6 +875,41 @@ func TestAccLibvirtDomain_Cpu(t *testing.T) {
 	})
 }
 
+func TestAccLibvirtDomain_Tpm(t *testing.T) {
+	var domain libvirt.Domain
+	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	config := fmt.Sprintf(`
+	resource "libvirt_domain" "%s" {
+		name = "%s"
+		tpm {
+			model           = "tpm-crb"
+			backend_type    = "emulator"
+			backend_version = "2.0"
+		}
+	}`, randomDomainName, randomDomainName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLibvirtDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLibvirtDomainExists("libvirt_domain."+randomDomainName, &domain),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "tpm.0.model", "tpm-crb"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "tpm.0.backend_type", "emulator"),
+					resource.TestCheckResourceAttr(
+						"libvirt_domain."+randomDomainName, "tpm.0.backend_version", "2.0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLibvirtDomain_Video(t *testing.T) {
 	var domain libvirt.Domain
 	randomDomainName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)


### PR DESCRIPTION
Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.

* TPM state was not being read. I fixed by adding it for type emulator, type tpm-crb. I would add more but I don't know what to expect from other TPM configurations.
* There was no test for TPM, so I added related to the TPM configuration above.
* There was a bug on reading the tpm.0.model from Terraform script. Without the fix in this PR, the test (new one for TPM) would have failed.  