### PR TITLE
ci: add acceptance tests with TCG emulation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,14 @@ jobs:
             libvirt-clients \
             libvirt-dev
 
-      - name: Start libvirtd
+      - name: Start libvirtd and configure permissions
         run: |
           sudo systemctl start libvirtd
           sudo systemctl status libvirtd
+          # Add runner to libvirt group
+          sudo usermod -a -G libvirt runner
+          # Change socket permissions to allow group access
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
 
       - name: Install Terraform
         if: matrix.tf-binary == 'terraform'


### PR DESCRIPTION
Enable acceptance tests in GitHub Actions using QEMU TCG emulation. Tests run in a matrix with both Terraform and OpenTofu.

Sets TF_PROVIDER_LIBVIRT_DOMAIN_TYPE=qemu to force TCG instead of KVM, allowing tests to run in environments without nested virtualization support.