### PR TITLE
for machine q35 use sata

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -582,9 +582,13 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 
 			if strings.HasSuffix(url.Path, ".iso") {
 				disk.Device = "cdrom"
+				bus := "ide"
+				if strings.Contains(domainDef.OS.Type.Machine, "q35") {
+					bus = "sata"
+				}
 				disk.Target = &libvirtxml.DomainDiskTarget{
 					Dev: fmt.Sprintf("hd%s", diskLetterForIndex(numOfISOs)),
-					Bus: "ide",
+					Bus: bus,
 				}
 				disk.Driver = &libvirtxml.DomainDiskDriver{
 					Name: "qemu",
@@ -605,9 +609,13 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 
 			if strings.HasSuffix(file.(string), ".iso") {
 				disk.Device = "cdrom"
+				bus := "ide"
+				if strings.Contains(domainDef.OS.Type.Machine, "q35") {
+					bus = "sata"
+				}
 				disk.Target = &libvirtxml.DomainDiskTarget{
 					Dev: fmt.Sprintf("hd%s", diskLetterForIndex(numOfISOs)),
-					Bus: "ide",
+					Bus: bus,
 				}
 				disk.Driver = &libvirtxml.DomainDiskDriver{
 					Name: "qemu",


### PR DESCRIPTION
Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.

on NixOS, i tried to create a VM for talos linux and encountered the following error

I compared to a machine not created with the provided and found the provider created a VM with machine of type pc-i440fx-10.0.

I then went ahead and added     "machine = "pc-q35-10.0" " to my terraform.
then i got the error

```
│ Error: error defining libvirt domain: unsupported configuration: IDE controllers are unsupported for this QEMU binary or machine type
│ 
│   with libvirt_domain.vm["talos-1"],
│   on main.tf line 51, in resource "libvirt_domain" "vm":
│   51: resource "libvirt_domain" "vm" {
│
```
to which i added the lines in the commit to create a sata bus in the volume if the machine is of type q35.
