### PR TITLE
fix: replace volume when the creation options change

### DIFF
--- a/internal/provider/volume_resource.go
+++ b/internal/provider/volume_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -127,6 +128,9 @@ func (r *VolumeResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						},
 					},
 				},
+			},
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.RequiresReplace(),
 			},
 		},
 	})

--- a/internal/provider/volume_resource_test.go
+++ b/internal/provider/volume_resource_test.go
@@ -383,6 +383,42 @@ func TestAccVolumeResource_uploadFromFile(t *testing.T) {
 	})
 }
 
+func TestAccVolumeResource_createContentChangeRequiresReplace(t *testing.T) {
+	poolPath := t.TempDir()
+
+	sourceDir := t.TempDir()
+	sourceFilePath1 := sourceDir + "/source1.img"
+	sourceFilePath2 := sourceDir + "/source2.img"
+
+	if err := os.WriteFile(sourceFilePath1, bytes.Repeat([]byte("a"), 1024*1024), 0644); err != nil {
+		t.Fatalf("Failed to create source1 file: %v", err)
+	}
+	if err := os.WriteFile(sourceFilePath2, bytes.Repeat([]byte("b"), 1024*1024), 0644); err != nil {
+		t.Fatalf("Failed to create source2 file: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeResourceConfigUploadFromFile("test-volume-replace", poolPath, sourceFilePath1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_volume.test", "name", "test-volume-replace.img"),
+					resource.TestCheckResourceAttrSet("libvirt_volume.test", "id"),
+				),
+			},
+			{
+				Config: testAccVolumeResourceConfigUploadFromFile("test-volume-replace", poolPath, sourceFilePath2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_volume.test", "name", "test-volume-replace.img"),
+					resource.TestCheckResourceAttrSet("libvirt_volume.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVolumeResource_uploadFromHTTPWithContentLength(t *testing.T) {
 	poolPath := t.TempDir()
 	testContent := bytes.Repeat([]byte("a"), 1024*1024)


### PR DESCRIPTION
Hi,

I changed my `libvirt_cloudinit_disk` resource, which then triggered an update of the related `libvirt_volume`. But as the code says, volumes are immutable and cannot be updated.

This PR indicates to Terraform that the any change to the `create` field of a volume (which happens when the source cloudinit disk changes) should trigger a replacement instead of an update.