### PR TITLE
feat: make storage volume allocation user-overridable

### DIFF
--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -98,6 +98,7 @@ resource "libvirt_volume" "from_local" {
 
 ### Optional
 
+- `allocation` (Number) Volume allocation in bytes. When unset, libvirt sparsely allocates the volume. Set equal to capacity to force a fully-allocated, non-sparse volume.
 - `allocation_unit` (String) Specifies the units for the allocated space in the storage volume.
 - `backing_store` (Attributes) Backing store configuration for copy-on-write volumes (see [below for nested schema](#nestedatt--backing_store))
 - `capacity` (Number) Volume capacity in bytes (required unless using create.content)
@@ -109,7 +110,6 @@ resource "libvirt_volume" "from_local" {
 
 ### Read-Only
 
-- `allocation` (Number) Configures the total amount of space allocated for the storage volume.
 - `id` (String) Volume identifier (same as key)
 - `key` (String) Defines a unique key identifier for the storage volume.
 - `path` (String) Volume path on the host filesystem (same as target.path)

--- a/internal/codegen/policy/field_policy.go
+++ b/internal/codegen/policy/field_policy.go
@@ -23,7 +23,6 @@ var fieldPolicies = map[string][]fieldPolicy{
 	},
 	"StorageVolume.allocation": {
 		policyComputedReportedField,
-		policyDisablePreserveUserIntent,
 	},
 	"StorageVolume.physical": {
 		policyComputedReportedField,

--- a/internal/codegen/policy/field_policy_test.go
+++ b/internal/codegen/policy/field_policy_test.go
@@ -109,6 +109,7 @@ func TestApplyFieldPoliciesMarksReportedFieldOverrides(t *testing.T) {
 			Fields: []*generator.FieldIR{
 				{TFName: "capacity", IsOptional: true, IsRequired: true},
 				{TFName: "physical", IsOptional: true, IsRequired: true, PreserveUserIntent: true},
+				{TFName: "allocation", IsOptional: true, IsRequired: true, PreserveUserIntent: true},
 			},
 		},
 	}
@@ -145,5 +146,17 @@ func TestApplyFieldPoliciesMarksReportedFieldOverrides(t *testing.T) {
 	}
 	if volumePhysical.PreserveUserIntent {
 		t.Fatal("expected StorageVolume.physical to disable PreserveUserIntent")
+	}
+
+	// Unlike physical (and the pool-level reported fields), allocation keeps
+	// PreserveUserIntent so a user-configured allocation — exposed via the
+	// Optional+Computed schema override — is authoritative and not clobbered on
+	// readback.
+	volumeAllocation := structs[1].Fields[2]
+	if !volumeAllocation.IsComputed || volumeAllocation.IsOptional || volumeAllocation.IsRequired {
+		t.Fatal("expected StorageVolume.allocation to be computed in the IR after override")
+	}
+	if !volumeAllocation.PreserveUserIntent {
+		t.Fatal("expected StorageVolume.allocation to keep PreserveUserIntent")
 	}
 }

--- a/internal/provider/volume_resource.go
+++ b/internal/provider/volume_resource.go
@@ -110,6 +110,11 @@ func (r *VolumeResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			Optional:    true,
 			Computed:    true,
 		},
+		"allocation": schema.Int64Attribute{
+			Description: "Volume allocation in bytes. When unset, libvirt sparsely allocates the volume. Set equal to capacity to force a fully-allocated, non-sparse volume.",
+			Optional:    true,
+			Computed:    true,
+		},
 		"target": schema.SingleNestedAttribute{
 			Optional:   true,
 			Attributes: targetAttrs,


### PR DESCRIPTION
Previously allocation was a computed-only field with PreserveUserIntent disabled, so it could not be set from configuration and the unset value was always read back from libvirt. There was no way to influence whether a volume was sparsely or fully allocated.

Mirror capacity's treatment: keep allocation Computed but expose an Optional+Computed schema override and leave PreserveUserIntent enabled. When unset the volume is sparsely allocated exactly as before; when set, the configured value is authoritative and emitted to libvirt. Setting allocation equal to capacity yields a fully-allocated, non-sparse volume.