### PR TITLE
Allow 'addresses' to specify the host IP addresses.

### DIFF
--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -27,11 +27,11 @@ func TestAccLibvirtNetwork_Addresses(t *testing.T) {
 				resource "libvirt_network" "%s" {
 					name      = "%s"
 					domain    = "k8s.local"
-					addresses = ["10.17.3.0/24"]
+					addresses = ["10.17.3.1/24"]
 				}`, randomNetworkResource, randomNetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(randomNetworkResourceFull,
-						"addresses.0", "10.17.3.0/24"),
+						"addresses.0", "10.17.3.1/24"),
 					resource.TestCheckResourceAttr(randomNetworkResourceFull,
 						"mode", "nat"),
 				),

--- a/libvirt/utils_net.go
+++ b/libvirt/utils_net.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net"
+	"strings"
 )
 
 // randomMACAddress returns a randomized MAC address
@@ -69,4 +70,17 @@ func networkRange(network *net.IPNet) (firstIP net.IP, lastIP net.IP) {
 	}
 
 	return netIP.Mask(network.Mask), getLastIP(network, netIP)
+}
+
+// sameNetworkAddress returns true if both input strings (in addr/netmask format)
+// have the same network address
+func sameNetworkAddress(a, b string) bool {
+	_, netA, errA := net.ParseCIDR(strings.TrimSpace(a))
+	_, netB, errB := net.ParseCIDR(strings.TrimSpace(b))
+
+	if errA != nil || errB != nil {
+		return false // if either can't be parsed, treat as different
+	}
+
+	return netA.IP.Equal(netB.IP) && netA.Mask.String() == netB.Mask.String()
 }


### PR DESCRIPTION
Currently "addresses" argument is used to set IPs and also DHCP options, but the host address part of addresses is ignored. This change uses the full IP address of "addresses" to actually set the host address while keeping the existing DHCP related behavior. Refs #1188.
