### PR TITLE
feat: Undefine on update toggle

### DIFF
--- a/internal/libvirt/client.go
+++ b/internal/libvirt/client.go
@@ -14,8 +14,9 @@ import (
 
 // Client wraps the libvirt connection and provides helper methods
 type Client struct {
-	conn *libvirt.Libvirt
-	uri  string
+	conn             *libvirt.Libvirt
+	uri              string
+	UndefineOnUpdate bool
 }
 
 // NewClient creates a new libvirt client from a connection URI
@@ -74,6 +75,10 @@ func (c *Client) Libvirt() *libvirt.Libvirt {
 // URI returns the connection URI
 func (c *Client) URI() string {
 	return c.uri
+}
+
+func (c *Client) IsUndefineOnUpdate() bool {
+	return c.UndefineOnUpdate
 }
 
 // Ping verifies the connection is still alive

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -822,12 +822,14 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	if err := r.client.Libvirt().DomainUndefine(existingDomain); err != nil {
-		resp.Diagnostics.AddError(
-			"Domain Undefine Failed",
-			"Failed to undefine existing domain: "+err.Error(),
-		)
-		return
+	if r.client.IsUndefineOnUpdate() {
+		if err := r.client.Libvirt().DomainUndefine(existingDomain); err != nil {
+			resp.Diagnostics.AddError(
+				"Domain Undefine Failed",
+				"Failed to undefine existing domain: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	newDomain, err := r.client.Libvirt().DomainDefineXML(xmlString)


### PR DESCRIPTION
Exposes a provider level configuration to toggle undefining domains on update. The current default behavior is to undefine on update, but this causes issues with some setups (eg. efi vms with nvram).
This change makes it configurable, defaulting to the current behavior for backward compatibility.

Another option what we can do is also modify the Undefine behaviour (with `DomainUndefineFlags(existingDomain, flags)`) and select to undefine `nvram` explicitly (this removes nvram), preferably by exposing a config toggle. But IMHO then the user should just tell terraform to recreate the resource. 

An example change (lowering the amount of ram) where it fails.
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # libvirt_domain.builder-win will be updated in-place
  ~ resource "libvirt_domain" "builder-win" {
        id          = 56
      ~ memory      = 4096 -> 2096
        name        = "builder-win"
        # (10 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
libvirt_domain.builder-win: Modifying... [name=builder-win]
╷
│ Error: Domain Undefine Failed
│
│   with libvirt_domain.builder-win,
│   on builder-win.tf line 1, in resource "libvirt_domain" "builder-win":
│    1: resource "libvirt_domain" "builder-win" {
│
│ Failed to undefine existing domain: Requested operation is not valid: cannot undefine domain with nvram
```

With the patch and update to the provider config.
```
provider "libvirt" {
  uri = "qemu:///system"
  undefine_on_update = false
}
```
Log:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # libvirt_domain.builder-win will be updated in-place
  ~ resource "libvirt_domain" "builder-win" {
        id          = 56
      ~ memory      = 4096 -> 2096
        name        = "builder-win"
        # (10 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
libvirt_domain.builder-win: Modifying... [name=builder-win]
libvirt_domain.builder-win: Modifications complete after 1s [name=builder-win]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Verify the change:
```
virsh  dumpxml builder-win | grep currentMemory
  <currentMemory unit='KiB'>2146304</currentMemory>
```