### PR TITLE
Fix domain id inconsistency on update

### DIFF
--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -1178,8 +1178,8 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 		newState.Metadata = plan.Metadata
 	}
 
-	if newState.ID.IsNull() && !state.ID.IsNull() && !state.ID.IsUnknown() {
-		newState.ID = state.ID
+	if !plan.ID.IsNull() && !plan.ID.IsUnknown() {
+		newState.ID = plan.ID
 	}
 
 	if !newState.Autostart.IsNull() && !newState.Autostart.IsUnknown() {

--- a/internal/provider/domain_resource_test.go
+++ b/internal/provider/domain_resource_test.go
@@ -589,6 +589,53 @@ func TestAccDomainResource_updateWithRunning(t *testing.T) {
 	})
 }
 
+// TestAccDomainResource_updateRunningDomainIDConsistency verifies that updating
+// a running domain does not cause a "Provider produced inconsistent result after
+// apply" error on the id attribute when the domain restarts with a new runtime id.
+func TestAccDomainResource_updateRunningDomainIDConsistency(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainResourceConfigRunning("test-domain-id-consistency"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_domain.test", "running", "true"),
+					resource.TestCheckResourceAttrSet("libvirt_domain.test", "id"),
+				),
+			},
+			{
+				Config: testAccDomainResourceConfigRunningUpdated("test-domain-id-consistency"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_domain.test", "memory", "1024"),
+					resource.TestCheckResourceAttr("libvirt_domain.test", "running", "true"),
+					resource.TestCheckResourceAttrSet("libvirt_domain.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainResourceConfigRunningUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "libvirt_domain" "test" {
+  name        = %[1]q
+  memory      = 1024
+  memory_unit = "MiB"
+  vcpu        = 1
+  type        = "kvm"
+  running     = true
+
+  os = {
+    type         = "hvm"
+    type_arch    = "x86_64"
+    type_machine = "q35"
+  }
+}
+`, name)
+}
+
 func TestAccDomainResource_updateKeepsNvram(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },


### PR DESCRIPTION
Updating a running `libvirt_domain` in a way that requires a restart (e.g. changing `memory`) fails with:

```
Error: Provider produced inconsistent result after apply
.id: was cty.NumberIntVal(N), but now cty.NumberIntVal(M)
```

`id` (libvirt's runtime domain ID) changes on every restart. It's `Computed` with `UseStateForUnknown`, so the planner copies the prior value into the plan, but `Update` restarts the domain and the new ID no longer matches.
To fix this we write `plan.ID` back to `newState.ID` when the plan has a known value. 
