### PR TITLE
fix: honor destroy.graceful via domain destroy flags

### DIFF
--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -69,8 +69,7 @@ type DomainCreateModel struct {
 
 // DomainDestroyModel describes domain shutdown behavior
 type DomainDestroyModel struct {
-	Graceful types.Bool  `tfsdk:"graceful"`
-	Timeout  types.Int64 `tfsdk:"timeout"`
+	Graceful types.Bool `tfsdk:"graceful"`
 }
 
 type domainPlanData struct {
@@ -399,6 +398,25 @@ func domainStartFlagsFromCreate(ctx context.Context, createVal types.Object) (ui
 	return flags, nil
 }
 
+func domainDestroyFlagsFromDestroy(ctx context.Context, destroyVal types.Object) (golibvirt.DomainDestroyFlagsValues, diag.Diagnostics) {
+	flags := golibvirt.DomainDestroyDefault
+	if destroyVal.IsNull() || destroyVal.IsUnknown() {
+		return flags, nil
+	}
+
+	var destroyModel DomainDestroyModel
+	diags := destroyVal.As(ctx, &destroyModel, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		return flags, diags
+	}
+
+	if !destroyModel.Graceful.IsNull() && destroyModel.Graceful.ValueBool() {
+		flags |= golibvirt.DomainDestroyGraceful
+	}
+
+	return flags, nil
+}
+
 // Metadata returns the resource type name
 func (r *DomainResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_domain"
@@ -433,7 +451,6 @@ func (r *DomainResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			Optional:    true,
 			Attributes: map[string]schema.Attribute{
 				"graceful": schema.BoolAttribute{Optional: true},
-				"timeout":  schema.Int64Attribute{Optional: true},
 			},
 		},
 	}
@@ -951,6 +968,12 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
+	destroyFlags, destroyDiags := domainDestroyFlagsFromDestroy(ctx, state.Destroy)
+	resp.Diagnostics.Append(destroyDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Look up the domain
 	domain, err := r.client.LookupDomainByUUID(state.UUID.ValueString())
 	if err != nil {
@@ -970,7 +993,7 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	// DomainState values: 0=nostate, 1=running, 2=blocked, 3=paused, 4=shutdown, 5=shutoff, 6=crashed, 7=pmsuspended
 	if uint32(domainState) == uint32(golibvirt.DomainRunning) {
-		err = r.client.Libvirt().DomainDestroy(domain)
+		err = r.client.Libvirt().DomainDestroyFlags(domain, destroyFlags)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Failed to Destroy Domain",

--- a/internal/provider/domain_resource_destroy_test.go
+++ b/internal/provider/domain_resource_destroy_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	golibvirt "github.com/digitalocean/go-libvirt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDomainDestroyFlagsFromDestroy(t *testing.T) {
+	t.Parallel()
+
+	destroyAttrTypes := map[string]attr.Type{
+		"graceful": types.BoolType,
+	}
+
+	tests := []struct {
+		name           string
+		destroy        types.Object
+		expectGraceful bool
+	}{
+		{
+			name:           "null uses default flags",
+			destroy:        types.ObjectNull(destroyAttrTypes),
+			expectGraceful: false,
+		},
+		{
+			name: "graceful true sets graceful flag",
+			destroy: func() types.Object {
+				obj, diags := types.ObjectValue(
+					destroyAttrTypes,
+					map[string]attr.Value{
+						"graceful": types.BoolValue(true),
+					},
+				)
+				if diags.HasError() {
+					t.Fatalf("failed to create destroy object: %v", diags)
+				}
+				return obj
+			}(),
+			expectGraceful: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags, diags := domainDestroyFlagsFromDestroy(context.Background(), tc.destroy)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			gotGraceful := flags&golibvirt.DomainDestroyGraceful != 0
+			if gotGraceful != tc.expectGraceful {
+				t.Fatalf("unexpected graceful flag: got=%t want=%t (flags=%v)", gotGraceful, tc.expectGraceful, flags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves: #1060

Note that this uses the graceful flag of the destroy operation, which is not equivalent to sending a shutdown operation, and sends a SIGTERM to QEMU and not an ACPI shutdown request to the guest.

It could be that SIGTERM makes QEMU just flushes pending IO and kill the guest rather than injecting an ACPI shutdown event vs the monitor command `system_powerdown`.

I'd be in support of adding another flag to the destroy block to attempt a shutdown. I'd not like to define a timeout for the provider, so I think if we do this, the result should be to loop indefinitely until the guest is shutoff, and if it does not, this would trigger a timeout in another layer, like terraform destroy operation, before it actually destroys the guest.