### PR TITLE
fix: return empty list instead of null when user explicitly sets []

### DIFF
--- a/internal/codegen/templates/convert.go.tmpl
+++ b/internal/codegen/templates/convert.go.tmpl
@@ -230,6 +230,13 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 				return nil, fmt.Errorf("converting {{ .GoName }} to List: %s", diags.Errors()[0].Summary())
 			}
 			model.{{ .GoName }} = listVal
+		} else if plan != nil && !plan.{{ .GoName }}.IsNull() {
+			// User explicitly set an empty list - return empty list to preserve intent
+			listVal, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: {{ .NestedStruct.Name }}AttributeTypes()}, []{{ .NestedStruct.Name }}Model{})
+			if diags.HasError() {
+				return nil, fmt.Errorf("converting {{ .GoName }} to List: %s", diags.Errors()[0].Summary())
+			}
+			model.{{ .GoName }} = listVal
 		} else {
 			model.{{ .GoName }} = types.ListNull(types.ObjectType{AttrTypes: {{ .NestedStruct.Name }}AttributeTypes()})
 		}
@@ -247,6 +254,13 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 				}
 			}
 			listVal, diags := types.ListValueFrom(ctx, {{ .ElementType }}, values)
+			if diags.HasError() {
+				return nil, fmt.Errorf("converting {{ .GoName }} to List: %s", diags.Errors()[0].Summary())
+			}
+			model.{{ .GoName }} = listVal
+		} else if plan != nil && !plan.{{ .GoName }}.IsNull() {
+			// User explicitly set an empty list - return empty list to preserve intent
+			listVal, diags := types.ListValueFrom(ctx, {{ .ElementType }}, xml.{{ .GoName }})
 			if diags.HasError() {
 				return nil, fmt.Errorf("converting {{ .GoName }} to List: %s", diags.Errors()[0].Summary())
 			}


### PR DESCRIPTION
Previously, when a user set an empty list like `hostdevs = []`, the provider returned `null` instead of `[]` after apply, causing "Provider produced inconsistent result after apply" errors.

The fix adds a check: when the plan has an explicitly set (non-null) list but the XML has no elements, return an empty list to preserve user intent. This applies to both nested object lists and simple value lists.

- Import/datasource (no plan): still returns null for absent data
- User set `field = []`: now correctly returns `[]`
- User set `field = null` or omitted: returns null

Fixes #1247