### PR TITLE
fix: support importing volume by key

### DIFF
--- a/internal/provider/volume_resource.go
+++ b/internal/provider/volume_resource.go
@@ -493,4 +493,5 @@ func (r *VolumeResource) Delete(ctx context.Context, req resource.DeleteRequest,
 // ImportState imports an existing storage volume
 func (r *VolumeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("key"), req, resp)
 }

--- a/internal/provider/volume_resource.go
+++ b/internal/provider/volume_resource.go
@@ -352,6 +352,14 @@ func (r *VolumeResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// After import only identity fields are populated. In that sparse state,
+	// read all XML-backed fields instead of preserving absent prior config.
+	isImport := model.Name.IsNull() || model.Name.IsUnknown()
+	var plan *generated.StorageVolumeModel
+	if !isImport {
+		plan = &model.StorageVolumeModel
+	}
+
 	// Look up the volume by key
 	volume, err := r.client.Libvirt().StorageVolLookupByKey(model.Key.ValueString())
 	if err != nil {
@@ -364,7 +372,7 @@ func (r *VolumeResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Read the volume state (use current state as plan to preserve user intent)
-	resp.Diagnostics.Append(r.readVolume(ctx, &model, volume, &model.StorageVolumeModel)...)
+	resp.Diagnostics.Append(r.readVolume(ctx, &model, volume, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -414,6 +422,9 @@ func (r *VolumeResource) readVolume(ctx context.Context, model *VolumeResourceMo
 
 	// Update the embedded model
 	model.StorageVolumeModel = *volumeModel
+	model.ID = types.StringValue(volume.Key)
+	model.Key = types.StringValue(volume.Key)
+	model.Pool = types.StringValue(volume.Pool)
 
 	// Populate computed fields that generated conversion might skip
 	// target.path is Computed, always populate it

--- a/internal/provider/volume_resource_test.go
+++ b/internal/provider/volume_resource_test.go
@@ -14,6 +14,7 @@ import (
 
 	libvirtclient "github.com/dmacvicar/terraform-provider-libvirt/v2/internal/libvirt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func init() {
@@ -77,6 +78,49 @@ func TestAccVolumeResource_basic(t *testing.T) {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccVolumeResource_importByKey(t *testing.T) {
+	poolPath := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeResourceConfigBasic("test-volume-import", poolPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("libvirt_volume.test", "key"),
+				),
+			},
+			{
+				ResourceName: "libvirt_volume.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					volume, ok := state.RootModule().Resources["libvirt_volume.test"]
+					if !ok {
+						return "", fmt.Errorf("libvirt_volume.test not found in state")
+					}
+
+					key := volume.Primary.Attributes["key"]
+					if key == "" {
+						return "", fmt.Errorf("libvirt_volume.test key not found in state")
+					}
+
+					return key, nil
+				},
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"allocation_unit",
+					"capacity_unit",
+					"physical_unit",
+					"target.permissions",
+					"target.timestamps",
+					"type",
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
Hi, Thanks a lot for maintaining this project. 

I've been trying to import volume with this provider like `terraform libvirt_volume.name <key>`, and it kept failing. 
I could find same case #1277 here too. 

The reason was (`internal/provider/volume_resource.go`): `Read` looks the volume via `key` while `ImportState` doesn't populate it.

Happy to adjust the approach if you prefer other way. Thanks