### PR TITLE
Fix boot_devices syntax in libvirt_domain example

### DIFF
--- a/examples/resources/libvirt_domain/resource.tf
+++ b/examples/resources/libvirt_domain/resource.tf
@@ -10,8 +10,15 @@ resource "libvirt_domain" "example" {
     type         = "hvm"
     type_arch    = "x86_64"
     type_machine = "q35"
-    boot_devices = ["hd", "network"]
-  }
+    boot_devices = [
+      {
+        dev  = "hd"
+      },
+      {
+        dev  = "network"
+      }
+    ]  
+    }
 
   devices = {
     disks = [


### PR DESCRIPTION
# Description
The example configuration for libvirt_domain resource incorrectly uses a list of strings for the boot_devices attribute. According to the Terraform provider schema, boot_devices expects a list of objects, each containing a required dev attribute.
# Current Issue
```
os = {
  type         = "hvm"
  type_arch    = "x86_64"
  type_machine = "q35"
  boot_devices = ["hd", "network"]  # ❌ Invalid: list of strings
}
```
Error message:


```
╵
╷
│ Error: Incorrect attribute value type
│ 
│   on domain_with_autostart.tf line 9, in resource "libvirt_domain" "example":
│    9:   os = {
│   10:     type         = "hvm"
│   11:     type_arch    = "x86_64"
│   12:     type_machine = "q35"
│   13:     boot_devices = ["hd", "network"]
│   14:   }
│ 
│ Inappropriate value for attribute "os": attribute "boot_devices": element 0: object required.
╵
```

# Fixed Syntax
``` hcl
os = {
  type         = "hvm"
  type_arch    = "x86_64"
  type_machine = "q35"
  boot_devices = [
    {
      dev = "hd"      # ✅ Valid: object with required "dev" field
    },
    {
      dev = "network"
    }
  ]
}
```

# Schema Reference
From the provider's nested schema for os.boot_devices:

Required: dev (String) - Specifies the device type for booting the domain

# Testing
Built from commit: 1f59c15765f28aac63ebaa19ace9c364e47545af

Validated configuration with terraform validate

Confirmed the corrected syntax eliminates the type mismatch error