### PR TITLE
Proposal for dnsmasq:options support

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -24,6 +24,7 @@ Virtual network configuration
 - `autostart` (Boolean) Whether the network should be started automatically when the host boots
 - `bandwidth` (Attributes) Configures the bandwidth settings for the virtual network, specifying what limits are applied to data transport. (see [below for nested schema](#nestedatt--bandwidth))
 - `bridge` (Attributes) (see [below for nested schema](#nestedatt--bridge))
+- `dnsmasq_options` (String List) Appends <dnsmasq:options> to Network definition
 - `dns` (Attributes) DNS configuration for the network (see [below for nested schema](#nestedatt--dns))
 - `domain` (Attributes) Configures the domain associated with the network. (see [below for nested schema](#nestedatt--domain))
 - `forward` (Attributes) Network forwarding mode configuration (see [below for nested schema](#nestedatt--forward))


### PR DESCRIPTION
I wrote a small addition to optional fields without complicating the parsing with XML Namespace support.

The dnsmasq_options field is a simple list of string and it works in an analogue way as autostrart and bridge.

Example 

```
  dnsmasq_options = [
    "server=/test.example.com/192.168.200.1",
    "test"
  ]
```

Correctly ends up in:

```
  <dnsmasq:options>
    <dnsmasq:option value='server=/test.example.com/192.168.200.1'/>
    <dnsmasq:option value='test'/>
  </dnsmasq:options>
```