### PR TITLE
fix: Add internal/generated/imports.go for vendoring of generated sources

### DIFF
--- a/internal/generated/imports.go
+++ b/internal/generated/imports.go
@@ -1,0 +1,16 @@
+// go:build imports
+package generated
+
+// This is only here for vendoring
+
+import (
+	_ "github.com/hashicorp/terraform-plugin-framework/attr"
+	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	_ "github.com/hashicorp/terraform-plugin-framework/types"
+	_ "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	_ "libvirt.org/go/libvirtxml"
+)


### PR DESCRIPTION
The move to using generated schemas meant that 'go vendor' didn't see the imports in the generated code.  This commit adds an otherwise empty imports.go that contains the imports so offline builds can continue to work.  It's hidden behind a //go:build imports so there's no impact at build or runtime.