### PR TITLE
cloudinit_disk: add staging_directory to avoid tmpfs reboot drift

### DIFF
--- a/docs/resources/cloudinit_disk.md
+++ b/docs/resources/cloudinit_disk.md
@@ -80,6 +80,7 @@ See the [cloud-init documentation](https://cloudinit.readthedocs.io/) for config
 ### Optional
 
 - `network_config` (String) Cloud-init network configuration (optional, usually YAML)
+- `staging_directory` (String) Directory to stage the generated ISO in before it is uploaded to a libvirt volume. Defaults to a subdirectory of the OS temp directory (os.TempDir()) if unset. On Linux, the default temp directory is commonly tmpfs-backed and is cleared on every reboot; since this resource's existence is verified by checking whether the staged file still exists (see Read()), losing that file causes Terraform to report the resource, and anything downstream referencing its `path`, as needing full recreation, even though nothing about the actual configuration changed. Set this to a directory that persists across reboots (e.g. a path inside your Terraform project root) to avoid that.
 
 ### Read-Only
 

--- a/internal/provider/cloudinit_disk_resource.go
+++ b/internal/provider/cloudinit_disk_resource.go
@@ -28,13 +28,14 @@ type CloudInitDiskResource struct {
 
 // CloudInitDiskResourceModel describes the resource data model
 type CloudInitDiskResourceModel struct {
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	UserData      types.String `tfsdk:"user_data"`
-	MetaData      types.String `tfsdk:"meta_data"`
-	NetworkConfig types.String `tfsdk:"network_config"`
-	Path          types.String `tfsdk:"path"`
-	Size          types.Int64  `tfsdk:"size"`
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	UserData         types.String `tfsdk:"user_data"`
+	MetaData         types.String `tfsdk:"meta_data"`
+	NetworkConfig    types.String `tfsdk:"network_config"`
+	StagingDirectory types.String `tfsdk:"staging_directory"`
+	Path             types.String `tfsdk:"path"`
+	Size             types.Int64  `tfsdk:"size"`
 }
 
 // NewCloudInitDiskResource creates a new cloud-init disk resource
@@ -120,6 +121,20 @@ See the [cloud-init documentation](https://cloudinit.readthedocs.io/) for config
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"staging_directory": schema.StringAttribute{
+				Description: "Directory to stage the generated ISO in before it is uploaded to a libvirt volume. " +
+					"Defaults to a subdirectory of the OS temp directory (os.TempDir()) if unset. " +
+					"On Linux, the default temp directory is commonly tmpfs-backed and is cleared on every " +
+					"reboot; since this resource's existence is verified by checking whether the staged file " +
+					"still exists (see Read()), losing that file causes Terraform to report the resource, and " +
+					"anything downstream referencing its `path`, as needing full recreation, even though " +
+					"nothing about the actual configuration changed. Set this to a directory that persists " +
+					"across reboots (e.g. a path inside your Terraform project root) to avoid that.",
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"path": schema.StringAttribute{
 				Description: "Full path to the generated ISO file",
 				Computed:    true,
@@ -166,8 +181,15 @@ func (r *CloudInitDiskResource) Create(ctx context.Context, req resource.CreateR
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 	model.ID = types.StringValue(checksum[:16]) // Use first 16 chars of checksum
 
-	// Create temp directory for cloud-init ISOs if it doesn't exist
-	tmpDir := filepath.Join(os.TempDir(), "terraform-provider-libvirt-cloudinit")
+	// Create temp directory for cloud-init ISOs if it doesn't exist.
+	// If the user has set "staging_directory", use that instead of the OS temp
+	// directory -- see the schema description for why this matters.
+	var tmpDir string
+	if !model.StagingDirectory.IsNull() && model.StagingDirectory.ValueString() != "" {
+		tmpDir = model.StagingDirectory.ValueString()
+	} else {
+		tmpDir = filepath.Join(os.TempDir(), "terraform-provider-libvirt-cloudinit")
+	}
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Create Temp Directory",

--- a/internal/provider/cloudinit_disk_resource_test.go
+++ b/internal/provider/cloudinit_disk_resource_test.go
@@ -70,6 +70,75 @@ func TestAccCloudInitDiskResource_withVolume(t *testing.T) {
 	})
 }
 
+func TestAccCloudInitDiskResource_stagingDirectory(t *testing.T) {
+	stagingDir := t.TempDir()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudInitDiskResourceConfigStagingDirectory("test-cloudinit-staging", stagingDir),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_cloudinit_disk.test", "name", "test-cloudinit-staging"),
+					resource.TestCheckResourceAttr("libvirt_cloudinit_disk.test", "staging_directory", stagingDir),
+					resource.TestCheckResourceAttrSet("libvirt_cloudinit_disk.test", "path"),
+					testAccCheckCloudInitDiskExistsInDir("libvirt_cloudinit_disk.test", stagingDir),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckCloudInitDiskExistsInDir verifies that the ISO file exists on
+// disk inside a specific, caller-supplied directory -- used to confirm
+// staging_directory actually controls where the file is written, rather
+// than the resource silently falling back to os.TempDir().
+func testAccCheckCloudInitDiskExistsInDir(resourceName, expectedDir string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		path := rs.Primary.Attributes["path"]
+		if path == "" {
+			return fmt.Errorf("no path is set for %s", resourceName)
+		}
+
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("ISO file does not exist at %s: %w", path, err)
+		}
+
+		if !strings.HasPrefix(path, expectedDir) {
+			return fmt.Errorf("ISO file is not in the configured staging_directory: got %s, expected prefix %s", path, expectedDir)
+		}
+
+		return nil
+	}
+}
+
+func testAccCloudInitDiskResourceConfigStagingDirectory(name, stagingDir string) string {
+	return fmt.Sprintf(`
+resource "libvirt_cloudinit_disk" "test" {
+  name              = %[1]q
+  staging_directory = %[2]q
+  user_data = <<-EOF
+    #cloud-config
+    users:
+      - name: root
+        ssh_authorized_keys:
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho1w+1D4vJccMzEQBzREzCY4NjkrJYh8+9rQJgDrYPrWLe1PJYvDG6r1uDlLrZJhwwq1PcJQw test@example.com
+  EOF
+
+  meta_data = <<-EOF
+    instance-id: %[1]s-001
+    local-hostname: %[1]s
+  EOF
+}
+`, name, stagingDir)
+}
+
 // testAccCheckCloudInitDiskExists verifies that the ISO file exists on disk
 func testAccCheckCloudInitDiskExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {


### PR DESCRIPTION
Resolves: #1368
## Problem

`libvirt_cloudinit_disk` stages its rendered ISO content in a file under `os.TempDir()` (`internal/provider/cloudinit_disk_resource.go`, line 170). `Read()` calls `os.Stat()` on that recorded path on every refresh:

```go
fileInfo, err := os.Stat(isoPath)
if err != nil {
    if os.IsNotExist(err) {
        resp.State.RemoveResource(ctx)
        return
    }
```

If the file is missing, the resource is removed from state entirely — not just marked changed. This means `terraform plan` reports the resource, and everything downstream referencing its `.path` (a `libvirt_volume`, and in turn the `libvirt_domain` that mounts it), as needing full recreation.
On Ubuntu (and most modern Linux distributions), `/tmp` is `tmpfs`-backed and is cleared on every reboot by design. Since there's currently no way to override the staging location via provider or resource configuration, **this drift happens on every full reboot of the Terraform host**, for every `libvirt_cloudinit_disk` resource in the configuration — even though nothing about the actual infrastructure changed.
Worth noting: the resource's `ID`/filename is already a SHA-256 checksum of the actual `user_data`/`meta_data`/`network_config` content, and `Create()` already checks for an existing file with that checksum before regenerating (lines 182-186). The design clearly intends this file to be durable and reusable — the bug is that its storage location doesn't match that intent.
Full repro and analysis in #1368.
## Fix
Adds an optional `staging_directory` attribute to `libvirt_cloudinit_disk`. If unset, behavior is unchanged (falls back to the existing `os.TempDir()`-based path) — fully backward compatible. If set, the ISO is staged there instead, letting users point it at a location that survives a reboot (e.g. inside their Terraform project root).

```hcl
resource "libvirt_cloudinit_disk" "seed" {
  name              = "my-vm-cloudinit"
  staging_directory = "${path.module}/.cloudinit-staging"
  user_data         = "..."
  meta_data         = "..."
}
```

## Testing

- `make lint` / `make build`: pass. `make lint` shows 4 pre-existing `govet` findings in `internal/codegen/parser/libvirtxml.go`, unrelated to this change — confirmed via `git stash` (identical output with the change removed).
- `make testacc` (full suite): all `cloudinit_disk`, `domain`, `volume`, and `pool` tests pass, including a new `TestAccCloudInitDiskResource_stagingDirectory` covering this attribute. One pre-existing failure, `TestAccNetworkResource_isolated`, also confirmed unrelated via `git stash` — traced to a single-NIC host quirk (libvirt's `default` NAT network implicitly binding to the host's only physical interface, `eno1`, causing an unrelated isolated-network test to fail on this specific machine).
- Manually verified against a live 10-VM libvirt fleet across two independent full host reboots: confirmed the bug reproduces with `staging_directory` unset, and is resolved with it set to a project-relative directory — including a clean-slate re-test (staging directory fully removed and recreated beforehand) to rule out stale-file artifacts.