### PR TITLE
bug: add secure flag for GetXMLDesc

### DIFF
--- a/internal/provider/data_source_node_device_info.go
+++ b/internal/provider/data_source_node_device_info.go
@@ -210,7 +210,7 @@ func (d *NodeDeviceInfoDataSource) Read(ctx context.Context, req datasource.Read
 	deviceName := data.Name.ValueString()
 
 	// Get device XML
-	xmlDesc, err := d.client.Libvirt().NodeDeviceGetXMLDesc(deviceName, 0)
+	xmlDesc, err := d.client.Libvirt().NodeDeviceGetXMLDesc(deviceName, 1)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get device information",

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -567,7 +567,7 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 	}
 
-	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(domain, 0)
+	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(domain, 1)
 	if err != nil {
 		cleanupOnError()
 		resp.Diagnostics.AddError(
@@ -663,7 +663,7 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(domain, 0)
+	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(domain, 1)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Read Domain",
@@ -879,7 +879,7 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
-	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(newDomain, 0)
+	xmlDesc, err := r.client.Libvirt().DomainGetXMLDesc(newDomain, 1)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Read Domain",

--- a/internal/provider/network_resource.go
+++ b/internal/provider/network_resource.go
@@ -332,7 +332,7 @@ func (r *NetworkResource) ImportState(ctx context.Context, req resource.ImportSt
 // readNetwork reads network state from libvirt and populates the model
 func (r *NetworkResource) readNetwork(ctx context.Context, model *NetworkResourceModel, net golibvirt.Network, plan *generated.NetworkModel) error {
 	// Get network XML
-	xmlDoc, err := r.client.Libvirt().NetworkGetXMLDesc(net, 0)
+	xmlDoc, err := r.client.Libvirt().NetworkGetXMLDesc(net, 1)
 	if err != nil {
 		return fmt.Errorf("failed to get network XML: %w", err)
 	}

--- a/internal/provider/pool_resource.go
+++ b/internal/provider/pool_resource.go
@@ -316,7 +316,7 @@ func (r *PoolResource) readPoolWithPlan(ctx context.Context, model *PoolResource
 	var diags diag.Diagnostics
 
 	// Get pool XML
-	xmlDoc, err := r.client.Libvirt().StoragePoolGetXMLDesc(pool, 0)
+	xmlDoc, err := r.client.Libvirt().StoragePoolGetXMLDesc(pool, 1)
 	if err != nil {
 		diags.AddError(
 			"Failed to Get Pool XML",
@@ -390,7 +390,7 @@ func (r *PoolResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Get pool XML to check if we should delete the underlying storage
-	xmlDoc, err := r.client.Libvirt().StoragePoolGetXMLDesc(pool, 0)
+	xmlDoc, err := r.client.Libvirt().StoragePoolGetXMLDesc(pool, 1)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Get Pool XML",


### PR DESCRIPTION
When using private data, such as a VNC password, etc., it is recorded and then requested from the server, but due to the lack of the DomainXMLSecure flag (1), null is returned instead. Without the flag (0), passwords are actually set, but the provider returns an error when checking. Issue #1242