### PR TITLE
fix: preserve planned channel source unix path on readback

### DIFF
--- a/internal/codegen/policy/field_policy.go
+++ b/internal/codegen/policy/field_policy.go
@@ -38,6 +38,12 @@ var fieldPolicies = map[string][]fieldPolicy{
 	"DomainInterfaceTarget.dev": {
 		policyPreservePlannedValueOnReadbackOmit,
 	},
+	"DomainChardevSourceUNIX.path": {
+		// libvirt rewrites this path at runtime for virtio guest-agent
+		// channels (e.g. /run/libvirt/qemu/channel/<id>-<name>/<target>),
+		// so the planned value must win against the readback value.
+		policyPreservePlannedValueOnReadbackOmit,
+	},
 }
 
 // ApplyFieldPolicies mutates the IR with Terraform-specific schema/conversion

--- a/internal/codegen/policy/field_policy_test.go
+++ b/internal/codegen/policy/field_policy_test.go
@@ -71,6 +71,12 @@ func TestApplyFieldPoliciesMarksReadbackPreservationOverrides(t *testing.T) {
 				{TFName: "dev"},
 			},
 		},
+		{
+			Name: "DomainChardevSourceUNIX",
+			Fields: []*generator.FieldIR{
+				{TFName: "path"},
+			},
+		},
 	}
 
 	ApplyFieldPolicies(structs)
@@ -83,6 +89,9 @@ func TestApplyFieldPoliciesMarksReadbackPreservationOverrides(t *testing.T) {
 	}
 	if !structs[2].Fields[0].PreservePlannedValueOnReadbackOmit {
 		t.Fatal("expected DomainInterfaceTarget.dev to preserve planned value on host-generated readback")
+	}
+	if !structs[3].Fields[0].PreservePlannedValueOnReadbackOmit {
+		t.Fatal("expected DomainChardevSourceUNIX.path to preserve planned value against runtime rewrite")
 	}
 }
 

--- a/internal/regression/domain_channel_source_path_test.go
+++ b/internal/regression/domain_channel_source_path_test.go
@@ -1,0 +1,31 @@
+package regression
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmacvicar/terraform-provider-libvirt/v2/internal/generated"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"libvirt.org/go/libvirtxml"
+)
+
+func TestDomainChardevSourceUNIXPathPreservesPlannedValueAgainstRuntimeRewrite(t *testing.T) {
+	ctx := context.Background()
+
+	plan := &generated.DomainChardevSourceUNIXModel{
+		Path: types.StringValue("/var/lib/libvirt/qemu/channel/target/test.org.qemu.guest_agent.0"),
+	}
+	xml := &libvirtxml.DomainChardevSourceUNIX{
+		Path: "/run/libvirt/qemu/channel/103-test/org.qemu.guest_agent.0",
+	}
+
+	model, err := generated.DomainChardevSourceUNIXFromXML(ctx, xml, plan)
+	if err != nil {
+		t.Fatalf("converting chardev source unix from XML: %v", err)
+	}
+
+	want := "/var/lib/libvirt/qemu/channel/target/test.org.qemu.guest_agent.0"
+	if got := model.Path.ValueString(); got != want {
+		t.Fatalf("expected planned path to be preserved against libvirt runtime rewrite, got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
libvirt rewrites the <source path=...> of a virtio guest-agent channel at runtime to /run/libvirt/qemu/channel/<id>-<name>/<target>. The active XML readback then carried this runtime path back into state, causing "Provider produced inconsistent result after apply" whenever the domain restarted during Update and got a new numeric id.

Apply `policyPreservePlannedValueOnReadbackOmit` to `DomainChardevSourceUNIX.path` to match existing pattern for `DomainInterfaceTarget.dev` and `DomainGraphicSpice.listen`.

`DomainChardevSourceUNIX.path` is shared by channels, TPM external sources, disk vhost-user sources, and disk reservation sources; in each case the path is a user-provided UNIX endpoint, so preserving the planned value is intentional.

Refs: #1319
