### PR TITLE
fix: propagate backing store format type to target volume (#1275)

### DIFF
--- a/internal/provider/volume_resource.go
+++ b/internal/provider/volume_resource.go
@@ -248,6 +248,20 @@ func (r *VolumeResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Auto-propagate backing store format to volume target format if not explicitly set
+	// Libvirt defaults to 'raw' which rejects backing stores; this ensures a compatible
+	// format (e.g. qcow2) is used when the user specifies it on the backing store
+	if volumeDef.BackingStore != nil && volumeDef.BackingStore.Format != nil {
+		if volumeDef.Target == nil {
+			volumeDef.Target = &libvirtxml.StorageVolumeTarget{}
+		}
+		if volumeDef.Target.Format == nil {
+			volumeDef.Target.Format = &libvirtxml.StorageVolumeTargetFormat{
+				Type: volumeDef.BackingStore.Format.Type,
+			}
+		}
+	}
+
 	// Marshal to XML
 	xmlDoc, err := volumeDef.Marshal()
 	if err != nil {

--- a/internal/provider/volume_resource_test.go
+++ b/internal/provider/volume_resource_test.go
@@ -350,3 +350,63 @@ resource "libvirt_volume" "test" {
 }
 `, name, poolPath, sourceFile)
 }
+
+// Test: backing_store with format but no explicit target.format (auto-propagation)
+func TestAccVolumeResource_backingStoreAutoFormat(t *testing.T) {
+	poolPath := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeResourceConfigBackingStoreAutoFormat("test-volume-auto", poolPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_volume.base", "name", "test-volume-auto-base.qcow2"),
+					resource.TestCheckResourceAttr("libvirt_volume.cow", "name", "test-volume-auto.qcow2"),
+					resource.TestCheckResourceAttrSet("libvirt_volume.cow", "backing_store.path"),
+					resource.TestCheckResourceAttr("libvirt_volume.cow", "backing_store.format.type", "qcow2"),
+					// target.format.type should be auto-propagated from backing_store.format
+					resource.TestCheckResourceAttr("libvirt_volume.cow", "target.format.type", "qcow2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVolumeResourceConfigBackingStoreAutoFormat(name, poolPath string) string {
+	return fmt.Sprintf(`
+
+resource "libvirt_pool" "test" {
+  name = "test-pool-backing-auto"
+  type = "dir"
+  target = {
+    path = %[2]q
+  }
+}
+
+resource "libvirt_volume" "base" {
+  name     = "%[1]s-base.qcow2"
+  pool     = libvirt_pool.test.name
+  capacity = 1073741824
+  target = {
+    format = {
+      type = "qcow2"
+    }
+  }
+}
+
+resource "libvirt_volume" "cow" {
+  name     = "%[1]s.qcow2"
+  pool     = libvirt_pool.test.name
+  capacity = 1073741824
+
+  backing_store = {
+    path = libvirt_volume.base.path
+    format = {
+      type = "qcow2"
+    }
+  }
+}
+`, name, poolPath)
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #1275 by ensuring that a volume correctly inherits the `format` attribute from its `backing_store` if a target format is not explicitly defined.

Previously, Libvirt would default the new volume to `raw`. Since `raw` volumes do not support backing stores, this resulted in a "backing storage not supported" error, even when the user intended to create a `qcow2` overlay. This change improves the provider's ergonomics by propagating the format type during XML marshaling.

## Changes

* **Logic:** added a check in `internal/provider/volume_resource.go` to propagate `backing_store.format.type` to `target.format.type` if the latter is nil.

* **Documentation:**
  * Updated `docs/resources/volume.md` and examples to remove the non-existent top-level `format` attribute.
  * Fixed `backing_store` examples to use the correct object schema (`{ type = "qcow2" }`) instead of a string.
* **Testing:** added `TestAccVolumeResource_backingStoreAutoFormat` to verify the fix.

## Verification Results
I did not run the full `make testacc` suite locally, because I'm using `libvirt` myself on my workstation and I was a bit concerned about potential side effects.

However, I verified the fix using a local build and provider override:

1. Compiled the provider locally.
2. Linked it via `dev_overrides` in `~/.terraformrc`.

Provisioned a 4-node Kubernetes lab using Debian 12 QCOW2 cloud images.

**Before fix:** Terraform failed with `Failed to create storage volume: ... backing storage not supported for raw volumes`.
**After fix:** all volumes created successfully as QCOW2 overlays with 196KiB initial allocation and 20GiB capacity.

The set of Terraform resources used for the validation (the ones that matter):

### Module implementation
```hcl
# main.tf

terraform {
  required_version = ">=1.14.0"

  required_providers {
    libvirt = {
      source  = "dmacvicar/libvirt"
      version = "~> 0.9.2"
    }
  }
}
```
```hcl
# variables.tf

variable "pool" {
  type = object({
    name = string
    path = string 
  })
}

variable "k8s_nodes" {
  type    = number
  default = 4
}

variable "k8s_base_image" {
  type = object({
    name   = string
    source = string
    format = string
  })

  default = {
    name   = "debian-12-base.qcow2"
    source = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2"
    format = "qcow2"
  }
}
```
```hcl
# pool.tf

# Create a dedicated pool for the lab
resource "libvirt_pool" "k8s_lab" {
  name = var.pool.name
  type = "dir"

  target = {
    path = var.pool.path
  }
}

# Base image, downloaded once
resource "libvirt_volume" "base_image" {
  pool   = libvirt_pool.k8s_lab.name
  name   = var.k8s_base_image.name

  create = {
    content = {
      url = var.k8s_base_image.source
    }
  }
}

# Individual disks for k8s nodes (thin-provisioned)
resource "libvirt_volume" "node_disk" {
  count = var.k8s_nodes

  pool = libvirt_pool.k8s_lab.name
  name = "k8s-node-${count.index}.${var.k8s_base_image.format}"
  
  # 20 GB in bytes
  capacity = 20 * 1024 * 1024 * 1024

  backing_store = {
    path = libvirt_volume.base_image.path
    
    format = {
        type = var.k8s_base_image.format
    }
  }
}
```
### Terraform manifest (module path redacted)
```hcl
terraform {
  required_version = "1.14.5"

  required_providers {
    libvirt = {
      source  = "dmacvicar/libvirt"
      version = "~> 0.9.2"
    }
  }
}

provider "libvirt" {
  uri = "qemu:///system"
}

locals {
  pool = {
    name = "k8s-lab-1"
    path = "/var/lib/libvirt/k8s-lab-1-images"
  }
}

module "lab" {
  source = "<module_path>"

  network = local.network
  pool    = local.pool
}
```