### PR TITLE
fix: allow integer fields with value 0 to be returned correctly

### DIFF
--- a/internal/codegen/templates/convert.go.tmpl
+++ b/internal/codegen/templates/convert.go.tmpl
@@ -87,11 +87,7 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 				model.{{ $.GoName }}{{ .GoName }} = types.StringNull()
 			}
 			{{- else }}
-			if xml.{{ $.GoName }}.{{ .GoName }} != 0 {
-				model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
-			} else {
-				model.{{ $.GoName }}{{ .GoName }} = types.Int64Null()
-			}
+			model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
 			{{- end }}
 			{{- end }}
 		} else {
@@ -122,11 +118,7 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 			model.{{ $.GoName }}{{ .GoName }} = types.StringNull()
 		}
 		{{- else }}
-		if xml.{{ $.GoName }}.{{ .GoName }} != 0 {
-			model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
-		} else {
-			model.{{ $.GoName }}{{ .GoName }} = types.Int64Null()
-		}
+		model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
 		{{- end }}
 		{{- end }}
 		{{- end }}
@@ -150,11 +142,7 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 				model.{{ $.GoName }}{{ .GoName }} = types.StringNull()
 			}
 			{{- else }}
-			if xml.{{ $.GoName }}.{{ .GoName }} != 0 {
-				model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
-			} else {
-				model.{{ $.GoName }}{{ .GoName }} = types.Int64Null()
-			}
+			model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
 			{{- end }}
 		} else {
 			{{- if eq .GoType "string" }}
@@ -171,11 +159,7 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 			model.{{ $.GoName }}{{ .GoName }} = types.StringNull()
 		}
 		{{- else }}
-		if xml.{{ $.GoName }}.{{ .GoName }} != 0 {
-			model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
-		} else {
-			model.{{ $.GoName }}{{ .GoName }} = types.Int64Null()
-		}
+		model.{{ $.GoName }}{{ .GoName }} = types.Int64Value(int64(xml.{{ $.GoName }}.{{ .GoName }}))
 		{{- end }}
 		{{- end }}
 	} else if !plan.{{ $.GoName }}{{ .GoName }}.IsNull() && !plan.{{ $.GoName }}{{ .GoName }}.IsUnknown() {
@@ -338,17 +322,13 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 		{{- end }}
 	{{- else if eq .TFType "types.Int64" }}
 		{{- if .IsPointer }}
-	if xml.{{ .GoName }} != nil && *xml.{{ .GoName }} != 0 {
+	if xml.{{ .GoName }} != nil {
 		model.{{ .GoName }} = types.Int64Value(int64(*xml.{{ .GoName }}))
 	} else {
 		model.{{ .GoName }} = types.Int64Null()
 	}
 		{{- else }}
-	if xml.{{ .GoName }} != 0 {
-		model.{{ .GoName }} = types.Int64Value(int64(xml.{{ .GoName }}))
-	} else {
-		model.{{ .GoName }} = types.Int64Null()
-	}
+	model.{{ .GoName }} = types.Int64Value(int64(xml.{{ .GoName }}))
 		{{- end }}
 	{{- else if eq .TFType "types.Bool" }}
 		{{- if .IsPointer }}
@@ -402,17 +382,13 @@ func {{ .Name }}ToXML(ctx context.Context, model *{{ .Name }}Model) (*libvirtxml
 		{{- end }}
 		{{- else if eq .TFType "types.Int64" }}
 		{{- if .IsPointer }}
-		if xml.{{ .GoName }} != nil && *xml.{{ .GoName }} != 0 {
+		if xml.{{ .GoName }} != nil {
 			model.{{ .GoName }} = types.Int64Value(int64(*xml.{{ .GoName }}))
 		} else {
 			model.{{ .GoName }} = types.Int64Null()
 		}
 		{{- else }}
-		if xml.{{ .GoName }} != 0 {
-			model.{{ .GoName }} = types.Int64Value(int64(xml.{{ .GoName }}))
-		} else {
-			model.{{ .GoName }} = types.Int64Null()
-		}
+		model.{{ .GoName }} = types.Int64Value(int64(xml.{{ .GoName }}))
 		{{- end }}
 		{{- else if eq .TFType "types.Bool" }}
 		{{- if .IsPresenceBoolean }}


### PR DESCRIPTION
Previously, the codegen template incorrectly treated integer values of 0 as null/empty when converting XML to Terraform state. This caused PCI address fields (domain, bus, slot, function) with value 0 to be returned as null, resulting in "Provider produced inconsistent result after apply" errors.

Most PCI devices have domain=0, and many have slot=0 or function=0 (e.g., 0000:03:00.0), making PCI passthrough unusable without workarounds.

The fix removes the `!= 0` checks from convert.go.tmpl:
- For pointer fields: only check `!= nil`
- For non-pointer fields: always set the value

This affects 8 locations in the template covering computed, optional, and flattened value attribute fields.

Fixes #1246: perpetual drift for PCI passthrough devices where any address component equals.
